### PR TITLE
Fix location of conf.py file for readthedocs.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,7 +22,7 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: true
 
 python:


### PR DESCRIPTION
Signed-off-by: Tim Callahan <tcal@google.com>