### PR TITLE
Add make as a requirement

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -5,6 +5,9 @@ git submodule update --init
 # Verify dependencies that can be installed with apt (if available)
 missing=()
 
+if ! which make >/dev/null; then
+    missing+=(make)    
+fi
 if ! which openocd >/dev/null; then
     missing+=(openocd)    
 fi


### PR DESCRIPTION
This adds `make` as one of the requirements. Does not change much for a regular user, but helps in the CI scenario