### PR TITLE
scripts/setup: Improve gcc versioning

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -51,10 +51,15 @@ if [ ${#missing[@]} -gt 0 ]; then
     fi
 fi
 
-# Warn about different versions
+# Check GCC
+if ! which riscv64-unknown-elf-gcc >/dev/null; then
+    echo "Error: RISCV GCC toolchain not found. Please install one, following the instructions at"
+    echo "https://cfu-playground.readthedocs.io/en/latest/setup-guide.html#step-3-install-riscv-toolchain"
 
-if ! riscv64-unknown-elf-gcc --version | grep ' 8.3.' >/dev/null; then
-    echo "Possibly unsupported version of riscv64-unknown-elf-gcc. 8.3.0 works." >&2
+elif ! riscv64-unknown-elf-gcc --version | grep 'SiFive GCC 8.3.0-2020.04.1.' >/dev/null; then
+    echo "Unsupported version of riscv64-unknown-elf-gcc. SiFive GCC 8.3.0-2020.04.1 is known to work." >&2
+    echo "To install this version, follow the instructions at"
+    echo "https://cfu-playground.readthedocs.io/en/latest/setup-guide.html#step-3-install-riscv-toolchain"
 fi
 
 # Verify other dependencies

--- a/scripts/setup
+++ b/scripts/setup
@@ -56,6 +56,7 @@ if [ ${#missing[@]} -gt 0 ]; then
     fi
 fi
 
+
 # Build flashrom after installing dependencies
 echo "BUILDING FLASHROM"
 (

--- a/scripts/setup
+++ b/scripts/setup
@@ -11,9 +11,6 @@ fi
 if ! which openocd >/dev/null; then
     missing+=(openocd)    
 fi
-if ! which riscv64-unknown-elf-gcc >/dev/null; then
-    missing+=(gcc-riscv64-unknown-elf)
-fi
 if ! which yosys >/dev/null; then
     missing+=(yosys)
 fi


### PR DESCRIPTION
This change prints the URL of the GCC compiler installation
documentation when GCC is not found, or is an unrecognized version.

Currently, setup attempts to install GCC if one is not found. That is
almost always the wrong thing to do.

Fixes #57 