### PR TITLE
Cleanup, trying to get mnv2_first to build for hps.

### DIFF
--- a/proj/proj_template_v/cfu.v
+++ b/proj/proj_template_v/cfu.v
@@ -24,6 +24,7 @@ module Cfu (
   input               io_bus_rsp_ready,
   output              io_bus_rsp_payload_response_ok,
   output     [31:0]   io_bus_rsp_payload_outputs_0,
+  input               rst,
   input               clk
 );
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -2,14 +2,16 @@
 set -e
 git submodule update --init
 
+
+
 # Verify dependencies that can be installed with apt (if available)
 missing=()
 
 if ! which make >/dev/null; then
-    missing+=(make)    
+    missing+=(make)
 fi
 if ! which openocd >/dev/null; then
-    missing+=(openocd)    
+    missing+=(openocd)
 fi
 if ! which riscv64-unknown-elf-gcc >/dev/null; then
     missing+=(gcc-riscv64-unknown-elf)
@@ -26,6 +28,12 @@ fi
 if ! which verilator >/dev/null; then
     missing+=(verilator libevent-dev libjson-c-dev)
 fi
+if ! (apt list -i | grep libusb-1.0-0-dev) ; then
+    missing+=(libusb-1.0-0-dev libftdi1-dev)
+fi
+
+echo Missing:
+echo $missing
 
 in_ci=0
 if [ $# -gt 0 ] ; then
@@ -50,6 +58,14 @@ if [ ${#missing[@]} -gt 0 ]; then
         exit 1
     fi
 fi
+
+
+# Build flashrom after installing dependencies
+echo "BUILDING FLASHROM"
+(
+  cd third_party/flashrom
+  make -j4 CONFIG_ENABLE_LIBPCI_PROGRAMMERS=no
+)
 
 # Warn about different versions
 

--- a/soc/hps_platform.py
+++ b/soc/hps_platform.py
@@ -101,7 +101,7 @@ class _CRG(Module):
 
 class Platform(LatticePlatform):
     # The NX-17 has a 450 MHz clock. Our system clock should be a divisor of that.
-    clk_divisor = 4
+    clk_divisor = 8
     sys_clk_freq = int(450e6 / clk_divisor)
 
     def __init__(self, toolchain="radiant"):

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -80,7 +80,8 @@ class HpsSoC(LiteXSoC):
         LiteXSoC.__init__(self,
                           platform=platform,
                           sys_clk_freq=platform.sys_clk_freq,
-                          csr_data_width=32)
+                          csr_data_width=(32 if litespi_flash else 8))
+
 
         # Clock, Controller, CPU
         self.submodules.crg = platform.create_crg()


### PR DESCRIPTION
Switch to 1kB icache for VexRiscv
Halve the clock rate
Build flashrom (incl extra deps)
Switch back to 8b CSR bus if not using litespi

Signed-off-by: Tim Callahan <tcal@google.com>