### PR TITLE
HPS updates: allow alt synth tool; Renode files.

### DIFF
--- a/proj/proj_template_v/renode/hps.repl
+++ b/proj/proj_template_v/renode/hps.repl
@@ -1,0 +1,62 @@
+
+cpu: CPU.VexRiscv @ sysbus
+    cpuType: "rv32im"
+    init:
+        RegisterCustomCSR "BPM" 0xB04  User
+        RegisterCustomCSR "BPM" 0xB05  User
+        RegisterCustomCSR "BPM" 0xB06  User
+        RegisterCustomCSR "BPM" 0xB07  User
+        RegisterCustomCSR "BPM" 0xB08  User
+        RegisterCustomCSR "BPM" 0xB09  User
+        RegisterCustomCSR "BPM" 0xB0A  User
+        RegisterCustomCSR "BPM" 0xB0B  User
+        RegisterCustomCSR "BPM" 0xB0C  User
+        RegisterCustomCSR "BPM" 0xB0D  User
+        RegisterCustomCSR "BPM" 0xB0E  User
+        RegisterCustomCSR "BPM" 0xB0F  User
+        RegisterCustomCSR "BPM" 0xB10  User
+        RegisterCustomCSR "BPM" 0xB11  User
+        RegisterCustomCSR "BPM" 0xB12  User
+        RegisterCustomCSR "BPM" 0xB13  User
+        RegisterCustomCSR "BPM" 0xB14  User
+        RegisterCustomCSR "BPM" 0xB15  User
+
+
+ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }
+
+
+uart: UART.LiteX_UART @ { sysbus 0xf0002800 }
+    -> cpu@0
+
+
+timer0: Timers.LiteX_Timer @ { sysbus 0xf0003000 }
+    -> cpu@1
+    frequency: 56250000
+
+
+sram: Memory.MappedMemory @ { sysbus 0x40000000 }
+    size: 0x00050000
+
+
+//spiflash: Memory.MappedMemory @ { sysbus 0x20000000 }
+//    size: 0x01000000
+
+
+spi: SPI.LiteX_SPI_Flash @ { sysbus 0xf0001000 }
+
+
+//mt25q: SPI.Micron_MT25Q @ spi
+//    underlyingMemory: spiflash
+
+
+rom: Memory.MappedMemory @ { sysbus 0x20200000 }
+    size: 0x00e00000
+
+
+//# MEMORY {
+//#         sram_lram : ORIGIN = 0x40000000, LENGTH = 0x00050000
+//#         sram : ORIGIN = 0x40000000, LENGTH = 0x00050000
+//#         spiflash : ORIGIN = 0x20000000, LENGTH = 0x01000000
+//#         rom : ORIGIN = 0x20200000, LENGTH = 0x00e00000
+//#         csr : ORIGIN = 0xf0000000, LENGTH = 0x00010000
+//# }

--- a/proj/proj_template_v/renode/hps.resc
+++ b/proj/proj_template_v/renode/hps.resc
@@ -1,0 +1,11 @@
+
+using sysbus
+mach create "litex-vexriscv"
+machine LoadPlatformDescription @hps.repl
+machine StartGdbServer 10001
+showAnalyzer sysbus.uart
+showAnalyzer sysbus.uart Antmicro.Renode.Analyzers.LoggingUartAnalyzer
+
+sysbus LoadELF $ORIGIN/build/software.elf
+
+

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -42,6 +42,14 @@ OUT_DIR:=   build/$(SOC_NAME)
 # LITEX_ARGS= --output-dir $(OUT_DIR) --csr-csv $(OUT_DIR)/csr.csv $(CFU_ARGS) $(UART_ARGS)
 LITEX_ARGS= --output-dir $(OUT_DIR) --csr-csv $(OUT_DIR)/csr.csv $(CFU_ARGS)
 
+#==== Specify a different synth tool; still uses Radiant PnR
+ifdef USE_YOSYS
+LITEX_ARGS += --synth_mode yosys
+else ifdef USE_LSE
+LITEX_ARGS += --synth_mode lse
+endif
+
+#==== Specify complete open source toolchain: Yosys + NextPnR
 ifdef USE_OXIDE
 LITEX_ARGS += --toolchain oxide
 else ifdef USE_SYMBIFLOW


### PR DESCRIPTION
* Add "USE_LSE=1" and "USE_YOSYS=1" options for gateware build
  - these still use Radiant place and route
* Add Renode platform and script files for HPS
  - only in proj_template_v; I need to centralized these...

Signed-off-by: Tim Callahan <tcal@google.com>