### PR TITLE
Fix disassembly for CFU instructions in software.elf.dis.

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -29,6 +29,7 @@ LIBBASE_DIR    := $(SOC_SOFTWARE_DIR)/libbase
 LITEX_DIR      := $(CFU_ROOT)/third_party/python/litex/litex
 VEX_SRC_DIR    := $(LITEX_DIR)/soc/cores/cpu/vexriscv
 PYRUN          := $(CFU_ROOT)/scripts/pyrun
+FIX_CFU_DIS    := $(PYRUN) $(CFU_ROOT)/scripts/fix_cfu_dis.py
 XXD            := $(PYRUN) $(CFU_ROOT)/scripts/xxd.py
 
 LD_DIR     := $(BUILD_DIR)/ld
@@ -148,7 +149,7 @@ $(TARGET): $(OBJECTS) $(LDSCRIPTS)
 	$(QUIET) echo "  LD       $@"
 	$(QUIET) $(CXX) $(OBJECTS) $(LFLAGS) -o $@
 	$(QUIET) echo "  OBJDUMP  $@.dis"
-	$(QUIET) $(OBJDUMP) -d -S -l $(TARGET) > $(TARGET).dis
+	$(QUIET) $(OBJDUMP) -d -S -l $(TARGET) | $(FIX_CFU_DIS) > $(TARGET).dis
 	$(QUIET) echo "  OBJDUMP  $@.sym"
 	$(QUIET) $(OBJDUMP) -s $(TARGET) > $(TARGET).sym
 

--- a/scripts/fix_cfu_dis.py
+++ b/scripts/fix_cfu_dis.py
@@ -17,8 +17,6 @@
 import sys
 import re
 
-totals =  {}
-
 regnames = ['x0', 'ra', 'sp', 'gp', 
                 'tp', 't0', 't1', 't2', 
                 's0', 's1', 'a0', 'a1',
@@ -28,8 +26,7 @@ regnames = ['x0', 'ra', 'sp', 'gp',
                 's8', 's9', 's10', 's11',
                 't3', 't4', 't5', 't6']
 
-n = 1
-cyc = 0
+
 lines = sys.stdin.readlines()
 
 for i in range(len(lines)):

--- a/scripts/fix_cfu_dis.py
+++ b/scripts/fix_cfu_dis.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import sys
+import re
+
+totals =  {}
+
+regnames = ['x0', 'ra', 'sp', 'gp', 
+                'tp', 't0', 't1', 't2', 
+                's0', 's1', 'a0', 'a1',
+                'a2', 'a3', 'a4', 'a5',
+                'a6', 'a7', 's2', 's3',
+                's4', 's5', 's6', 's7',
+                's8', 's9', 's10', 's11',
+                't3', 't4', 't5', 't6']
+
+n = 1
+cyc = 0
+lines = sys.stdin.readlines()
+
+for i in range(len(lines)):
+    lin = lines[i]
+    lin = lin.replace('\r','')
+    lin = lin.replace('\n','')
+    #
+    # Replace the last word with 'cfu[funct7,funct3]   rd, rs1, rs2'
+    #
+    # 40000148:       0094280b                0x94280b
+    #
+    m = re.match(r"^(\w+:\s+\w+\s+)(0x[0-9A-Fa-f]+)$", lin)
+    if m:
+        bits   = int(m.group(2), 0)
+        funct7 = (bits >> 25) & 127
+        rs2    = (bits >> 20) & 31
+        rs1    = (bits >> 15) & 31
+        funct3 = (bits >> 12) & 7
+        rd     = (bits >> 7) & 31
+        op     = f'cfu[{funct7},{funct3}]  {regnames[rd]}, {regnames[rs1]}, {regnames[rs2]}'
+
+        print(m.group(1) + op)
+
+    else:
+
+        print(lin)
+


### PR DESCRIPTION
Used to look like:
```
40003bfc:       2efe8e8b                0x2efe8e8b
```

Now looks like:
```
40003bfc:       2efe8e8b                cfu[23,0]  t4, t4, a5
```

Signed-off-by: Tim Callahan <tcal@google.com>