### PR TITLE
mnv2_first tests

### DIFF
--- a/.github/includes/actions/run-in-renode/action.yml
+++ b/.github/includes/actions/run-in-renode/action.yml
@@ -1,0 +1,50 @@
+name: Run in Renode
+description: Runs a specified sample in Renode
+inputs:
+  path:
+    description: Path to the sample
+    required: true
+  test:
+    description: Path to the test file
+    required: true
+  build-params:
+    description: Additional build parameters
+    required: false
+    default: ''
+
+runs:
+  using: "includes"
+  steps:
+    - name: Fetch toolchain
+      run: |
+        wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
+        echo "/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin" >> $GITHUB_PATH
+    - name: Clone repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+
+    - name: Setup environment
+      run: bash scripts/setup -ci
+    - name: Build sample
+      run:
+        pwd && source environment && cd ${{ inputs.path }} && make ${{ inputs.build-params }} -j8 software && cp build/software.elf renode/
+
+    - name: Run tests
+      uses: antmicro/renode-actions/test-in-renode@main
+      with:
+        renode-version: '1.12.0+20210403git44d6786'
+        tests-to-run: ${{ inputs.test }}
+    - name: Archive results
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results
+        path: |
+          report.html
+          log.html
+          robot_output.xml
+

--- a/.github/workflows-src/Makefile
+++ b/.github/workflows-src/Makefile
@@ -1,0 +1,46 @@
+# Copyright (C) 2017-2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+# Set up a Python environment to run the actions_include tool on.
+ENV_DIR = venv
+PYTHON = $(ENV_DIR)/bin/python3
+ACTIVATE = . $(ENV_DIR)/bin/activate;
+
+env: requirements.txt
+	rm -rf $(ENV_DIR)
+	virtualenv --copies $(ENV_DIR)
+	$(ACTIVATE) pip install -r $<
+	touch --reference=$< $(PYTHON)
+
+.PHONY: env
+
+$(PYTHON): requirements.txt
+	make env
+
+# Generate the output files
+SRC_YAML = $(wildcard *.yml)
+OUT_YAML = $(addprefix ../workflows/,$(SRC_YAML))
+
+../workflows/%.yml: %.yml | $(PYTHON)
+	@echo
+	@echo Updating $@
+	@echo ------------------------------------------------
+	$(ACTIVATE) python -m actions_includes $< $@
+	@echo ------------------------------------------------
+
+update:
+	@for F in $(SRC_YAML); do touch $$F; done
+	make build
+
+build: $(OUT_YAML) | $(PYTHON)
+	@true
+
+info:
+	@echo 'Output files: $(OUT_YAML)'
+
+.PHONY: info

--- a/.github/workflows-src/requirements.txt
+++ b/.github/workflows-src/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/mithro/actions-includes.git#egg=actions-includes

--- a/.github/workflows-src/run-in-renode.yml
+++ b/.github/workflows-src/run-in-renode.yml
@@ -8,3 +8,19 @@ jobs:
         with:
           path: proj/proj_template
           test: proj/proj_template/renode/litex-vexriscv-tflite.robot
+  mnv2_first-litex:
+    runs-on: ubuntu-20.04
+    steps:
+      - includes: /run-in-renode
+        with:
+          path: proj/mnv2_first
+          test: proj/mnv2_first/renode/litex-vexriscv-tflite.robot
+          build-params: SW_ONLY=1
+  mnv2_first-hps:
+    runs-on: ubuntu-20.04
+    steps:
+      - includes: /run-in-renode
+        with:
+          path: proj/mnv2_first
+          test: proj/mnv2_first/renode/hps.robot
+          build-params: SW_ONLY=1 PLATFORM=hps

--- a/.github/workflows-src/run-in-renode.yml
+++ b/.github/workflows-src/run-in-renode.yml
@@ -1,0 +1,10 @@
+name: Run in Renode
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  proj_template:
+    runs-on: ubuntu-20.04
+    steps:
+      - includes: /run-in-renode
+        with:
+          path: proj/proj_template
+          test: proj/proj_template/renode/litex-vexriscv-tflite.robot

--- a/.github/workflows-src/test-projects.yml
+++ b/.github/workflows-src/test-projects.yml
@@ -1,4 +1,4 @@
-name: Run in Renode
+name: Test projects
 on: [push, pull_request, workflow_dispatch]
 jobs:
   proj_template:

--- a/.github/workflows/run-in-renode.yml
+++ b/.github/workflows/run-in-renode.yml
@@ -1,28 +1,52 @@
+
+# !! WARNING !!
+# Do not modify this file directly!
+# !! WARNING !!
+#
+# It is generated from: ../workflows-src/run-in-renode.yml
+# using the script from https://github.com/mithro/actions-includes@main
+
 name: Run in Renode
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  run-in-renode:
+  proj_template:
     runs-on: ubuntu-20.04
     steps:
-      - run: wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
-      - run: echo "/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-      - run: bash scripts/setup -ci
-      - run: pwd && source environment && cd proj/proj_template && make -j8 software && cp build/software.elf renode/
-      - name: Run tests
-        uses: antmicro/renode-actions/test-in-renode@main
-        with:
-          renode-version: '1.12.0+20210403git44d6786'
-          tests-to-run: 'proj/proj_template/renode/litex-vexriscv-tflite.robot'
-      - name: Archive results
-        uses: actions/upload-artifact@v2
-        with:
-          name: test-results
-          path: |
-            report.html
-            log.html
-            robot_output.xml
+    - name: ⏰ 🛂 📕 - Checking workflow expansion is up to date
+      uses: mithro/actions-includes@main
+      if: runner.os == 'Linux'
+      continue-on-error: false
+      with:
+        workflow: .github/workflows/run-in-renode.yml
+    - name: Fetch toolchain
+      run: |
+        wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
+        echo "/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin" >> $GITHUB_PATH
+    - name: Clone repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+
+    - name: Setup environment
+      run: bash scripts/setup -ci
+    - name: Build sample
+      run: pwd && source environment && cd proj/proj_template && make  -j8 software && cp build/software.elf renode/
+
+    - name: Run tests
+      uses: antmicro/renode-actions/test-in-renode@main
+      with:
+        renode-version: 1.12.0+20210403git44d6786
+        tests-to-run: proj/proj_template/renode/litex-vexriscv-tflite.robot
+    - name: Archive results
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results
+        path: |
+          report.html
+          log.html
+          robot_output.xml
 

--- a/.github/workflows/run-in-renode.yml
+++ b/.github/workflows/run-in-renode.yml
@@ -50,3 +50,85 @@ jobs:
           log.html
           robot_output.xml
 
+  mnv2_first-litex:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: ⏰ 🛂 📕 - Checking workflow expansion is up to date
+      uses: mithro/actions-includes@main
+      if: runner.os == 'Linux'
+      continue-on-error: false
+      with:
+        workflow: .github/workflows/run-in-renode.yml
+    - name: Fetch toolchain
+      run: |
+        wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
+        echo "/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin" >> $GITHUB_PATH
+    - name: Clone repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+
+    - name: Setup environment
+      run: bash scripts/setup -ci
+    - name: Build sample
+      run: pwd && source environment && cd proj/mnv2_first && make SW_ONLY=1 -j8 software && cp build/software.elf renode/
+
+    - name: Run tests
+      uses: antmicro/renode-actions/test-in-renode@main
+      with:
+        renode-version: 1.12.0+20210403git44d6786
+        tests-to-run: proj/mnv2_first/renode/litex-vexriscv-tflite.robot
+    - name: Archive results
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results
+        path: |
+          report.html
+          log.html
+          robot_output.xml
+
+  mnv2_first-hps:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: ⏰ 🛂 📕 - Checking workflow expansion is up to date
+      uses: mithro/actions-includes@main
+      if: runner.os == 'Linux'
+      continue-on-error: false
+      with:
+        workflow: .github/workflows/run-in-renode.yml
+    - name: Fetch toolchain
+      run: |
+        wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
+        echo "/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin" >> $GITHUB_PATH
+    - name: Clone repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+
+    - name: Setup environment
+      run: bash scripts/setup -ci
+    - name: Build sample
+      run: pwd && source environment && cd proj/mnv2_first && make SW_ONLY=1 PLATFORM=hps -j8 software && cp build/software.elf renode/
+
+    - name: Run tests
+      uses: antmicro/renode-actions/test-in-renode@main
+      with:
+        renode-version: 1.12.0+20210403git44d6786
+        tests-to-run: proj/mnv2_first/renode/hps.robot
+    - name: Archive results
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results
+        path: |
+          report.html
+          log.html
+          robot_output.xml
+

--- a/.github/workflows/test-projects.yml
+++ b/.github/workflows/test-projects.yml
@@ -3,10 +3,10 @@
 # Do not modify this file directly!
 # !! WARNING !!
 #
-# It is generated from: ../workflows-src/run-in-renode.yml
+# It is generated from: ../workflows-src/test-projects.yml
 # using the script from https://github.com/mithro/actions-includes@main
 
-name: Run in Renode
+name: Test projects
 on: [push, pull_request, workflow_dispatch]
 jobs:
   proj_template:
@@ -17,7 +17,7 @@ jobs:
       if: runner.os == 'Linux'
       continue-on-error: false
       with:
-        workflow: .github/workflows/run-in-renode.yml
+        workflow: .github/workflows/test-projects.yml
     - name: Fetch toolchain
       run: |
         wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
@@ -58,7 +58,7 @@ jobs:
       if: runner.os == 'Linux'
       continue-on-error: false
       with:
-        workflow: .github/workflows/run-in-renode.yml
+        workflow: .github/workflows/test-projects.yml
     - name: Fetch toolchain
       run: |
         wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
@@ -99,7 +99,7 @@ jobs:
       if: runner.os == 'Linux'
       continue-on-error: false
       with:
-        workflow: .github/workflows/run-in-renode.yml
+        workflow: .github/workflows/test-projects.yml
     - name: Fetch toolchain
       run: |
         wget -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,10 @@ csr.csv
 # VSCode files
 *.code-workspace
 .vscode/*
+
+# Robot test results
+log.html
+report.html
+results-*robot.xml
+robot_output.xml
+*fail.save

--- a/proj/mnv2_first/renode/hps.resc
+++ b/proj/mnv2_first/renode/hps.resc
@@ -1,6 +1,6 @@
 
 using sysbus
-mach create "litex-vexriscv"
+mach create "hps"
 machine LoadPlatformDescription $ORIGIN/hps.repl
 machine StartGdbServer 10001
 showAnalyzer sysbus.uart

--- a/proj/mnv2_first/renode/hps.resc
+++ b/proj/mnv2_first/renode/hps.resc
@@ -1,7 +1,7 @@
 
 using sysbus
 mach create "litex-vexriscv"
-machine LoadPlatformDescription @hps.repl
+machine LoadPlatformDescription $ORIGIN/hps.repl
 machine StartGdbServer 10001
 showAnalyzer sysbus.uart
 showAnalyzer sysbus.uart Antmicro.Renode.Analyzers.LoggingUartAnalyzer

--- a/proj/mnv2_first/renode/hps.robot
+++ b/proj/mnv2_first/renode/hps.robot
@@ -1,0 +1,48 @@
+*** Settings ***
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Setup                    Reset Emulation
+Test Teardown                 Test Teardown
+Resource                      ${RENODEKEYWORDS}
+
+*** Keywords ***
+Create Machine
+    Execute Command          include @${CURDIR}/hps.resc
+    Create Terminal Tester   sysbus.uart
+
+    Start Emulation
+
+*** Test Cases ***
+Should Run Mobile Net V2 Golden Tests
+    Create Machine
+
+    Wait For Line On Uart    CFU Playground
+    Wait For Prompt On Uart  main>
+    Write Line To Uart       1
+    Wait For Prompt On Uart  models>
+    Write Line To Uart       1
+    Wait For Prompt On Uart  pdti8>
+    Write Line To Uart       g
+    Wait For Line On Uart    Golden tests passed  120
+    Wait For Prompt On Uart  pdti8>
+
+
+Should Run TFLite Unit Tests
+    Create Machine
+
+    Write Line To Uart       5
+    Wait For Line On Uart    CONV TEST:
+    Wait For Line On Uart    ~~~ALL TESTS PASSED~~~
+    Wait For Line On Uart    DEPTHWISE_CONV TEST:
+    Wait For Line On Uart    ~~~ALL TESTS PASSED~~~
+    Wait For Prompt On Uart  main>
+
+
+Should Run 1x1 Conv2D Golden Tests
+    Create Machine
+
+    Write Line To Uart       3
+    Wait For Prompt On Uart  mnv2_first>
+    Write Line To Uart       1
+    Wait For Line On Uart    OK - output tensor matches
+    Wait For Prompt On Uart  mnv2_first>

--- a/proj/mnv2_first/renode/litex-vexriscv-tflite.robot
+++ b/proj/mnv2_first/renode/litex-vexriscv-tflite.robot
@@ -1,0 +1,48 @@
+*** Settings ***
+Suite Setup                   Setup
+Suite Teardown                Teardown
+Test Setup                    Reset Emulation
+Test Teardown                 Test Teardown
+Resource                      ${RENODEKEYWORDS}
+
+*** Keywords ***
+Create Machine
+    Execute Command          include @${CURDIR}/litex-vexriscv-tflite.resc
+    Create Terminal Tester   sysbus.uart
+
+    Start Emulation
+
+*** Test Cases ***
+Should Run Mobile Net V2 Golden Tests
+    Create Machine
+
+    Wait For Line On Uart    CFU Playground
+    Wait For Prompt On Uart  main>
+    Write Line To Uart       1
+    Wait For Prompt On Uart  models>
+    Write Line To Uart       2
+    Wait For Prompt On Uart  mnv2>
+    Write Line To Uart       g
+    Wait For Line On Uart    Golden tests passed  120
+    Wait For Prompt On Uart  mnv2>
+
+
+Should Run TFLite Unit Tests
+    Create Machine
+
+    Write Line To Uart       5
+    Wait For Line On Uart    CONV TEST:
+    Wait For Line On Uart    ~~~ALL TESTS PASSED~~~
+    Wait For Line On Uart    DEPTHWISE_CONV TEST:
+    Wait For Line On Uart    ~~~ALL TESTS PASSED~~~
+    Wait For Prompt On Uart  main>
+
+
+Should Run 1x1 Conv2D Golden Tests
+    Create Machine
+
+    Write Line To Uart       3
+    Wait For Prompt On Uart  mnv2_first>
+    Write Line To Uart       1
+    Wait For Line On Uart    OK - output tensor matches
+    Wait For Prompt On Uart  mnv2_first>


### PR DESCRIPTION
This PR adds tests for both HPS and LiteX for mnv2_first project.

These tests will, eventually, be quite similar for all platforms. Right now they differ in one test case.
I would suggest keeping them separate for now and try to unify when we have more actual cases.

GitHub Actions workflow, on the other hand, is something that should be definitely unified.

I took the liberty of using @mithro 's actions-includes. This really solves all the issues with code reuse - otherwise each job is mostly copy-paste.
It does, however, require some additional consideration:

1. I used the `.github/workflows-src/Makefile` from SymbiFlow/fasm. It has, obviously, `SymbiFlow Authors` copyrights. Is this an issue?
2. The `.github/workflows/test-projects.yml` is autogenerated. It requires running `make update` in `.github/workflows-src` whenever the workflow source files change. I don't think it's a big issue, when we compare to the number of issues it solves.

So @tcal-x if you consider these changes to be ok, then I think this is mergable. Otherwise I can rely on plain old copy-paste to create the workflow.

I also add Robot output files to gitignore.

Quick PR summary:

* Two robot files, for hps and litex-vexriscv-zephyr, for the mnv2_first project
* .github/includes/actions/run-in-renode/action.yml - the base for Renode tests. It's generally the same action we had there before for proj_template, but now it's parametrized with project path, test file path and build flags
* .github/workflows-src - template files for workflows going into .github/workflows, along with their build system
* .github/workflows/test-projects.yml - autogenerated workflow file