### PR TITLE
Add a simple Dockerfile with all dependencies

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:testing
+
+ENV RISCV_DIR=/toolchain/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin
+ENV PATH="/renode:${RISCV_DIR}:${PATH}"
+ENV WORKDIR=/CFU-Playground
+
+RUN apt update -y && apt install -y wget git python3-pip make gcc openocd yosys expect ccache verilator libevent-dev libjson-c-dev libusb-1.0-0-dev libftdi1-dev vim && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /toolchain && cd /toolchain && wget -nv https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz && tar xf riscv64*tar.gz && rm riscv64*tar.gz
+
+RUN mkdir /renode && wget -nv https://dl.antmicro.com/projects/renode/builds/renode-latest.linux-portable.tar.gz && tar xf renode-*tar.gz -C /renode --strip-components=1 && rm renode-*tar.gz && python3 -m pip install -r /renode/tests/requirements.txt
+
+RUN git clone https://github.com/google/CFU-Playground ${WORKDIR}
+WORKDIR ${WORKDIR}
+
+RUN ./scripts/setup -ci

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:testing
 
 ENV RISCV_DIR=/toolchain/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin
 ENV PATH="/renode:${RISCV_DIR}:${PATH}"
-ENV WORKDIR=/CFU-Playground
+ARG WORKDIR=/CFU-Playground
 
 RUN apt update -y && apt install -y wget git python3-pip make gcc openocd yosys expect ccache verilator libevent-dev libjson-c-dev libusb-1.0-0-dev libftdi1-dev vim && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I'm not really sure if this should be merged. I created this Dockerfile and I use it for my development. Maybe someone will find it useful.

But I'm ok with rejecting this PR if you don't see it fitting in this repo.

Build the dockerfile with `cd scripts; docker build -t cfu-playground .`

Run with `docker run -ti cfu-playground`