### PR TITLE
Pass --synth-mode option to Radiant tools (lse, yosys).

### DIFF
--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -211,6 +211,8 @@ def main():
                         help="Whether to do a full build, including the bitstream")
     parser.add_argument("--toolchain", default="radiant",
                         help="Which toolchain to use, radiant (default) or oxide")
+    parser.add_argument("--synth_mode", default="radiant",
+                        help="Which synthesis to use, radiant/synplify (default), lse, or yosys")
     parser.add_argument("--litespi-flash", action="store_true", help="Use litespi flash")
     parser.add_argument("--cfu", default=None, help="Specify file containing CFU Verilog module")
 


### PR DESCRIPTION
Default is Synplify.
Specify 'yosys' to get Yosys,
or 'lse' to get (Radiant) LSE.

Signed-off-by: Tim Callahan <tcal@google.com>