### PR TITLE
liteSPI updates/fixes.  Change GD25LQ128C->GD25LQ128D.

### DIFF
--- a/soc/hps_platform.py
+++ b/soc/hps_platform.py
@@ -101,7 +101,7 @@ class _CRG(Module):
 
 class Platform(LatticePlatform):
     # The NX-17 has a 450 MHz clock. Our system clock should be a divisor of that.
-    clk_divisor = 8
+    clk_divisor = 6
     sys_clk_freq = int(450e6 / clk_divisor)
 
     def __init__(self, toolchain="radiant"):

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -29,7 +29,7 @@ from litex.soc.cores.bitbang import I2CMaster
 
 from litex.build.lattice.radiant import radiant_build_args, radiant_build_argdict
 
-from litespi.modules import GD25LQ128C
+from litespi.modules import GD25LQ128D
 from litespi.opcodes import SpiNorFlashOpCodes as Codes
 from litespi.phy.generic import LiteSPIPHY
 from litespi import LiteSPI
@@ -141,7 +141,7 @@ class HpsSoC(LiteXSoC):
         self.csr.add("spiflash")
         
     def setup_litespi_flash(self):
-        self.submodules.spiflash_phy  = LiteSPIPHY(self.platform.request("spiflash"), GD25LQ128C(Codes.READ_1_1_1))
+        self.submodules.spiflash_phy  = LiteSPIPHY(self.platform.request("spiflash"), GD25LQ128D(Codes.READ_1_1_1), default_divisor=1)
         self.submodules.spiflash_mmap  = LiteSPI(phy=self.spiflash_phy,
             clk_freq        = self.platform.sys_clk_freq,
             mmap_endianness = self.cpu.endianness)


### PR DESCRIPTION
Set liteSPI PHY divisor to 1.   Up sys clk to 75MHz.

Signed-off-by: Tim Callahan <tcal@google.com>