### PR TITLE
Simplify top scripts (continuation of PR #101)

### DIFF
--- a/proj/example_cfu_v/cfu.v
+++ b/proj/example_cfu_v/cfu.v
@@ -15,43 +15,43 @@
 
 
 module Cfu (
-  input               io_bus_cmd_valid,
-  output              io_bus_cmd_ready,
-  input      [2:0]    io_bus_cmd_payload_function_id,
-  input      [31:0]   io_bus_cmd_payload_inputs_0,
-  input      [31:0]   io_bus_cmd_payload_inputs_1,
-  output              io_bus_rsp_valid,
-  input               io_bus_rsp_ready,
-  output              io_bus_rsp_payload_response_ok,
-  output     [31:0]   io_bus_rsp_payload_outputs_0,
-  input               rst,
-  input               clk
+  input               cmd_valid,
+  output              cmd_ready,
+  input      [2:0]    cmd_payload_function_id,
+  input      [31:0]   cmd_payload_inputs_0,
+  input      [31:0]   cmd_payload_inputs_1,
+  output              rsp_valid,
+  input               rsp_ready,
+  output              rsp_payload_response_ok,
+  output     [31:0]   rsp_payload_outputs_0,
+  input               clk,
+  input               reset
 );
 
-  assign io_bus_rsp_valid = io_bus_cmd_valid;
-  assign io_bus_cmd_ready = io_bus_rsp_ready;
-  assign io_bus_rsp_payload_response_ok = 1'b1;
+  assign rsp_valid = cmd_valid;
+  assign cmd_ready = rsp_ready;
+  assign rsp_payload_response_ok = 1'b1;
 
   //  byte sum (unsigned)
   wire [31:0] cfu0;
-  assign cfu0[31:0] =  io_bus_cmd_payload_inputs_0[7:0]   + io_bus_cmd_payload_inputs_1[7:0] +
-                       io_bus_cmd_payload_inputs_0[15:8]  + io_bus_cmd_payload_inputs_1[15:8] +
-                       io_bus_cmd_payload_inputs_0[23:16] + io_bus_cmd_payload_inputs_1[23:16] +
-                       io_bus_cmd_payload_inputs_0[31:24] + io_bus_cmd_payload_inputs_1[31:24];
+  assign cfu0[31:0] =  cmd_payload_inputs_0[7:0]   + cmd_payload_inputs_1[7:0] +
+                       cmd_payload_inputs_0[15:8]  + cmd_payload_inputs_1[15:8] +
+                       cmd_payload_inputs_0[23:16] + cmd_payload_inputs_1[23:16] +
+                       cmd_payload_inputs_0[31:24] + cmd_payload_inputs_1[31:24];
 
   // byte swap
   wire [31:0] cfu1;
-  assign cfu1[31:24] =     io_bus_cmd_payload_inputs_0[7:0];
-  assign cfu1[23:16] =     io_bus_cmd_payload_inputs_0[15:8];
-  assign cfu1[15:8] =      io_bus_cmd_payload_inputs_0[23:16];
-  assign cfu1[7:0] =       io_bus_cmd_payload_inputs_0[31:24];
+  assign cfu1[31:24] =     cmd_payload_inputs_0[7:0];
+  assign cfu1[23:16] =     cmd_payload_inputs_0[15:8];
+  assign cfu1[15:8] =      cmd_payload_inputs_0[23:16];
+  assign cfu1[7:0] =       cmd_payload_inputs_0[31:24];
 
   // bit reverse
   wire [31:0] cfu2;
   genvar n;
   generate
       for (n=0; n<32; n=n+1) begin
-          assign cfu2[n] =     io_bus_cmd_payload_inputs_0[31-n];
+          assign cfu2[n] =     cmd_payload_inputs_0[31-n];
       end
   endgenerate
 
@@ -59,8 +59,8 @@ module Cfu (
   //
   // select output -- note that we're not fully decoding the 3 function_id bits
   //
-  assign io_bus_rsp_payload_outputs_0 = io_bus_cmd_payload_function_id[1] ? cfu2 :
-                                      ( io_bus_cmd_payload_function_id[0] ? cfu1 : cfu0);
+  assign rsp_payload_outputs_0 = cmd_payload_function_id[1] ? cfu2 :
+                                      ( cmd_payload_function_id[0] ? cfu1 : cfu0);
 
 
 endmodule

--- a/proj/proj_template_v/cfu.v
+++ b/proj/proj_template_v/cfu.v
@@ -15,30 +15,30 @@
 
 
 module Cfu (
-  input               io_bus_cmd_valid,
-  output              io_bus_cmd_ready,
-  input      [2:0]    io_bus_cmd_payload_function_id,
-  input      [31:0]   io_bus_cmd_payload_inputs_0,
-  input      [31:0]   io_bus_cmd_payload_inputs_1,
-  output              io_bus_rsp_valid,
-  input               io_bus_rsp_ready,
-  output              io_bus_rsp_payload_response_ok,
-  output     [31:0]   io_bus_rsp_payload_outputs_0,
-  input               rst,
+  input               cmd_valid,
+  output              cmd_ready,
+  input      [2:0]    cmd_payload_function_id,
+  input      [31:0]   cmd_payload_inputs_0,
+  input      [31:0]   cmd_payload_inputs_1,
+  output              rsp_valid,
+  input               rsp_ready,
+  output              rsp_payload_response_ok,
+  output     [31:0]   rsp_payload_outputs_0,
+  input               reset,
   input               clk
 );
 
   // Trivial handshaking for a combinational CFU
-  assign io_bus_rsp_valid = io_bus_cmd_valid;
-  assign io_bus_cmd_ready = io_bus_rsp_ready;
-  assign io_bus_rsp_payload_response_ok = 1'b1;
+  assign rsp_valid = cmd_valid;
+  assign cmd_ready = rsp_ready;
+  assign rsp_payload_response_ok = 1'b1;
 
   //
   // select output -- note that we're not fully decoding the 3 function_id bits
   //
-  assign io_bus_rsp_payload_outputs_0 = io_bus_cmd_payload_function_id[0] ? 
-                                           io_bus_cmd_payload_inputs_1 :
-                                           io_bus_cmd_payload_inputs_0 ;
+  assign rsp_payload_outputs_0 = cmd_payload_function_id[0] ? 
+                                           cmd_payload_inputs_1 :
+                                           cmd_payload_inputs_0 ;
 
 
 endmodule

--- a/python/nmigen_cfu/cfu.py
+++ b/python/nmigen_cfu/cfu.py
@@ -157,16 +157,17 @@ class Cfu(SimpleElaboratable):
     ----------
     Attribute public names and types form the Verilog module interface:
 
-        input               io_bus_cmd_valid,
-        output              io_bus_cmd_ready,
-        input      [19:0]   io_bus_cmd_payload_function_id,
-        input      [31:0]   io_bus_cmd_payload_inputs_0,
-        input      [31:0]   io_bus_cmd_payload_inputs_1,
-        output              io_bus_rsp_valid,
-        input               io_bus_rsp_ready,
-        output              io_bus_rsp_payload_response_ok,
-        output     [31:0]   io_bus_rsp_payload_outputs_0,
-        input clk
+        input               cmd_valid,
+        output              cmd_ready,
+        input      [9:0]    cmd_payload_function_id,
+        input      [31:0]   cmd_payload_inputs_0,
+        input      [31:0]   cmd_payload_inputs_1,
+        output              rsp_valid,
+        input               rsp_ready,
+        output              rsp_payload_response_ok,
+        output     [31:0]   rsp_payload_outputs_0,
+        input               clk
+        input               reset
     """
 
     def __init__(self, instructions):
@@ -174,16 +175,17 @@ class Cfu(SimpleElaboratable):
         for i in range(8):
             if i not in self.instructions:
                 self.instructions[i] = _FallbackInstruction()
-        self.cmd_valid = Signal(name='io_bus_cmd_valid')
-        self.cmd_ready = Signal(name='io_bus_cmd_ready')
+        self.cmd_valid = Signal(name='cmd_valid')
+        self.cmd_ready = Signal(name='cmd_ready')
         self.cmd_function_id = Signal(
-            10, name='io_bus_cmd_payload_function_id')
-        self.cmd_in0 = Signal(32, name='io_bus_cmd_payload_inputs_0')
-        self.cmd_in1 = Signal(32, name='io_bus_cmd_payload_inputs_1')
-        self.rsp_valid = Signal(name='io_bus_rsp_valid')
-        self.rsp_ready = Signal(name='io_bus_rsp_ready')
-        self.rsp_ok = Signal(name='io_bus_rsp_payload_response_ok')
-        self.rsp_out = Signal(32, name='io_bus_rsp_payload_outputs_0')
+            10, name='cmd_payload_function_id')
+        self.cmd_in0 = Signal(32, name='cmd_payload_inputs_0')
+        self.cmd_in1 = Signal(32, name='cmd_payload_inputs_1')
+        self.rsp_valid = Signal(name='rsp_valid')
+        self.rsp_ready = Signal(name='rsp_ready')
+        self.rsp_ok = Signal(name='rsp_payload_response_ok')
+        self.rsp_out = Signal(32, name='rsp_payload_outputs_0')
+        self.reset = Signal(name='reset')
         self.ports = [
             self.cmd_valid,
             self.cmd_ready,
@@ -194,6 +196,7 @@ class Cfu(SimpleElaboratable):
             self.rsp_ready,
             self.rsp_ok,
             self.rsp_out,
+            self.reset
         ]
 
     def elab(self, m):

--- a/soc/arty.mk
+++ b/soc/arty.mk
@@ -34,7 +34,7 @@ endif
 
 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
 CFU_V:=     $(PROJ_DIR)/cfu.v
-CFU_ARGS:=  --cfu $(CFU_V)
+CFU_ARGS:=  --cpu-cfu $(CFU_V)
 
 SOC_NAME:=  arty.$(PROJ)
 OUT_DIR:=   build/$(SOC_NAME)
@@ -84,8 +84,8 @@ $(CFU_V):
 	$(error $(CFU_V) not found. $(HELP_MESSAGE))
 
 $(BIOS_BIN): $(CFU_V)
-	$(ARTY_RUN) $(LITEX_ARGS) 
+	$(ARTY_RUN)
 
 $(BITSTREAM): $(CFU_V)
 	@echo Building bitstream for Arty. CFU option: $(CFU_ARGS)
-	$(ARTY_RUN) $(LITEX_ARGS) --build
+	$(ARTY_RUN) --build

--- a/soc/arty.py
+++ b/soc/arty.py
@@ -65,14 +65,13 @@ def main():
     vivado_build_args(parser)
     parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--cfu", default=None, help="Specify file containing CFU Verilog module")
     parser.add_argument("--with-mapped-flash", action="store_true", help="Add litespi SPI flash")
     parser.add_argument("--toolchain", default="vivado", help="Specify toolchain for implementing gateware ('vivado' or 'symbiflow')")
     parser.set_defaults(
             csr_csv='csr.csv',
             uart_name='serial',
             uart_baudrate=921600,
-            cpu_variant='full+debug',    # don't specify 'cfu' here
+            cpu_variant='full+cfu+debug',
             with_etherbone=False)
 
     args = parser.parse_args()
@@ -86,16 +85,6 @@ def main():
                     toolchain=args.toolchain, 
                     with_mapped_flash=args.with_mapped_flash,
                     **soc_kwargs)
-
-    # get the CFU version, plus the CFU itself and a wrapper 
-    # ...since we're using stock litex, it doesn't know about the Cfu variants, so we need to use "external_variant"
-    if args.cfu:
-        assert 'full' in args.cpu_variant
-        var = "FullCfuDebug" if ('debug' in args.cpu_variant) else "FullCfu"
-        vexriscv = "../third_party/python/pythondata_cpu_vexriscv/pythondata_cpu_vexriscv"
-        soc.cpu.use_external_variant(f"{vexriscv}/verilog/VexRiscv_{var}.v")
-        soc.platform.add_source(args.cfu)
-        soc.platform.add_source(f"{vexriscv}/verilog/wrapVexRiscv_{var}.v")
 
     builder = Builder(soc, **builder_argdict(args))
 

--- a/soc/cfu/Cfu.v
+++ b/soc/cfu/Cfu.v
@@ -15,49 +15,50 @@
 
 
 module Cfu (
-  input               io_bus_cmd_valid,
-  output              io_bus_cmd_ready,
-  input      [2:0]    io_bus_cmd_payload_function_id,
-  input      [31:0]   io_bus_cmd_payload_inputs_0,
-  input      [31:0]   io_bus_cmd_payload_inputs_1,
-  output              io_bus_rsp_valid,
-  input               io_bus_rsp_ready,
-  output              io_bus_rsp_payload_response_ok,
-  output     [31:0]   io_bus_rsp_payload_outputs_0,
-  input               clk
+  input               cmd_valid,
+  output              cmd_ready,
+  input      [2:0]    cmd_payload_function_id,
+  input      [31:0]   cmd_payload_inputs_0,
+  input      [31:0]   cmd_payload_inputs_1,
+  output              rsp_valid,
+  input               rsp_ready,
+  output              rsp_payload_response_ok,
+  output     [31:0]   rsp_payload_outputs_0,
+  input               clk,
+  input               reset
 );
 
-  assign io_bus_rsp_valid = io_bus_cmd_valid;
-  assign io_bus_cmd_ready = io_bus_rsp_ready;
-  assign io_bus_rsp_payload_response_ok = 1'b1;
+  assign rsp_valid = cmd_valid;
+  assign cmd_ready = rsp_ready;
+  assign rsp_payload_response_ok = 1'b1;
 
   //  byte sum (unsigned)
   wire [31:0] cfu0;
-  assign cfu0[31:0] =  io_bus_cmd_payload_inputs_0[7:0]   + io_bus_cmd_payload_inputs_1[7:0] +
-                       io_bus_cmd_payload_inputs_0[15:8]  + io_bus_cmd_payload_inputs_1[15:8] +
-                       io_bus_cmd_payload_inputs_0[23:16] + io_bus_cmd_payload_inputs_1[23:16] +
-                       io_bus_cmd_payload_inputs_0[31:24] + io_bus_cmd_payload_inputs_1[31:24];
+  assign cfu0[31:0] =  cmd_payload_inputs_0[7:0]   + cmd_payload_inputs_1[7:0] +
+                       cmd_payload_inputs_0[15:8]  + cmd_payload_inputs_1[15:8] +
+                       cmd_payload_inputs_0[23:16] + cmd_payload_inputs_1[23:16] +
+                       cmd_payload_inputs_0[31:24] + cmd_payload_inputs_1[31:24];
 
   // byte swap
   wire [31:0] cfu1;
-  assign cfu1[31:24] =     io_bus_cmd_payload_inputs_0[7:0];
-  assign cfu1[23:16] =     io_bus_cmd_payload_inputs_0[15:8];
-  assign cfu1[15:8] =      io_bus_cmd_payload_inputs_0[23:16];
-  assign cfu1[7:0] =       io_bus_cmd_payload_inputs_0[31:24];
+  assign cfu1[31:24] =     cmd_payload_inputs_0[7:0];
+  assign cfu1[23:16] =     cmd_payload_inputs_0[15:8];
+  assign cfu1[15:8] =      cmd_payload_inputs_0[23:16];
+  assign cfu1[7:0] =       cmd_payload_inputs_0[31:24];
 
   // bit reverse
   wire [31:0] cfu2;
   genvar n;
   generate
       for (n=0; n<32; n=n+1) begin
-          assign cfu2[n] =     io_bus_cmd_payload_inputs_0[31-n];
+          assign cfu2[n] =     cmd_payload_inputs_0[31-n];
       end
   endgenerate
 
 
   // select output
-  assign io_bus_rsp_payload_outputs_0 = io_bus_cmd_payload_function_id[1] ? cfu2 :
-                                      ( io_bus_cmd_payload_function_id[0] ? cfu1 : cfu0);
+  assign rsp_payload_outputs_0 = cmd_payload_function_id[1] ? cfu2 :
+                                      ( cmd_payload_function_id[0] ? cfu1 : cfu0);
 
 
 endmodule

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -34,7 +34,7 @@ endif
 
 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
 CFU_V:=     $(PROJ_DIR)/cfu.v
-CFU_ARGS:=  --cfu $(CFU_V)
+CFU_ARGS:=  --cpu-cfu $(CFU_V)
 
 SOC_NAME:=  hps.$(PROJ)
 OUT_DIR:=   build/$(SOC_NAME)
@@ -100,8 +100,8 @@ $(CFU_V):
 	$(error $(CFU_V) not found. $(HELP_MESSAGE))
 
 $(BIOS_BIN): $(CFU_V)
-	$(HPS_RUN) $(LITEX_ARGS)
+	$(HPS_RUN)
 
 $(BITSTREAM): $(CFU_V)
 	@echo Building bitstream for Arty. CFU option: $(CFU_ARGS)
-	$(HPS_RUN) $(LITEX_ARGS) --build
+	$(HPS_RUN) --build

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -219,20 +219,19 @@ def main():
 
     args = parser.parse_args()
 
-    # get the CFU version, plus the CFU itself and a wrapper 
-    # ...since we're using stock litex, it doesn't know about the Cfu variants, so we need to use "external_variant"
-    variant = "full"
+
     if args.cpu_cfu:
+        variant = "full+cfu+debug" if args.debug else "full+cfu"
+        soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash, variant=variant, cpu_cfu=args.cpu_cfu)
         if args.slim_cpu:
-            var = "SlimCfuDebug" if args.debug else "SlimCfu"
+            # override the actual source to get the Slim version
+            #  -- this is a hack needed because litex/.../vexriscv/core.py doesn't know about the Slim versions.
             vexriscv = "../third_party/python/pythondata_cpu_vexriscv/pythondata_cpu_vexriscv"
-            soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash)
+            var = "SlimCfuDebug" if args.debug else "SlimCfu"
             soc.cpu.use_external_variant(f"{vexriscv}/verilog/VexRiscv_{var}.v")
-            soc.platform.add_source(args.cpu_cfu)
-            soc.platform.add_source(f"{vexriscv}/verilog/wrapVexRiscv_{var}.v")
-        else:
-            variant = "full+cfu+debug" if args.debug else "full+cfu"
-            soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash, variant=variant, cpu_cfu=args.cpu_cfu)
+    else:
+        variant = "full+debug" if args.debug else "full"
+        soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash, variant=variant)
         
 
     builder = create_builder(soc, args)

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -75,19 +75,21 @@ class HpsSoC(LiteXSoC):
 
     cpu_type = "vexriscv"
 
-    def __init__(self, platform, debug, litespi_flash=False):
+    def __init__(self, platform, debug, litespi_flash=False, variant=None, cpu_cfu=None):
         LiteXSoC.__init__(self,
                           platform=platform,
                           sys_clk_freq=platform.sys_clk_freq,
                           csr_data_width=(32 if litespi_flash else 8))
-
+        if variant == None:
+            variant = "full+debug" if debug else "full"
 
         # Clock, Controller, CPU
         self.submodules.crg = platform.create_crg()
         self.add_controller("ctrl")
         self.add_cpu(self.cpu_type,
-                     variant=("full+debug" if debug else "full"),
-                     reset_address=self.rom_origin)
+                     variant=variant,
+                     reset_address=self.rom_origin,
+                     cfu=cpu_cfu)
 
         # RAM
         self.setup_ram()
@@ -213,24 +215,25 @@ def main():
     parser.add_argument("--synth_mode", default="radiant",
                         help="Which synthesis to use, radiant/synplify (default), lse, or yosys")
     parser.add_argument("--litespi-flash", action="store_true", help="Use litespi flash")
-    parser.add_argument("--cfu", default=None, help="Specify file containing CFU Verilog module")
+    parser.add_argument("--cpu-cfu", default=None, help="Specify file containing CFU Verilog module")
 
     args = parser.parse_args()
 
-    soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash)
-
     # get the CFU version, plus the CFU itself and a wrapper 
     # ...since we're using stock litex, it doesn't know about the Cfu variants, so we need to use "external_variant"
-    if args.cfu:
-        assert 'full' in soc.cpu.variant
+    variant = "full"
+    if args.cpu_cfu:
         if args.slim_cpu:
             var = "SlimCfuDebug" if args.debug else "SlimCfu"
+            vexriscv = "../third_party/python/pythondata_cpu_vexriscv/pythondata_cpu_vexriscv"
+            soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash)
+            soc.cpu.use_external_variant(f"{vexriscv}/verilog/VexRiscv_{var}.v")
+            soc.platform.add_source(args.cpu_cfu)
+            soc.platform.add_source(f"{vexriscv}/verilog/wrapVexRiscv_{var}.v")
         else:
-            var = "FullCfuDebug" if args.debug else "FullCfu"
-        vexriscv = "../third_party/python/pythondata_cpu_vexriscv/pythondata_cpu_vexriscv"
-        soc.cpu.use_external_variant(f"{vexriscv}/verilog/VexRiscv_{var}.v")
-        soc.platform.add_source(args.cfu)
-        soc.platform.add_source(f"{vexriscv}/verilog/wrapVexRiscv_{var}.v")
+            variant = "full+cfu+debug" if args.debug else "full+cfu"
+            soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash, variant=variant, cpu_cfu=args.cpu_cfu)
+        
 
     builder = create_builder(soc, args)
     builder_kwargs = radiant_build_argdict(args) if args.toolchain == "radiant" else {}

--- a/soc/nexys_video.mk
+++ b/soc/nexys_video.mk
@@ -34,7 +34,7 @@ endif
 
 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
 CFU_V:=     $(PROJ_DIR)/cfu.v
-CFU_ARGS:=  --cfu $(CFU_V)
+CFU_ARGS:=  --cpu-cfu $(CFU_V)
 
 SOC_NAME:=  nexys_video.$(PROJ)
 OUT_DIR:=   build/$(SOC_NAME)
@@ -84,8 +84,8 @@ $(CFU_V):
 	$(error $(CFU_V) not found. $(HELP_MESSAGE))
 
 $(BIOS_BIN): $(CFU_V)
-	$(NEXYS_VIDEO_RUN) $(LITEX_ARGS) 
+	$(NEXYS_VIDEO_RUN)
 
 $(BITSTREAM): $(CFU_V)
 	@echo Building bitstream for nexys_video. CFU option: $(CFU_ARGS)
-	$(NEXYS_VIDEO_RUN) $(LITEX_ARGS) --build
+	$(NEXYS_VIDEO_RUN) --build

--- a/soc/nexys_video.py
+++ b/soc/nexys_video.py
@@ -65,13 +65,12 @@ def main():
     vivado_build_args(parser)
     parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--cfu", default=None, help="Specify file containing CFU Verilog module")
     parser.add_argument("--toolchain", default="vivado", help="Specify toolchain for implementing gateware ('vivado' or 'symbiflow')")
     parser.set_defaults(
             csr_csv='csr.csv',
             uart_name='serial',
             uart_baudrate=921600,
-            cpu_variant='full+debug',    # don't specify 'cfu' here
+            cpu_variant='full+cfu+debug',
             with_etherbone=False)
 
     args = parser.parse_args()
@@ -82,16 +81,6 @@ def main():
     soc_kwargs["l2_size"] = 8 * 1024
     soc = CustomSoC(with_ethernet=args.with_ethernet, with_etherbone=args.with_etherbone,
                     toolchain=args.toolchain, **soc_kwargs)
-
-    # get the CFU version, plus the CFU itself and a wrapper 
-    # ...since we're using stock litex, it doesn't know about the Cfu variants, so we need to use "external_variant"
-    if args.cfu:
-        assert 'full' in args.cpu_variant
-        var = "FullCfuDebug" if ('debug' in args.cpu_variant) else "FullCfu"
-        vexriscv = "../third_party/python/pythondata_cpu_vexriscv/pythondata_cpu_vexriscv"
-        soc.cpu.use_external_variant(f"{vexriscv}/verilog/VexRiscv_{var}.v")
-        soc.platform.add_source(args.cfu)
-        soc.platform.add_source(f"{vexriscv}/verilog/wrapVexRiscv_{var}.v")
 
     builder = Builder(soc, **builder_argdict(args))
 

--- a/soc/qmtech_wukong.mk
+++ b/soc/qmtech_wukong.mk
@@ -34,7 +34,7 @@ endif
 
 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
 CFU_V:=     $(PROJ_DIR)/cfu.v
-CFU_ARGS:=  --cfu $(CFU_V)
+CFU_ARGS:=  --cpu-cfu $(CFU_V)
 
 SOC_NAME:=  qmtech_wukong.$(PROJ)
 OUT_DIR:=   build/$(SOC_NAME)
@@ -84,8 +84,8 @@ $(CFU_V):
 	$(error $(CFU_V) not found. $(HELP_MESSAGE))
 
 $(BIOS_BIN): $(CFU_V)
-	$(QMTECH_WUKONG_RUN) $(LITEX_ARGS) 
+	$(QMTECH_WUKONG_RUN)
 
 $(BITSTREAM): $(CFU_V)
 	@echo Building bitstream for QMTECH Wukong Board. CFU option: $(CFU_ARGS)
-	$(QMTECH_WUKONG_RUN) $(LITEX_ARGS) --build
+	$(QMTECH_WUKONG_RUN) --build

--- a/soc/qmtech_wukong.py
+++ b/soc/qmtech_wukong.py
@@ -65,13 +65,12 @@ def main():
     vivado_build_args(parser)
     parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--cfu", default=None, help="Specify file containing CFU Verilog module")
     parser.add_argument("--toolchain", default="vivado", help="Specify toolchain for implementing gateware ('vivado' or 'symbiflow')")
     parser.set_defaults(
             csr_csv='csr.csv',
             uart_name='serial',
             uart_baudrate=921600,
-            cpu_variant='full+debug',    # don't specify 'cfu' here
+            cpu_variant='full+cfu+debug',
             with_etherbone=False)
 
     args = parser.parse_args()
@@ -82,16 +81,6 @@ def main():
     soc_kwargs["l2_size"] = 8 * 1024
     soc = CustomSoC(with_ethernet=args.with_ethernet, with_etherbone=args.with_etherbone,
                     toolchain=args.toolchain, **soc_kwargs)
-
-    # get the CFU version, plus the CFU itself and a wrapper 
-    # ...since we're using stock litex, it doesn't know about the Cfu variants, so we need to use "external_variant"
-    if args.cfu:
-        assert 'full' in args.cpu_variant
-        var = "FullCfuDebug" if ('debug' in args.cpu_variant) else "FullCfu"
-        vexriscv = "../third_party/python/pythondata_cpu_vexriscv/pythondata_cpu_vexriscv"
-        soc.cpu.use_external_variant(f"{vexriscv}/verilog/VexRiscv_{var}.v")
-        soc.platform.add_source(args.cfu)
-        soc.platform.add_source(f"{vexriscv}/verilog/wrapVexRiscv_{var}.v")
 
     builder = Builder(soc, **builder_argdict(args))
 


### PR DESCRIPTION
Continuation of PR #101.

Updated VexRiscv verilogs to remove wrappers and not rename the VexRiscv core with "_inner".

Small updates to the handling of Slim VexRiscv -- they can still use the new CFU integration,
their source just needs to be changed.

