### PR TITLE
In nMigen Cfu, tie implicit "rst" to explicit "reset".

### DIFF
--- a/python/nmigen_cfu/cfu.py
+++ b/python/nmigen_cfu/cfu.py
@@ -272,6 +272,11 @@ class Cfu(SimpleElaboratable):
             ]
             m.submodules[f"fn{i}"] = instruction
 
+        # tie "reset" and "rst" together (issue #110)
+        rst = ResetSignal('sync')
+        m.d.comb += rst.eq(self.reset)
+
+
 
 class CfuTestBase(TestBase):
     """Tests CFU ops independent of timing and handshaking."""

--- a/python/nmigen_cfu/cfu.py
+++ b/python/nmigen_cfu/cfu.py
@@ -17,6 +17,7 @@ __package__ = 'nmigen_cfu'
 
 from nmigen import Array, Signal, signed
 from .util import SimpleElaboratable, TestBase
+from nmigen.hdl import ResetSignal
 
 
 class InstructionBase(SimpleElaboratable):


### PR DESCRIPTION
This is a suboptimal fix because the generated Verilog Cfu module will have both "rst" and "reset" ports.   This PR ties them together, so that even though only "reset" is driven by sys_rst, it gets passed to the "rst" net inside the Cfu.

Signed-off-by: Tim Callahan <tcal@google.com>