### PR TITLE
Make CFU-Playground more board agnostic, easier to extend for specific boards.

### DIFF
--- a/environment
+++ b/environment
@@ -19,7 +19,7 @@ CFU_ROOT=$(dirname $(realpath ${BASH_SOURCE[0]}))
 # We deliberately clear anything that may have already been in PYTHONPATH to
 # prevent accidentally pulling in anything outside this project.
 PYTHONPATH="${CFU_ROOT}/python"
-for i in "${CFU_ROOT}/third_party/python"/* "${CFU_ROOT}/python/"*; do
+for i in "${CFU_ROOT}/third_party/python"/* "${CFU_ROOT}/python/"* "${CFU_ROOT}/soc/"*; do
     # Avoid adding files such as README.md to our path
     if [ -d "$i/src" ]; then
         PYTHONPATH="${PYTHONPATH}:${i}/src"

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -76,7 +76,7 @@ export DEFINES    += PLATFORM_$(PLATFORM)
 export DEFINES    += PLATFORM=$(PLATFORM)
 
 SHELL           := /bin/bash
-TTY             := $(wildcard /dev/ttyUSB?)
+TTY             := $(or $(wildcard /dev/ttyUSB?), $(wildcard /dev/ttyACM?))
 CRC             := 
 #CRC             := --no-crc
 

--- a/proj/proj_template/Makefile
+++ b/proj/proj_template/Makefile
@@ -26,7 +26,7 @@ DEFINES += NDEBUG
 #DEFINES += NPROFILE
 
 # Uncomment to include pdti8 in built binary
-#DEFINES += INCLUDE_MODEL_PDTI8
+DEFINES += INCLUDE_MODEL_PDTI8
 
 # Uncomment to include micro_speech in built binary
 #DEFINES += INCLUDE_MODEL_MICRO_SPEECH

--- a/proj/proj_template_v/Makefile
+++ b/proj/proj_template_v/Makefile
@@ -23,7 +23,7 @@ DEFINES += NDEBUG
 # DEFINES += CFU_SOFTWARE_DEFINED
 
 # Uncomment to include pdti8 in built binary
-#DEFINES += INCLUDE_MODEL_PDTI8
+DEFINES += INCLUDE_MODEL_PDTI8
 
 # Uncomment to include micro_speech in built binary
 #DEFINES += INCLUDE_MODEL_MICRO_SPEECH
@@ -47,6 +47,6 @@ DEFINES += NDEBUG
 #DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_VWW
 
 # Uncomment to include all TFLM examples (pdti8, micro_speech, magic_wand)
-DEFINES += INCLUDE_ALL_TFLM_EXAMPLES
+#DEFINES += INCLUDE_ALL_TFLM_EXAMPLES
 
 include ../proj.mk

--- a/soc/board_specific_workflows/__init__.py
+++ b/soc/board_specific_workflows/__init__.py
@@ -15,6 +15,7 @@
 
 from .general import GeneralSoCWorkflow
 from .digilent_arty import DigilentArtySoCWorkflow
+from .workflow_args import parse_workflow_args
 
 
 def workflow_factory(target: str) -> GeneralSoCWorkflow:
@@ -35,5 +36,6 @@ def workflow_factory(target: str) -> GeneralSoCWorkflow:
 __all__ = [
     'DigilentArtySoCWorkflow',
     'GeneralSoCWorkflow',
+    'parse_workflow_args'
     'workflow_factory',
 ]

--- a/soc/board_specific_workflows/__init__.py
+++ b/soc/board_specific_workflows/__init__.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .general import GeneralSoCWorkflow
-from .digilent_arty import DigilentArtySoCWorkflow
-from .workflow_args import parse_workflow_args
+from general import GeneralSoCWorkflow
+from digilent_arty import DigilentArtySoCWorkflow
+from workflow_args import parse_workflow_args
 
 
 def workflow_factory(target: str) -> GeneralSoCWorkflow:

--- a/soc/board_specific_workflows/__init__.py
+++ b/soc/board_specific_workflows/__init__.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .general import GeneralSoCWorkflow
+from .digilent_arty import DigilentArtySoCWorkflow
+
+
+def workflow_factory(target: str) -> GeneralSoCWorkflow:
+    """Factory function to map a target to a SoC workflow.
+    
+    Args:
+        target: A string representing the target board.
+    
+    Returns:
+        The SoC workflow for the specific board. Will return the general
+        workflow if there is no known specific workflow.
+    """
+    return {
+        'digilent_arty': DigilentArtySoCWorkflow,
+    }.get(target, GeneralSoCWorkflow)
+
+
+__all__ = [
+    'DigilentArtySoCWorkflow',
+    'GeneralSoCWorkflow',
+    'workflow_factory',
+]

--- a/soc/board_specific_workflows/digilent_arty.py
+++ b/soc/board_specific_workflows/digilent_arty.py
@@ -13,12 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .general import GeneralSoCWorkflow
-from litex.soc.integration.soc import LiteXSoC
+import general
+from litex.soc.integration import soc as litex_soc
+from litex.soc.integration import builder
+from litex.build.xilinx import vivado
 
 
-class DigilentArtySoCWorkflow(GeneralSoCWorkflow):
+class DigilentArtySoCWorkflow(general.GeneralSoCWorkflow):
     """Specializes the general workflow for the Digilent Arty."""
-    def make_soc(self, **kwargs) -> LiteXSoC:
+    def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
         """Runs the general make_soc with a l2_size parameter."""
         return super().make_soc(l2_size=8 * 1024, **kwargs)
+
+    def build_soc(self, soc: litex_soc.LiteXSoC, **kwargs) -> builder.Builder:
+        """Specializes build_soc to add Vivado args if needed."""
+        if isinstance(soc.platform.toolchain, vivado.XilinxVivadoToolchain):
+            kwargs.update(vivado.vivado_build_argdict(self.args))
+        return super().build_soc(soc, **kwargs)

--- a/soc/board_specific_workflows/digilent_arty.py
+++ b/soc/board_specific_workflows/digilent_arty.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .general import GeneralSoCWorkflow
+from litex.soc.integration.soc import LiteXSoC
+
+
+class DigilentArtySoCWorkflow(GeneralSoCWorkflow):
+    """Specializes the general workflow for the Digilent Arty."""
+    def make_soc(self, **kwargs) -> LiteXSoC:
+        """Runs the general make_soc with a l2_size parameter."""
+        return super().make_soc(l2_size=8 * 1024, **kwargs)

--- a/soc/board_specific_workflows/general.py
+++ b/soc/board_specific_workflows/general.py
@@ -49,10 +49,7 @@ class GeneralSoCWorkflow():
         """
         self.args = args
         self.soc_constructor = soc_constructor
-        if builder_constructor:
-            self.builder_constructor = builder_constructor
-        else:
-            self.builder_constructor = builder.Builder
+        self.builder_constructor = builder_constructor or builder.Builder
 
     def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
         """Utilizes self.soc_constructor to make a LiteXSoC.

--- a/soc/board_specific_workflows/general.py
+++ b/soc/board_specific_workflows/general.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import importlib
+import litex.build.xilinx.vivado as litex_vivado
+import litex.soc.integration.builder as litex_builder
+import litex.soc.integration.soc as litex_soc
+import litex.soc.integration.soc_core as litex_soc_core
+import os
+
+# By caching this type we are allowed to patch it in tests.
+_VIVADO_TOOLCHAIN_TYPE = litex_vivado.XilinxVivadoToolchain
+
+
+class GeneralSoCWorkflow():
+    """Base class that implements general workflow for building/loading a SoC.
+
+    For many boards this class is sufficient, but some boards will require
+    a subclass that overrides one or more of the methods for designing,
+    building, and loading the SoC.
+
+    Attributes:
+        args: An argparse Namespace that holds SoC and build options.
+        module: The Litex-Boards module for the target board.
+    """
+    def __init__(self, args: argparse.Namespace) -> None:
+        try:
+            self.module = importlib.import_module(
+                self.format_import_path(args.target))
+        except:
+            raise ModuleNotFoundError(f'Could not load {args.target} target.')
+        self.args = args
+
+    @classmethod
+    def format_import_path(cls, target: str) -> str:
+        """Formats the import path for the litex_boards import."""
+        return f'litex_boards.targets.{target}'
+
+    def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
+        """ Utilizes self.module.BaseSoC to make a LiteXSoC.
+        
+        Args:
+            **kwargs: Arguments meant to extend/overwrite the general
+              arguments to self.module.BaseSoc.
+        
+        Returns:
+            The LiteXSoC for the target board.
+        """
+        base_soc_kwargs = {
+            'with_ethernet': self.args.with_ethernet,
+            'with_etherbone': self.args.with_etherbone,
+            'with_mapped_flash': self.args.with_mapped_flash,
+        }
+        base_soc_kwargs.update(litex_soc_core.soc_core_argdict(self.args))
+        if self.args.toolchain:
+            base_soc_kwargs['toolchain'] = self.args.toolchain
+
+        base_soc_kwargs.update(kwargs)
+        return self.module.BaseSoC(**base_soc_kwargs)
+
+    def build_soc(self, soc: litex_soc.LiteXSoC,
+                  **kwargs) -> litex_builder.Builder:
+        """ Creates a LiteX Builder and builds the Soc if self.args.build.
+        
+        Args:
+            soc: The LiteXSoC meant to be built.
+            **kwargs: Arguments meant to extend/overwrite the general
+              arguments to the LiteX Builder.
+
+        Returns:
+            The LiteX Builder for the SoC.
+        """
+        builder_kwargs = litex_builder.builder_argdict(self.args)
+        builder_kwargs.update(kwargs)
+        builder = litex_builder.Builder(soc, **builder_kwargs)
+        if isinstance(soc.platform.toolchain, _VIVADO_TOOLCHAIN_TYPE):
+            builder.build(**litex_vivado.vivado_build_argdict(self.args),
+                          run=self.args.build)
+        else:
+            builder.build(run=self.args.build)
+        return builder
+
+    def load(self, soc: litex_soc.LiteXSoC,
+             builder: litex_builder.Builder) -> None:
+        """ Loads a SoC onto the target baord.
+        
+        Args:
+            soc: The LiteXSoc meant to be loaded.
+            builder: The LiteX builder used to build the SoC.
+        """
+        prog = soc.platform.create_programmer()
+        bitstream_filename = self.format_bitstream_filename(builder.gateware_dir, soc.build_name)
+        prog.load_bitstream(bitstream_filename)
+    
+    @classmethod
+    def format_bitstream_filename(cls, directory: str, build_name: str) -> str:
+        return os.path.join(directory, f'{build_name}.bit')
+
+    def run(self) -> None:
+        """ Runs the workflow in order (make_soc -> build_soc -> load)."""
+        soc = self.make_soc()
+        builder = self.build_soc(soc)
+        if self.args.load:
+            self.load(soc, builder)

--- a/soc/board_specific_workflows/run_unit_tests.sh
+++ b/soc/board_specific_workflows/run_unit_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pushd $(dirname ${BASH_SOURCE[0]})
+../../scripts/pyrun -m unittest $*
+popd

--- a/soc/board_specific_workflows/run_unit_tests.sh
+++ b/soc/board_specific_workflows/run_unit_tests.sh
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-pushd $(dirname ${BASH_SOURCE[0]})
 ../../scripts/pyrun -m unittest $*
-popd

--- a/soc/board_specific_workflows/test_digilent_arty.py
+++ b/soc/board_specific_workflows/test_digilent_arty.py
@@ -22,7 +22,7 @@ from litex.build.xilinx import vivado
 from unittest import mock
 
 
-class DigilentArtySoCWorkflow(unittest.TestCase):
+class DigilentArtySoCWorkflowTest(unittest.TestCase):
     """TestCase for the DigilentArtySoCWorkflow."""
     def setUp(self):
         self.args = mock.MagicMock()
@@ -33,6 +33,9 @@ class DigilentArtySoCWorkflow(unittest.TestCase):
             vivado.XilinxVivadoToolchain)
         self.soc_constructor = mock.MagicMock()
         self.builder_constructor = mock.create_autospec(builder.Builder)
+        self.builder = mock.create_autospec(builder.Builder, instance=True)
+        self.builder_constructor.return_value = self.builder
+
 
     def simple_init(self):
         """Returns a DigilentArtySoCWorkflow with testing parameters."""
@@ -46,14 +49,18 @@ class DigilentArtySoCWorkflow(unittest.TestCase):
         kwargs = self.soc_constructor.call_args.kwargs
 
         self.assertIn('l2_size', kwargs)
-        self.assertTrue(kwargs['l2_size'], 8 * 1024)
+        self.assertEqual(kwargs['l2_size'], 8 * 1024)
 
     @mock.patch('litex.build.xilinx.vivado.vivado_build_argdict')
     def test_build_soc_vivado(self, mock_vivado_build_argdict):
         """Tests that vivado_build_argdict is called when using Vivado."""
+        argdict_return = {'ijkl': 'mnop'}
+        mock_vivado_build_argdict.return_value = argdict_return
         self.simple_init().build_soc(self.soc)
 
         mock_vivado_build_argdict.assert_called_once_with(self.args)
+        build_kwargs = self.builder.build.call_args.kwargs
+        self.assertEqual(argdict_return['ijkl'], build_kwargs['ijkl'])
 
 
 if __name__ == '__main__':

--- a/soc/board_specific_workflows/test_digilent_arty.py
+++ b/soc/board_specific_workflows/test_digilent_arty.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import digilent_arty
+import unittest
+import unittest.mock
+
+
+class FakeDigilentArtySoCWorkflow(digilent_arty.DigilentArtySoCWorkflow):
+    """Subclass of DigilentArtySoCWorkflow that makes __init__ a no-op."""
+    def __init__(self):
+        pass
+
+
+class DigilentArtySoCWorkflow(unittest.TestCase):
+    """TestCase for the DigilentArtySoCWorkflow."""
+    @unittest.mock.patch('general.GeneralSoCWorkflow.make_soc')
+    def test_make_soc(self, mock_make_soc):
+        """Tests the make_soc method of DigilentArtySoCWorkflow."""
+        FakeDigilentArtySoCWorkflow().make_soc()
+        kwargs = mock_make_soc.call_args.kwargs
+        mock_make_soc.assert_called_once()
+        self.assertIn('l2_size', kwargs)
+        self.assertTrue(kwargs['l2_size'], 8 * 1024)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/soc/board_specific_workflows/test_general.py
+++ b/soc/board_specific_workflows/test_general.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import general
+import unittest
+import unittest.mock
+
+
+class TestGeneralSoCWorkflow(unittest.TestCase):
+    """TestCase for the GeneralSoCWorkflow class.
+    
+    All methods except `run` are tested in this test case.  
+    """
+    def setUp(self):
+        """Sets up various mocks used throughout the tests."""
+
+        # Mocks the argparse arguments
+        self.mock_namespace = unittest.mock.MagicMock()
+        self.target_value = 'test_target'
+        self.target_keyword = 'target'
+        self.build_keyword = 'build'
+        self.build_value = True
+        self.call_kwargs = {
+            self.target_keyword: self.target_value,
+            self.build_keyword: self.build_value,
+        }
+        self.mock_namespace.configure_mock(**self.call_kwargs)
+
+        # Mocks the generated LiteXSoC
+        self.mock_soc = unittest.mock.MagicMock()
+        self.build_name = 'build_name'
+        self.mock_soc.configure_mock(build_name=self.build_name)
+
+        # Mocks the imported LiteX-Boards module
+        self.mock_module = unittest.mock.MagicMock()
+        self.mock_module.BaseSoC = unittest.mock.MagicMock(
+            return_value=self.mock_soc)
+
+        # Mocks the LiteX Builder
+        self.mock_builder = unittest.mock.MagicMock()
+        self.gateware_dir = 'test_gateware_dir/'
+        self.mock_builder.configure_mock(gateware_dir=self.gateware_dir)
+        self.mock_builder.build = unittest.mock.MagicMock()
+
+        # Overwrite the format_bistream_filename method to avoid os.
+        self.format_bitsream_filename = general.GeneralSoCWorkflow.format_bitstream_filename
+        self.test_format_func = lambda cls, x, y: f'{x}, {y}'
+        general.GeneralSoCWorkflow.format_bitstream_filename = self.test_format_func
+
+    def tearDown(self):
+        """Fixes the overwritten format_bitstream_filename method."""
+        general.GeneralSoCWorkflow.format_bitstream_filename = self.format_bitsream_filename
+
+    @unittest.mock.patch('importlib.import_module')
+    def patched_init(self, mock_import_module):
+        """Calls the constructor with a redefined importlib.import_module."""
+        mock_import_module.return_value = self.mock_module
+        self.mock_import_module = mock_import_module
+        return general.GeneralSoCWorkflow(self.mock_namespace)
+
+    def test_init(self):
+        """Tests constructor args and import."""
+        workflow = self.patched_init()
+
+        self.mock_import_module.assert_called_once_with(
+            general.GeneralSoCWorkflow.format_import_path(self.target_value))
+        self.assertEqual(workflow.args, self.mock_namespace)
+        self.assertEqual(workflow.module, self.mock_module)
+
+    @unittest.mock.patch('litex.soc.integration.soc_core.soc_core_argdict')
+    def patched_make_soc(self, mock_soc_core_argdict, **kwargs):
+        """Calls make_soc with a redefined soc_core_argdict."""
+        workflow = self.patched_init()
+        self.mock_soc_core_argdict = mock_soc_core_argdict
+        return workflow, workflow.make_soc(**kwargs)
+
+    def test_make_soc(self):
+        """Tests the general make_soc function without kwargs."""
+        _, soc = self.patched_make_soc()
+
+        self.mock_soc_core_argdict.assert_called_once_with(self.mock_namespace)
+        self.assertEqual(soc, self.mock_soc)
+        self.mock_module.BaseSoC.assert_called_once()
+
+    def test_make_soc_kwargs(self):
+        """Tests to see if kwargs are passed through in make_soc."""
+        self.patched_make_soc(**self.call_kwargs)
+        kwargs = self.mock_module.BaseSoC.call_args.kwargs
+
+        self.assertIn(self.target_keyword, kwargs)
+        self.assertTrue(kwargs[self.target_keyword] == self.target_value)
+
+    @unittest.mock.patch('litex.soc.integration.builder.Builder')
+    @unittest.mock.patch('litex.soc.integration.builder.builder_argdict')
+    @unittest.mock.patch('litex.build.xilinx.vivado.vivado_build_argdict')
+    def patched_build_soc(self,
+                          mock_vivado_build_argdict,
+                          mock_builder_argdict,
+                          mock_builder_class,
+                          is_vivado=False,
+                          **kwargs):
+        """Calls build_soc with redefined imports."""
+        workflow, soc = self.patched_make_soc()
+        mock_builder_argdict.return_value = self.call_kwargs
+        mock_builder_class.return_value = self.mock_builder
+        soc.platform = unittest.mock.MagicMock()
+        if is_vivado:
+            soc.platform.toolchain = unittest.mock.MagicMock(
+                spec=general._VIVADO_TOOLCHAIN_TYPE)
+            mock_vivado_build_argdict.return_value = self.call_kwargs
+
+        self.mock_builder_class = mock_builder_class
+        self.mock_builder_argdict = mock_builder_argdict
+        self.mock_vivado_build_argdict = mock_vivado_build_argdict
+
+        return workflow, workflow.build_soc(soc, **kwargs)
+
+    def test_build_soc(self):
+        """Tests general logic of build_soc (when is_vivado is False)."""
+        _, builder = self.patched_build_soc(is_vivado=False)
+        kwargs = self.mock_builder.build.call_args.kwargs
+
+        self.assertEqual(builder, self.mock_builder)
+        self.mock_builder_argdict.assert_called_once_with(self.mock_namespace)
+        self.mock_builder_class.assert_called_once_with(
+            self.mock_soc, **self.call_kwargs)
+        self.assertEqual(kwargs['run'], self.build_value)
+        self.mock_vivado_build_argdict.assert_not_called()
+
+    def test_build_soc_vivado(self):
+        """Tests build_soc when is_vivado is True."""
+        _, builder = self.patched_build_soc(is_vivado=True)
+        kwargs = self.mock_builder.build.call_args.kwargs
+
+        self.assertEqual(builder, self.mock_builder)
+        self.mock_builder_argdict.assert_called_once_with(self.mock_namespace)
+        self.mock_builder_class.assert_called_once_with(
+            self.mock_soc, **self.call_kwargs)
+        self.assertEqual(kwargs['run'], self.build_value)
+        self.mock_vivado_build_argdict.assert_called_once_with(
+            self.mock_namespace)
+
+    def test_build_soc_kwargs(self):
+        """Tests to see if kwargs are passed through in build_soc."""
+        extra_kwarg = {'a': 'a'}
+        self.patched_build_soc(is_vivado=False, **extra_kwarg)
+        kwargs = self.mock_builder_class.call_args.kwargs
+
+        self.assertIn('a', kwargs)
+
+    def test_load(self):
+        """Tests load with a redefined format bitstream."""
+        workflow, _ = self.patched_build_soc()
+        programmer = unittest.mock.MagicMock()
+        self.mock_soc.platform.create_programmer.return_value = programmer
+        workflow.load(self.mock_soc, self.mock_builder)
+
+        self.mock_soc.platform.create_programmer.assert_called_once()
+        programmer.load_bitstream.assert_called_once_with(
+            self.test_format_func(None, self.gateware_dir, self.build_name))
+
+
+class FakeGeneralSockWorkflow(general.GeneralSoCWorkflow):
+    """Subclasses GeneralSoCWorkflow to have all methods record call order."""
+    def __init__(self, load=False):
+        self.call_order = []
+        self.args = unittest.mock.MagicMock()
+        self.args.configure_mock(load=load)
+
+    def make_soc(self):
+        self.call_order.append('make_soc')
+        return unittest.mock.MagicMock()
+
+    def build_soc(self, soc):
+        self.call_order.append('build_soc')
+        return unittest.mock.MagicMock()
+
+    def load(self, soc, builder):
+        self.call_order.append('load')
+
+
+class TestGeneralSoCWorkflowRun(unittest.TestCase):
+    """TestCase for the `run` method of GeneralSoCWorkflow."""
+    def test_run_load_false(self):
+        workflow = FakeGeneralSockWorkflow(load=False)
+        workflow.run()
+        self.assertListEqual(workflow.call_order, ['make_soc', 'build_soc'])
+
+    def test_run_load_true(self):
+        workflow = FakeGeneralSockWorkflow(load=True)
+        workflow.run()
+        self.assertListEqual(workflow.call_order,
+                             ['make_soc', 'build_soc', 'load'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/soc/board_specific_workflows/workflow_args.py
+++ b/soc/board_specific_workflows/workflow_args.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from litex.build.xilinx.vivado import vivado_build_args
+from litex.soc.integration.builder import builder_args
+from litex.soc.integration.soc_core import soc_core_args
+from typing import List
+
+
+def parse_workflow_args(input: List[str] = None) -> argparse.Namespace:
+    """Parses command-line style flags for the workflow.
+
+    Args:
+        input: An optional list of strings in the style of sys.argv. Will
+          default to argparse's interpretation of sys.argv if omitted.
+    
+    Returns:
+        An argparse Namespace with the parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description='LiteX SoC')
+    parser.add_argument('--build', action='store_true', help='Build bitstream')
+    parser.add_argument('--load', action='store_true', help='Load bitstream')
+    parser.add_argument('--toolchain',
+                        help=('Specify toolchain for implementing '
+                              'gateware (\'vivado\' or \'symbiflow\')'))
+    builder_args(parser)
+    soc_core_args(parser)
+    vivado_build_args(parser)
+    parser.add_argument('--with-ethernet',
+                        action='store_true',
+                        help='Enable Ethernet support')
+    parser.add_argument('--with-etherbone',
+                        action='store_true',
+                        help='Enable Etherbone support')
+    parser.add_argument('--with-mapped-flash',
+                        action='store_true',
+                        help='Add litespi SPI flash')
+    parser.add_argument('--target',
+                        default='digilent_arty',
+                        help='Specify target board')
+    parser.set_defaults(csr_csv='csr.csv',
+                        uart_name='serial',
+                        uart_baudrate=921600,
+                        cpu_variant='full+cfu+debug',
+                        with_etherbone=False)
+
+    return parser.parse_args(input) if input else parser.parse_args()

--- a/soc/common_soc.py
+++ b/soc/common_soc.py
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,74 +13,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from migen import *
-
-from litex.build.xilinx.vivado import vivado_build_args, vivado_build_argdict, XilinxVivadoToolchain
-
-from litex.soc.integration.builder import *
-from litex.soc.integration.soc_core import soc_core_args, soc_core_argdict
-
 import argparse
-import os
+from board_specific_workflows import workflow_factory
+from litex.build.xilinx.vivado import vivado_build_args
+from litex.soc.integration.builder import builder_args
+from litex.soc.integration.soc_core import soc_core_args
 
-from importlib import import_module
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX SoC")
     parser.add_argument("--build", action="store_true", help="Build bitstream")
-    parser.add_argument("--load",  action="store_true", help="Load bitstream")
-    parser.add_argument("--toolchain", help="Specify toolchain for implementing gateware ('vivado' or 'symbiflow')")
+    parser.add_argument("--load", action="store_true", help="Load bitstream")
+    parser.add_argument(
+        "--toolchain",
+        help=
+        "Specify toolchain for implementing gateware ('vivado' or 'symbiflow')"
+    )
     builder_args(parser)
     soc_core_args(parser)
     vivado_build_args(parser)
-    parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
-    parser.add_argument("--with-mapped-flash", action="store_true", help="Add litespi SPI flash")
-    parser.add_argument("--target",  default="digilent_arty", help="Specify target board")
-    parser.set_defaults(
-            csr_csv='csr.csv',
-            uart_name='serial',
-            uart_baudrate=921600,
-            cpu_variant='full+cfu+debug',
-            with_etherbone=False)
+    parser.add_argument("--with-ethernet",
+                        action="store_true",
+                        help="Enable Ethernet support")
+    parser.add_argument("--with-etherbone",
+                        action="store_true",
+                        help="Enable Etherbone support")
+    parser.add_argument("--with-mapped-flash",
+                        action="store_true",
+                        help="Add litespi SPI flash")
+    parser.add_argument("--target",
+                        default="digilent_arty",
+                        help="Specify target board")
+    parser.set_defaults(csr_csv='csr.csv',
+                        uart_name='serial',
+                        uart_baudrate=921600,
+                        cpu_variant='full+cfu+debug',
+                        with_etherbone=False)
 
     args = parser.parse_args()
-
     assert not (args.with_ethernet and args.with_etherbone)
-    soc_kwargs = soc_core_argdict(args)
-    soc_kwargs["l2_size"] = 8 * 1024
 
-    try:
-        module = import_module("litex_boards.targets." + args.target)
-    except:
-        raise ModuleNotFoundError("could not load " + args.target + " target.")
-    
-    class CustomSoC(module.BaseSoC):
-        def __init__(self, **kwargs):
-            super().__init__(**kwargs)
+    soc_workflow = workflow_factory(args.target)(args)
+    soc_workflow.run()
 
-    kwargs = dict(
-        with_ethernet=args.with_ethernet, 
-        with_etherbone=args.with_etherbone,
-        with_mapped_flash=args.with_mapped_flash,
-        **soc_kwargs
-    )
-    
-    if args.toolchain:
-        kwargs["toolchain"] = args.toolchain
-    soc = CustomSoC(**kwargs)
-
-    builder = Builder(soc, **builder_argdict(args))
-
-    if isinstance(soc.platform.toolchain, XilinxVivadoToolchain):
-        builder.build(**vivado_build_argdict(args), run=args.build)
-    else:
-        builder.build(**{}, run=args.build)
-
-    if args.load:
-        prog = soc.platform.create_programmer()
-        bitstream_filename = os.path.join(builder.gateware_dir, soc.build_name + ".bit")
-        prog.load_bitstream(bitstream_filename)
 
 if __name__ == "__main__":
     main()

--- a/soc/common_soc.py
+++ b/soc/common_soc.py
@@ -13,48 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-from board_specific_workflows import workflow_factory
-from litex.build.xilinx.vivado import vivado_build_args
-from litex.soc.integration.builder import builder_args
-from litex.soc.integration.soc_core import soc_core_args
+import importlib
+from board_specific_workflows import workflow_factory, parse_workflow_args
+from litex.soc.integration import soc
+from typing import Callable
+
+def get_soc_constructor(target: str) -> Callable[..., soc.LiteXSoC]:
+    """Returns the constructor for the target SoC from litex-boards module."""
+    try:
+        module = importlib.import_module(f'litex_boards.targets.{target}')
+    except:
+        raise ModuleNotFoundError(f'Could not load {target} target.')
+    return module.BaseSoC
 
 
 def main():
-    parser = argparse.ArgumentParser(description="LiteX SoC")
-    parser.add_argument("--build", action="store_true", help="Build bitstream")
-    parser.add_argument("--load", action="store_true", help="Load bitstream")
-    parser.add_argument(
-        "--toolchain",
-        help=
-        "Specify toolchain for implementing gateware ('vivado' or 'symbiflow')"
-    )
-    builder_args(parser)
-    soc_core_args(parser)
-    vivado_build_args(parser)
-    parser.add_argument("--with-ethernet",
-                        action="store_true",
-                        help="Enable Ethernet support")
-    parser.add_argument("--with-etherbone",
-                        action="store_true",
-                        help="Enable Etherbone support")
-    parser.add_argument("--with-mapped-flash",
-                        action="store_true",
-                        help="Add litespi SPI flash")
-    parser.add_argument("--target",
-                        default="digilent_arty",
-                        help="Specify target board")
-    parser.set_defaults(csr_csv='csr.csv',
-                        uart_name='serial',
-                        uart_baudrate=921600,
-                        cpu_variant='full+cfu+debug',
-                        with_etherbone=False)
-
-    args = parser.parse_args()
+    args = parse_workflow_args()
     assert not (args.with_ethernet and args.with_etherbone)
 
-    soc_workflow = workflow_factory(args.target)(args)
-    soc_workflow.run()
+    soc_workflow = workflow_factory(args.target)
+    soc_workflow(args, get_soc_constructor(args.target)).run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR aims to make the CFU-Playground easier to operate with different FPGA boards.
- The `proj.mk` file checks for both a `/dev/ttyUSB` and `/dev/ttyACM` device.
- The default models included in the template are reduced back to just `pdti8`instead of the entire TFLM examples (for size and consistency reasons).
- The `common_soc.py` file has had its logic moved to a class that can be easily subclassed to provide board-specific tweaks if they need to exist. It has also been formatted to conform with the PEP 8 style guide.
