### PR TITLE
hps: make period constraint account for imprecise internal oscillator

### DIFF
--- a/soc/hps_platform.py
+++ b/soc/hps_platform.py
@@ -88,7 +88,11 @@ class _CRG(Module):
         # Clock from HFOSC
         self.submodules.sys_clk = sys_osc = NXOSCA()
         sys_osc.create_hf_clk(self.cd_sys, sys_clk_freq)
-        platform.add_period_constraint(self.cd_sys.clk, 1e9/sys_clk_freq)
+        # We make the period constraint 10% tighter than our actual system
+        # clock frequency, because the CrossLink-NX internal oscillator runs
+        # at ±10% of nominal frequency.
+        platform.add_period_constraint(self.cd_sys.clk,
+                                       1e9 / (sys_clk_freq * 1.1))
 
         # Power On Reset
         por_cycles = 4096


### PR DESCRIPTION
On the CrossLink-NX, the internal oscillator nominally runs at 450MHz but may
actually run at 405-495MHz. On my board it appears to run at ~488MHz.

If the oscillator produces a clock signal faster than we are expecting, it
means we actually have less time for signals to propagate. We need to specify a
period constraint accounting for the worst case (10% faster than nominal)
otherwise there is a chance that the design will meet timing, but when run on a
real device signals will not propagate fast enough resulting in strange
misbehaviour.