### PR TITLE
Use dcache metrics CSRs in benchmarks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/litex-hub/pythondata-software-compiler_rt.git
 [submodule "soc/deps/pythondata_cpu_vexriscv"]
 	path = third_party/python/pythondata_cpu_vexriscv
-	url = https://github.com/tcal-x/pythondata-cpu-vexriscv.git
+	url = https://github.com/antmicro/VexRiscv-verilog.git
 [submodule "third_party/python/nmigen"]
 	path = third_party/python/nmigen
 	url = https://github.com/nmigen/nmigen

--- a/common/src/metrics.c
+++ b/common/src/metrics.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 The CFU-Playground Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "metrics.h"
+
+#include <stdint.h>
+
+void get_csr_metrics(uint32_t *acc, uint32_t *refill, uint32_t *stall) {
+  __asm__ volatile ("csrr %0, %1" : "=r"(*acc) : "i"(CSR_ACC_COUNTER));
+  __asm__ volatile ("csrr %0, %1" : "=r"(*refill) : "i"(CSR_REFILL_COUNTER));
+  __asm__ volatile ("csrr %0, %1" : "=r"(*stall) : "i"(CSR_STALL_COUNTER));
+}

--- a/common/src/metrics.h
+++ b/common/src/metrics.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 The CFU-Playground Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef METRICS_H
+#define METRICS_H
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CSR_ACC_COUNTER     0xcc4
+#define CSR_REFILL_COUNTER  0xcc8
+#define CSR_STALL_COUNTER   0xccc
+
+void get_csr_metrics(uint32_t *acc, uint32_t *refill, uint32_t *stall);
+
+#define DCACHE_SETUP_METRICS \
+  uint32_t acc_pre, refill_pre, stall_pre, acc_cnt, refill_cnt, stall_cnt; \
+  get_csr_metrics(&acc_pre, &refill_pre, &stall_pre)
+
+#define DCACHE_PRINT_METRICS \
+  do { \
+    get_csr_metrics(&acc_cnt, &refill_cnt, &stall_cnt); \
+    printf("[Dcache accesses] Before: %lu, After: %lu, Diff: %lu\n", \
+           acc_pre, acc_cnt, acc_cnt - acc_pre); \
+    printf("[Dcache refills]  Before: %lu, After: %lu, Diff: %lu\n", \
+           refill_pre, refill_cnt, refill_cnt - refill_pre); \
+    printf("[Dcache stalls]   Before: %lu, After: %lu, Diff: %lu\n", \
+           stall_pre, stall_cnt, stall_cnt - stall_pre); \
+  } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // METRICS_H

--- a/common/src/models/magic_wand/magic_wand.c
+++ b/common/src/models/magic_wand/magic_wand.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/magic_wand/model_magic_wand.h"
 #include "tensorflow/lite/micro/examples/magic_wand/ring_micro_features_data.h"
 #include "tensorflow/lite/micro/examples/magic_wand/slope_micro_features_data.h"
@@ -39,7 +40,9 @@ static void magic_wand_init(void) { tflite_load_model(model_magic_wand); }
 // Run classification, after input has been loaded
 MagicWandResult magic_wand_classify() {
   printf("Running magic_wand\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   // Process the inference results.
   float* output = tflite_get_output_float();

--- a/common/src/models/micro_speech/micro_speech.c
+++ b/common/src/models/micro_speech/micro_speech.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/micro_speech/model_micro_speech.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/no_micro_features_data.h"
 #include "tensorflow/lite/micro/examples/micro_speech/micro_features/yes_micro_features_data.h"
@@ -39,7 +40,9 @@ static void micro_speech_init(void) { tflite_load_model(model_micro_speech); }
 // Run classification, after input has been loaded
 MicroSpeechResult micro_speech_classify() {
   printf("Running micro_speech\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   // Process the inference results.
   int8_t* output = tflite_get_output();

--- a/common/src/models/mlcommons_tiny_v01/anomd/anomd.c
+++ b/common/src/models/mlcommons_tiny_v01/anomd/anomd.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/mlcommons_tiny_v01/anomd/test_data/quant_anomaly_0.h"
 #include "models/mlcommons_tiny_v01/anomd/test_data/quant_anomaly_1.h"
 #include "models/mlcommons_tiny_v01/anomd/test_data/quant_anomaly_2.h"
@@ -53,7 +54,9 @@ uint32_t uint32_xor_reduction(int8_t* output, unsigned int length) {
 
 uint32_t anomd_classify() {
   printf("Running anomd\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   int8_t* output = tflite_get_output();
   return uint32_xor_reduction(output, 640);

--- a/common/src/models/mlcommons_tiny_v01/imgc/imgc.c
+++ b/common/src/models/mlcommons_tiny_v01/imgc/imgc.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/mlcommons_tiny_v01/imgc/test_data/quant_airplane.h"
 #include "models/mlcommons_tiny_v01/imgc/test_data/quant_bird.h"
 #include "models/mlcommons_tiny_v01/imgc/test_data/quant_car.h"
@@ -69,7 +70,9 @@ static void imgc_init(void) { tflite_load_model(pretrainedResnet_quant); }
 
 V01ImageClassificationResult image_classify() {
   printf("Running imgc\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   int8_t* output = tflite_get_output();
   return (V01ImageClassificationResult){

--- a/common/src/models/mlcommons_tiny_v01/kws/kws.c
+++ b/common/src/models/mlcommons_tiny_v01/kws/kws.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/mlcommons_tiny_v01/kws/test_data/down_0.h"
 #include "models/mlcommons_tiny_v01/kws/test_data/go_1.h"
 #include "models/mlcommons_tiny_v01/kws/test_data/left_2.h"
@@ -87,7 +88,9 @@ static void kws_init(void) { tflite_load_model(kws_ref_model); }
 
 V01KeywordSpottingResult kws_classify() {
   printf("Running kws\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   int8_t* output = tflite_get_output();
   return (V01KeywordSpottingResult){

--- a/common/src/models/mlcommons_tiny_v01/vww/vww.c
+++ b/common/src/models/mlcommons_tiny_v01/vww/vww.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/mlcommons_tiny_v01/vww/test_data/quant_test_no_0.h"
 #include "models/mlcommons_tiny_v01/vww/test_data/quant_test_no_1.h"
 #include "models/mlcommons_tiny_v01/vww/test_data/quant_test_yes_0.h"
@@ -42,7 +43,9 @@ static void vww_init(void) { tflite_load_model(vww_96_int8); }
 
 int32_t vww_classify() {
   printf("Running vww\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   int8_t* output = tflite_get_output();
   return (int32_t)output[1] - output[0];

--- a/common/src/models/mnv2/mnv2.c
+++ b/common/src/models/mnv2/mnv2.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/mnv2/input_00001_18027.h"
 #include "models/mnv2/input_00001_7281.h"
 #include "models/mnv2/input_00001_7425.h"
@@ -45,7 +46,9 @@ static void mnv2_init(void) { tflite_load_model(model_mobilenetv2_160_035); }
 // Run classification, after input has been loaded
 static int32_t mnv2_classify() {
   printf("Running mnv2\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   // Process the inference results.
   int8_t* output = tflite_get_output();

--- a/common/src/models/pdti8/pdti8.cc
+++ b/common/src/models/pdti8/pdti8.cc
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "menu.h"
+#include "metrics.h"
 #include "models/pdti8/model_pdti8.h"
 #include "tensorflow/lite/micro/examples/person_detection/no_person_image_data.h"
 #include "tensorflow/lite/micro/examples/person_detection/person_image_data.h"
@@ -31,7 +32,9 @@ static void pdti8_init(void) { tflite_load_model(model_pdti8); }
 // Run classification, after input has been loaded
 static int32_t pdti8_classify() {
   printf("Running pdti8\n");
+  DCACHE_SETUP_METRICS;
   tflite_classify();
+  DCACHE_PRINT_METRICS;
 
   // Process the inference results.
   int8_t* output = tflite_get_output();

--- a/proj/avg_pdti8/renode/litex-vexriscv-tflite.repl
+++ b/proj/avg_pdti8/renode/litex-vexriscv-tflite.repl
@@ -25,6 +25,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 uart: UART.LiteX_UART @ {

--- a/proj/example_cfu/renode/litex-vexriscv-tflite.repl
+++ b/proj/example_cfu/renode/litex-vexriscv-tflite.repl
@@ -25,6 +25,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 uart: UART.LiteX_UART @ {

--- a/proj/example_cfu_v/renode/litex-vexriscv-tflite.repl
+++ b/proj/example_cfu_v/renode/litex-vexriscv-tflite.repl
@@ -25,6 +25,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 uart: UART.LiteX_UART @ {

--- a/proj/mnv2_first/renode/hps.repl
+++ b/proj/mnv2_first/renode/hps.repl
@@ -20,6 +20,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }

--- a/proj/mnv2_first/renode/litex-vexriscv-tflite.repl
+++ b/proj/mnv2_first/renode/litex-vexriscv-tflite.repl
@@ -25,6 +25,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 uart: UART.LiteX_UART @ {

--- a/proj/proj_accel_1/renode/litex-vexriscv-tflite.repl
+++ b/proj/proj_accel_1/renode/litex-vexriscv-tflite.repl
@@ -25,6 +25,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 uart: UART.LiteX_UART @ {

--- a/proj/proj_template/renode/litex-vexriscv-tflite.repl
+++ b/proj/proj_template/renode/litex-vexriscv-tflite.repl
@@ -25,6 +25,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 uart: UART.LiteX_UART @ {

--- a/proj/proj_template_v/renode/hps.repl
+++ b/proj/proj_template_v/renode/hps.repl
@@ -20,6 +20,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }

--- a/proj/proj_template_v/renode/litex-vexriscv-tflite.repl
+++ b/proj/proj_template_v/renode/litex-vexriscv-tflite.repl
@@ -25,6 +25,9 @@ cpu: CPU.VexRiscv @ sysbus
         RegisterCustomCSR "BPM" 0xB13  User
         RegisterCustomCSR "BPM" 0xB14  User
         RegisterCustomCSR "BPM" 0xB15  User
+        RegisterCustomCSR "BPM" 0xCC4  User
+        RegisterCustomCSR "BPM" 0xCC8  User
+        RegisterCustomCSR "BPM" 0xCCC  User
 
 
 uart: UART.LiteX_UART @ {


### PR DESCRIPTION
This PR introduces displaying of additional dcache-related matrics from CPU's CSRs in benchmarks:

```
Running sequential stores benchmark
Hello, Store!
Val:28  Cycles: 11389084   Cycles/store: 10
[Dcache accesses] Before: 3223075888, After: 3224127310, Diff: 1051422
[Dcache refills]  Before: 952539, After: 952545, Diff: 6
[Dcache stalls]   Before: 89447457, After: 96635863, Diff: 7188406
```