### PR TITLE
hps: support for executing from LRAM

### DIFF
--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -56,27 +56,18 @@ class HpsSoC(LiteXSoC):
     # The start of the SPI Flash contains the FPGA gateware. Our ROM is after
     # that.
     rom_offset = 2*MB
-    rom_origin = spiflash_region.origin + rom_offset
-    rom_region = SoCRegion(rom_origin, spiflash_region.size - rom_offset,
-                           cached=True, linker=True)
     sram_origin = 0x40000000
-    sram_region = SoCRegion(sram_origin, RAM_SIZE, cached=True, linker=True)
     vexriscv_region = SoCRegion(origin=0xf00f0000, size=0x100)
 
-    # These variables are needed by builder.py. Normally they're defined by
-    # SoCCore, but we don't inherit from SoCCore.
-    integrated_rom_initialized = False
-    integrated_rom_size = rom_region.size
-
     mem_map = {
-        "rom":  rom_offset,
         "sram": sram_origin,
         "csr":  csr_origin,
     }
 
     cpu_type = "vexriscv"
 
-    def __init__(self, platform, debug, litespi_flash=False, variant=None, cpu_cfu=None):
+    def __init__(self, platform, debug, litespi_flash=False, variant=None,
+                 cpu_cfu=None, execute_from_lram=False):
         LiteXSoC.__init__(self,
                           platform=platform,
                           sys_clk_freq=platform.sys_clk_freq,
@@ -87,13 +78,22 @@ class HpsSoC(LiteXSoC):
         # Clock, Controller, CPU
         self.submodules.crg = platform.create_crg()
         self.add_controller("ctrl")
+        if execute_from_lram:
+            reset_address = 0x00000000
+        else:
+            reset_address = self.spiflash_region.origin + self.rom_offset
         self.add_cpu(self.cpu_type,
                      variant=variant,
-                     reset_address=self.rom_origin,
+                     reset_address=reset_address,
                      cfu=cpu_cfu)
 
         # RAM
-        self.setup_ram()
+        if execute_from_lram:
+            # Leave one LRAM free for ROM
+            ram_size = RAM_SIZE - 64*KB
+        else:
+            ram_size = RAM_SIZE
+        self.setup_ram(size=ram_size)
 
         # SPI Flash
         if litespi_flash:
@@ -101,8 +101,11 @@ class HpsSoC(LiteXSoC):
         else:
             self.setup_flash()
 
-        # ROM (part of SPI Flash)
-        self.bus.add_region("rom", self.rom_region)
+        # ROM (either part of SPI Flash, or embedded)
+        if execute_from_lram:
+            self.setup_rom_in_lram()
+        else:
+            self.setup_rom_in_flash()
 
         # "LEDS" - Just one LED on JTAG port
         self.submodules.leds = LedChaser(
@@ -130,11 +133,20 @@ class HpsSoC(LiteXSoC):
             self.platform.request("i2c", 1))
         self.csr.add("i2c")
 
-    def setup_ram(self):
-        self.submodules.lram = self.platform.create_ram(
-            32, self.sram_region.size)
-        self.bus.add_slave("sram_lram", self.lram.bus, self.sram_region)
-        self.bus.add_region("sram", self.sram_region)
+    def setup_ram(self, size):
+        region = SoCRegion(self.sram_origin, size, cached=True, linker=True)
+        self.submodules.lram = self.platform.create_ram(32, size)
+        self.bus.add_slave("sram_lram", self.lram.bus, region)
+        self.bus.add_region("sram", region)
+
+    def setup_rom_in_lram(self):
+        region = SoCRegion(self.cpu.reset_address, 64 * KB, mode='r',
+                           cached=True, linker=True)
+        self.submodules.rom = self.platform.create_ram(32, region.size)
+        self.bus.add_slave("rom_lram", self.rom.bus, region)
+        self.bus.add_region("rom", region)
+        self.integrated_rom_initialized = False
+        self.integrated_rom_size = region.size
 
     def setup_flash(self):
         self.submodules.spiflash = SpiFlash(self.platform.request("spiflash"), dummy=8,
@@ -151,6 +163,14 @@ class HpsSoC(LiteXSoC):
         self.csr.add("spiflash_phy")
         self.bus.add_slave(name="spiflash", slave=self.spiflash_mmap.bus, region=self.spiflash_region)
 
+    def setup_rom_in_flash(self):
+        region = SoCRegion(self.spiflash_region.origin + self.rom_offset,
+                           self.spiflash_region.size - self.rom_offset,
+                           mode='r', cached=True, linker=True)
+        self.bus.add_region("rom", region)
+        self.integrated_rom_initialized = False
+        self.integrated_rom_size = region.size
+
     def add_serial(self):
         self.add_uart("serial", baudrate=UART_SPEED)
 
@@ -159,7 +179,8 @@ class HpsSoC(LiteXSoC):
 
     # This method is defined on SoCCore and the builder assumes it exists.
     def initialize_rom(self, data):
-        pass
+        if hasattr(self, 'rom'):
+            self.rom.add_init(data)
 
     @property
     def mem_regions(self):
@@ -175,14 +196,6 @@ class HpsSoC(LiteXSoC):
             if region.linker:
                 region.type += "+linker"
         self.csr_regions = self.csr.regions
-
-        self.configure_rom()
-
-    def configure_rom(self):
-        # Have the builder build the BIOS, but not create an integrated ROM
-        # self.integrated_rom_size = 0
-        # self.integrated_rom_initialized = False
-        pass
 
 
 def hps_soc_args(parser: argparse.ArgumentParser):
@@ -218,13 +231,20 @@ def main():
                         help="Which synthesis to use, radiant/synplify (default), lse, or yosys")
     parser.add_argument("--litespi-flash", action="store_true", help="Use litespi flash")
     parser.add_argument("--cpu-cfu", default=None, help="Specify file containing CFU Verilog module")
+    parser.add_argument("--execute-from-lram", action="store_true",
+                        help="Make the CPU execute from integrated ROM stored in LRAM instead of flash")
 
     args = parser.parse_args()
 
 
     if args.cpu_cfu:
         variant = "full+cfu+debug" if args.debug else "full+cfu"
-        soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash, variant=variant, cpu_cfu=args.cpu_cfu)
+        soc = HpsSoC(Platform(args.toolchain),
+                     debug=args.debug,
+                     litespi_flash=args.litespi_flash,
+                     variant=variant,
+                     cpu_cfu=args.cpu_cfu,
+                     execute_from_lram=args.execute_from_lram)
         if args.slim_cpu:
             # override the actual source to get the Slim version
             #  -- this is a hack needed because litex/.../vexriscv/core.py doesn't know about the Slim versions.
@@ -233,8 +253,11 @@ def main():
             soc.cpu.use_external_variant(f"{vexriscv}/verilog/VexRiscv_{var}.v")
     else:
         variant = "full+debug" if args.debug else "full"
-        soc = HpsSoC(Platform(args.toolchain), debug=args.debug, litespi_flash=args.litespi_flash, variant=variant)
-        
+        soc = HpsSoC(Platform(args.toolchain),
+                     debug=args.debug,
+                     litespi_flash=args.litespi_flash,
+                     variant=variant,
+                     execute_from_lram=args.execute_from_lram)
 
     builder = create_builder(soc, args)
     builder_kwargs = {}


### PR DESCRIPTION
The motivation here is to have an easier way to debug and measure SPI flash performance (while the CPU is not executing directly from SPI flash).

This PR introduces the support only, but does not enable it. I am testing it with some local hacks like this:

```diff
diff --git a/common/src/main.c b/common/src/main.c
index 759bb22..fb1acea 100644
--- a/common/src/main.c
+++ b/common/src/main.c
@@ -47,7 +47,7 @@ static struct Menu MENU = {
         MENU_ITEM('2', "Functional CFU Tests", do_functional_cfu_tests),
         MENU_ITEM('3', "Project menu", do_proj_menu),
         MENU_ITEM('4', "Performance Counter Tests", perf_test_menu),
-        MENU_ITEM('5', "TFLite Unit Tests", tflite_do_tests),
+        //MENU_ITEM('5', "TFLite Unit Tests", tflite_do_tests),
         MENU_ITEM('6', "Benchmarks", do_benchmarks_menu),
         MENU_ITEM('7', "Util Tests", do_util_tests_menu),
 #ifdef PLATFORM_sim
diff --git a/proj/proj.mk b/proj/proj.mk
index 585b0b8..90c8fa5 100644
--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -250,8 +250,8 @@ ifneq 'sim' '$(PLATFORM)'
 prog: $(CFU_VERILOG)
        $(SOC_MK) prog

-bitstream: $(CFU_VERILOG)
-       $(SOC_MK) bitstream
+bitstream: $(CFU_VERILOG) $(SOFTWARE_BIN)
+       $(SOC_MK) bitstream SOFTWARE_BIN=$(SOFTWARE_BIN)

 ifeq '1' '$(words $(TTY))'
 run: $(SOFTWARE_BIN)
diff --git a/proj/proj_template/Makefile b/proj/proj_template/Makefile
index 6290188..fc5e25a 100644
--- a/proj/proj_template/Makefile
+++ b/proj/proj_template/Makefile
@@ -26,7 +26,7 @@ DEFINES += NDEBUG
 #DEFINES += NPROFILE

 # Uncomment to include pdti8 in built binary
-DEFINES += INCLUDE_MODEL_PDTI8
+#DEFINES += INCLUDE_MODEL_PDTI8

 # Uncomment to include micro_speech in built binary
 #DEFINES += INCLUDE_MODEL_MICRO_SPEECH
diff --git a/soc/hps.mk b/soc/hps.mk
index 12ba323..d72d9e1 100644
--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -34,7 +34,7 @@ endif

 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
 CFU_V:=     $(PROJ_DIR)/cfu.v
-CFU_ARGS:=  --cpu-cfu $(CFU_V)
+#CFU_ARGS:=  --cpu-cfu $(CFU_V)

 SOC_NAME:=  hps.$(PROJ)
 OUT_DIR:=   build/$(SOC_NAME)
@@ -60,6 +60,8 @@ ifdef SLIM_CPU
 LITEX_ARGS += --slim_cpu
 endif

+LITEX_ARGS += --execute-from-lram --nextpnr-timingstrict
+
 PYRUN:=     $(CFU_ROOT)/scripts/pyrun
 HPS_RUN:=   MAKEFLAGS=-j8 $(PYRUN) ./hps_soc.py $(LITEX_ARGS)

@@ -90,7 +92,7 @@ endif
 prog: $(BITSTREAM) check-timing
        @echo Loading bitstream and bios onto HPS
        $(CFU_ROOT)/scripts/hps_prog $(BITSTREAM) bitstream
-       $(CFU_ROOT)/scripts/hps_prog $(BIOS_BIN) program
+       #$(CFU_ROOT)/scripts/hps_prog $(BIOS_BIN) program

 clean:
        @echo Removing $(OUT_DIR)
@@ -102,6 +104,6 @@ $(CFU_V):
 $(BIOS_BIN): $(CFU_V)
        $(HPS_RUN)

-$(BITSTREAM): $(CFU_V)
+$(BITSTREAM): $(CFU_V) $(SOFTWARE_BIN)
        @echo Building bitstream for Arty. CFU option: $(CFU_ARGS)
-       $(HPS_RUN) --build
+       $(HPS_RUN) --integrated-rom-init $(SOFTWARE_BIN) --build

```

Note that to make the CFU Playground application fit inside 64KB I had to compile out all of Tensorflow, and also to have nextpnr meet timing I had to turn off CFU support. All of which really defeats the purpose of CFU Playground. But it can be hacked locally for working on SPI flash.