### PR TITLE
Enable running benchmarks on CrossLink NX Evaluation board

### DIFF
--- a/common/_common_soc/lattice_crosslink_nx_evn/ld/linker.ld
+++ b/common/_common_soc/lattice_crosslink_nx_evn/ld/linker.ld
@@ -1,0 +1,58 @@
+INCLUDE output_format.ld
+ENTRY(_start)
+
+__DYNAMIC = 0;
+
+INCLUDE regions.ld
+
+
+SECTIONS
+{
+	.text :
+	{
+		_ftext = .;
+		*(.text.start)
+		*(.text .stub .text.* .gnu.linkonce.t.*)
+		_etext = .;
+	} > spiflash
+
+	.rodata :
+	{
+		. = ALIGN(8);
+		_frodata = .;
+		*(.rodata .rodata.* .gnu.linkonce.r.*)
+		*(.rodata1)
+		*(.srodata .srodata.*)
+		. = ALIGN(8);
+		_erodata = .;
+	} > spiflash
+
+	.data : AT (ADDR(.rodata) + SIZEOF (.rodata))
+	{
+		. = ALIGN(8);
+		_fdata = .;
+		*(.data .data.* .gnu.linkonce.d.*)
+		*(.data1)
+		*(.ramtext .ramtext.*)
+		_gp = ALIGN(16);
+		*(.sdata .sdata.* .gnu.linkonce.s.* .sdata2 .sdata2.*)
+		_edata = ALIGN(16); /* Make sure _edata is >= _gp. */
+	} > sram
+
+	.bss : AT (ADDR(.data) + SIZEOF (.data))
+	{
+		. = ALIGN(16);
+		_fbss = .;
+		*(.dynsbss)
+		*(.sbss .sbss.* .gnu.linkonce.sb.*)
+		*(.scommon)
+		*(.dynbss)
+		*(.bss .bss.* .gnu.linkonce.b.*)
+		*(COMMON)
+		. = ALIGN(8);
+		_ebss = .;
+		_end = .;
+	} > sram
+}
+
+PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);

--- a/common/src/benchmarks.c
+++ b/common/src/benchmarks.c
@@ -23,8 +23,12 @@
 #include "perf.h"
 #include "generated/mem.h"
 
-#ifdef PLATFORM_hps
+#if defined(PLATFORM_hps)
 #define BUF_SIZE (32 * 1024)  // must be at least 1024
+#elif defined(MAIN_RAM_SIZE) && (MAIN_RAM_SIZE < 256 * 1024)
+#define BUF_SIZE (2 * 1024)  // must be at least 1024
+#elif defined(SRAM_SIZE) && (SRAM_SIZE < 256 * 1024)
+#define BUF_SIZE (2 * 1024)  // must be at least 1024
 #else
 #define BUF_SIZE (128 * 1024)  // must be at least 1024
 #endif

--- a/soc/board_specific_workflows/__init__.py
+++ b/soc/board_specific_workflows/__init__.py
@@ -16,6 +16,7 @@
 from digilent_arty import DigilentArtySoCWorkflow
 from general import GeneralSoCWorkflow
 from icebreaker import IcebreakerSoCWorkflow
+from lattice_crosslink_nx_evn import LatticeCrossLinkNXEVNSoCWorkflow
 from workflow_args import parse_workflow_args
 
 
@@ -32,6 +33,7 @@ def workflow_factory(target: str) -> GeneralSoCWorkflow:
     return {
         'digilent_arty': DigilentArtySoCWorkflow,
         '1bitsquared_icebreaker': IcebreakerSoCWorkflow,
+        'lattice_crosslink_nx_evn': LatticeCrossLinkNXEVNSoCWorkflow,
     }.get(target, GeneralSoCWorkflow)
 
 
@@ -39,6 +41,7 @@ __all__ = [
     'DigilentArtySoCWorkflow',
     'GeneralSoCWorkflow',
     'IcebreakerSoCWorkflow',
+    'LatticeCrossLinkNXEVNSoCWorkflow',
     'parse_workflow_args'
     'workflow_factory',
 ]

--- a/soc/board_specific_workflows/lattice_crosslink_nx_evn.py
+++ b/soc/board_specific_workflows/lattice_crosslink_nx_evn.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import general
+from litex.soc.integration import builder
+from litex.soc.integration import soc as litex_soc
+from litex.soc.integration.soc import SoCRegion
+
+from litespi.modules import MX25L12835F
+from litespi.opcodes import SpiNorFlashOpCodes as Codes
+from litespi.phy.generic import LiteSPIPHY
+from litespi import LiteSPI
+
+KB = 1024
+MB = 1024 * KB
+
+class LatticeCrossLinkNXEVNSoCWorkflow(general.GeneralSoCWorkflow):
+    def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
+        soc = super().make_soc(
+            integrated_rom_size=0,
+            integrated_rom_init=[],
+            **kwargs
+        )
+
+        soc.spiflash_region = SoCRegion(0x00000000, 16 * MB, mode="r", cached=True, linker=True)
+        soc.submodules.spiflash_phy = LiteSPIPHY(
+            soc.platform.request("spiflash"),
+            MX25L12835F(Codes.READ_1_1_1),
+            default_divisor=1)
+        soc.submodules.spiflash_mmap = LiteSPI(phy=soc.spiflash_phy,
+            clk_freq        = soc.sys_clk_freq,
+            mmap_endianness = soc.cpu.endianness)
+
+        soc.csr.add("spiflash_mmap")
+        soc.csr.add("spiflash_phy")
+        soc.bus.add_slave(name="spiflash", slave=soc.spiflash_mmap.bus, region=soc.spiflash_region)
+        soc.bus.add_region("rom", soc.spiflash_region)
+
+        return soc
+
+    def build_soc(self, soc: litex_soc.LiteXSoC, **kwargs) -> builder.Builder:
+        return super().build_soc(soc, **kwargs)


### PR DESCRIPTION
Currently it is not possible to run benchmarks (or any other piece of software) from this repository on CNX EVN board. This PR adds a new platform (based on existing `hps` platform), that enables that by using the on-board SPI flash chip.
Building gateware/software (in project directory, e.g. `proj/proj_template`):
```
UART_SPEED=115200 PLATFORM=cnx_evn TARGET=lattice_crosslink_nx_evn make bitstream software
```
Flashing/uploading using `ecpprog` (in project directory, e.g. `proj/proj_template`):
```
ecpprog -so 2097152 build/software.bin
ecpprog -S ../../soc/build/cnx_evn.proj_template/gateware/cnx_evn_platform.bit
```