### PR TITLE
Automate installing Renode

### DIFF
--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -104,6 +104,7 @@ COMMON_DIR         := $(CFU_ROOT)/common
 COMMON_FILES	   := $(shell find $(COMMON_DIR) -type f)
 MLCOMMONS_SRC_DIR  := $(CFU_ROOT)/third_party/mlcommons
 SAXON_SRC_DIR      := $(CFU_ROOT)/third_party/SaxonSoc
+RENODE_DIR         := $(CFU_ROOT)/third_party/renode
 SRC_DIR            := $(abspath $(PROJ_DIR)/src)
 
 TFLM_SRC_DIR       := $(CFU_ROOT)/third_party/tflite-micro
@@ -162,7 +163,7 @@ endif
 renode: $(SOFTWARE_ELF) 
 	@echo Running interactively under renode
 	$(COPY) $(SOFTWARE_ELF) $(PROJ_DIR)/renode/
-	pushd $(PROJ_DIR)/renode/ && renode -e "s @litex-vexriscv-tflite.resc" && popd
+	pushd $(PROJ_DIR)/renode/ && $(RENODE_DIR)/renode -e "s @litex-vexriscv-tflite.resc" && popd
 
 .PHONY: clean
 clean:

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,14 +1,14 @@
 FROM debian:testing
 
 ENV RISCV_DIR=/toolchain/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin
-ENV PATH="/renode:${RISCV_DIR}:${PATH}"
+ENV PATH="/third_party/renode:${RISCV_DIR}:${PATH}"
 ARG WORKDIR=/CFU-Playground
 
 RUN apt update -y && apt install -y wget git python3-pip make gcc openocd yosys expect ccache verilator libevent-dev libjson-c-dev libusb-1.0-0-dev libftdi1-dev vim && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /toolchain && cd /toolchain && wget -nv https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz && tar xf riscv64*tar.gz && rm riscv64*tar.gz
 
-RUN mkdir /renode && wget -nv https://dl.antmicro.com/projects/renode/builds/renode-latest.linux-portable.tar.gz && tar xf renode-*tar.gz -C /renode --strip-components=1 && rm renode-*tar.gz && python3 -m pip install -r /renode/tests/requirements.txt
+RUN mkdir /third_party/renode && wget -nv https://dl.antmicro.com/projects/renode/builds/renode-latest.linux-portable.tar.gz && tar xf renode-*tar.gz -C /third_party/renode --strip-components=1 && rm renode-*tar.gz && python3 -m pip install -r /third_party/renode/tests/requirements.txt
 
 RUN git clone https://github.com/google/CFU-Playground ${WORKDIR}
 WORKDIR ${WORKDIR}

--- a/scripts/setup
+++ b/scripts/setup
@@ -2,7 +2,7 @@
 set -e
 git submodule update --init
 
-
+CFU_ROOT="$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))"
 
 # Verify dependencies that can be installed with apt (if available)
 missing=()
@@ -63,9 +63,30 @@ fi
 # Build flashrom after installing dependencies
 echo "BUILDING FLASHROM"
 (
-  cd third_party/flashrom
+  cd ${CFU_ROOT}/third_party/flashrom
   make -j4 CONFIG_ENABLE_LIBPCI_PROGRAMMERS=no
 )
+
+RENODE_VERSION="1.12.0+20210705gita5fe374a"
+RENODE_VERSION_SPLIT=${RENODE_VERSION//"+"/ }
+RENODE_VERSION_SPLIT=${RENODE_VERSION_SPLIT//"git"/ }
+IFS=' ' read -r RENODE_VERSION_NO x RENODE_VERSION_SHA <<<"$RENODE_VERSION_SPLIT"
+RENODE_DIR=${CFU_ROOT}/third_party/renode
+# Get Renode if not installed
+if [ ! -e "${RENODE_DIR}/renode" ]; then
+    wget "https://dl.antmicro.com/projects/renode/builds/renode-${RENODE_VERSION}.linux-portable.tar.gz"
+    mkdir ${RENODE_DIR}
+    tar xf  renode-*.linux-portable.tar.gz -C ${RENODE_DIR} --strip-components=1
+    rm renode-${RENODE_VERSION}.linux-portable.tar.gz
+    echo "To use Renode from any location add it to system path:"
+    echo "export PATH=${RENODE_DIR}:\$PATH\""
+    echo ""
+    echo "If you wish to run automated Robot tests using Renode, run:"
+    echo "python3 -m pip install -r ${RENODE_DIR}/tests/requirements.txt"
+    echo ""
+elif ! ${RENODE_DIR}/renode --version | grep "${RENODE_VERSION_NO}.*${RENODE_VERSION_SHA}" >/dev/null; then
+    echo "Warning: Your Renode version does not match the required one (${RENODE_VERSION})"
+fi
 
 # Check GCC
 if ! which riscv64-unknown-elf-gcc >/dev/null; then


### PR DESCRIPTION
This is a solution for #4.

`scripts/setup` will download and extract Renode portable to `third_party/renode`. Each time the script is called it checks if Renode exists and checks its version so it will download Renode or throw a warning about wrong version.
All calls of Renode in scripts will now use `third_party/renode/renode` to avoid problems with different versions or with lack of Renode itself.