### PR TITLE
Support boards without mcycle write support in tflite.cc

### DIFF
--- a/common/src/tflite.cc
+++ b/common/src/tflite.cc
@@ -14,6 +14,8 @@
 
 #include "tflite.h"
 
+#include <cstdint>
+
 #include "perf.h"
 #include "playground_util/random.h"
 #include "proj_tflite.h"
@@ -238,16 +240,18 @@ void tflite_classify() {
   // Run the model on this input and make sure it succeeds.
   profiler->ClearEvents();
   perf_reset_all_counters();
-  perf_set_mcycle(0);
+
+  // perf_set_mcycle is a no-op for some boards, start and end used instead.
+  uint32_t start = perf_get_mcycle();
   if (kTfLiteOk != interpreter->Invoke()) {
     puts("Invoke failed.");
   }
-  unsigned int cyc = perf_get_mcycle();
+  uint32_t end = perf_get_mcycle();
 #ifndef NPROFILE
   profiler->Log();
 #endif
   perf_print_all_counters();
-  perf_print_value(cyc);
+  perf_print_value(end - start); // Possible overflow is intentional here.
   printf(" cycles total\n");
 }
 


### PR DESCRIPTION
Boards using tiny versions of VexRiscv (like ice40up5k derived boards) don't have the ability to write to the `mcycle` csr. This means incorrect cycle counts are printed in `tflite.cc` because `perf_set_mcycle(0);` is a no-op for these boards. This PR adds support for boards that can't write to `mcycle` by not calling `perf_set_mcycle` in `tflite.cc`.