### PR TITLE
Add third_party/renode to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ csr.csv
 *.code-workspace
 .vscode/*
 
+# Renode setup
+third_party/renode
+
 # Robot test results
 log.html
 report.html


### PR DESCRIPTION
Currently `scripts/setup` installs Renode in `third_party/renode`. Git doesn't ignore this directory however. This PR adds `third_party/renode` to our `.gitignore` so that it doesn't show up in "Untracked files:"