### PR TITLE
Update bit widths of the `cmd_payload_function_id` port in Verilog CFUs.

### DIFF
--- a/proj/example_cfu_v/cfu.v
+++ b/proj/example_cfu_v/cfu.v
@@ -17,7 +17,7 @@
 module Cfu (
   input               cmd_valid,
   output              cmd_ready,
-  input      [2:0]    cmd_payload_function_id,
+  input      [9:0]    cmd_payload_function_id,
   input      [31:0]   cmd_payload_inputs_0,
   input      [31:0]   cmd_payload_inputs_1,
   output              rsp_valid,

--- a/proj/proj_template_v/cfu.v
+++ b/proj/proj_template_v/cfu.v
@@ -17,7 +17,7 @@
 module Cfu (
   input               cmd_valid,
   output              cmd_ready,
-  input      [2:0]    cmd_payload_function_id,
+  input      [9:0]    cmd_payload_function_id,
   input      [31:0]   cmd_payload_inputs_0,
   input      [31:0]   cmd_payload_inputs_1,
   output              rsp_valid,


### PR DESCRIPTION
In `proj/proj_template_v` and `proj/example_cfu_v`, an older CFU module signature was used where `cmd_payload_function_id` was only 3 bits wide. The Verilog works fine from a functional standpoint, but as example projects it's probably best to extend the bit width to 10 bits so both funct7 and funct3 are visible.