### PR TITLE
report "ticks" to the tflite-micro profiler as cycles / 1024

### DIFF
--- a/common/src/tensorflow/lite/micro/micro_time.cc
+++ b/common/src/tensorflow/lite/micro/micro_time.cc
@@ -15,24 +15,36 @@ limitations under the License.
 
 #include "tensorflow/lite/micro/micro_time.h"
 
-static inline unsigned get_mcycle() {
-  unsigned result;
-  asm volatile("csrr %0, mcycle" : "=r"(result));
-  return result;
-}
-
-static inline void set_mcycle(unsigned cyc) {
-  asm volatile("csrw mcycle, %0" ::"r"(cyc));
+// Read the cycle counter.
+//
+// The value of the counter is stored across two 32-bit registers: `mcycle` and
+// `mcycleh`. This function is guaranteed to return a valid 64-bit cycle
+// counter value, even if `mcycle` overflows before reading `mcycleh`.
+//
+// Adapted from: The RISC-V Instruction Set Manual, Volume I: Unprivileged ISA
+// V20191213, pp. 61.
+static inline uint64_t get_mcycle() {
+  uint32_t cycle_low = 0;
+  uint32_t cycle_high = 0;
+  uint32_t cycle_high_2 = 0;
+  asm volatile(
+      "read%=:"
+      "  csrr %0, mcycleh;"     // Read `mcycleh`.
+      "  csrr %1, mcycle;"      // Read `mcycle`.
+      "  csrr %2, mcycleh;"     // Read `mcycleh` again.
+      "  bne  %0, %2, read%=;"  // Try again if `mcycle` overflowed before
+                                // reading `mcycleh`.
+      : "+r"(cycle_high), "=r"(cycle_low), "+r"(cycle_high_2)
+      :);
+  return (uint64_t) cycle_high << 32 | cycle_low;
 }
 
 namespace tflite {
 
 // Assumes 100 MHz
-int32_t ticks_per_second() { return 100000000; }
+int32_t ticks_per_second() { return 100000000 / 1024; }
 
-// WARNING (from tcal) -- very susceptible to wrap-around (happens every 40s)
-//   --> need to get mcycleh, and shift/divide down
-//
-int32_t GetCurrentTimeTicks() { return (int32_t)get_mcycle(); }
+// 1 "tick" = 1024 clock cycles
+int32_t GetCurrentTimeTicks() { return get_mcycle() >> 10; }
 
 }  // namespace tflite


### PR DESCRIPTION
In tflite-micro the profiling code uses int32_t to represent ticks,
presumably because it was intended to be fed from a relatively low
precision timer source and not the raw system clock cycle counter.

The HPS model (unaccelerated) has one layer which takes more than 2**31
cycles and so it was being displayed in the profile as taking negative
time.

Report "ticks" as clock cycles / 1024, instead of raw cycles. The choice
of divisor is arbitrary but 1024 can be implemented in a single shift
instruction and still makes the numbers easy to interpret (humans just
have to think of it as "kilocycles").

Also, for completeness sake, use the full 64-bit cycle counter in the
unlikely event that a single profiling event takes more than 2**32
cycles. This implementation of get_mcycle() is taken from OpenTitan:
https://github.com/lowRISC/opentitan/blob/d9dc048680d89bd630ffae673103509e28017709/sw/device/lib/runtime/ibex.h#L28
based on the recommendation in the RISC-V Instruction Set Manual.