### PR TITLE
Update Python CFU interface

### DIFF
--- a/proj/avg_pdti8/cfu.py
+++ b/proj/avg_pdti8/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import Mux, Signal, signed
-from nmigen_cfu import InstructionBase, SimpleElaboratable, TestBase, Cfu, CfuTestBase
+from nmigen_cfu import InstructionBase, SimpleElaboratable, TestBase, SimpleCfu, CfuTestBase
 import unittest
 
 
@@ -350,7 +350,7 @@ class SaturatingRoundingDoubleHighMulInstruction(InstructionBase):
         ]
 
 
-class AvgPdti8Cfu(Cfu):
+class AvgPdti8Cfu(SimpleCfu):
     def __init__(self):
         self.write = WriteInstruction()
         self.read = ReadInstruction()

--- a/proj/avg_pdti8/util.py
+++ b/proj/avg_pdti8/util.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from nmigen import Mux, Signal, signed
-from nmigen_cfu import InstructionBase, SimpleElaboratable, TestBase, Cfu, CfuTestBase
-from nmigen.sim import Delay, Settle
+from nmigen_cfu import SimpleElaboratable, TestBase
+from nmigen.sim import Settle
 import unittest
 
 

--- a/proj/example_cfu/cfu.py
+++ b/proj/example_cfu/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, Cfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
 
 import unittest
 
@@ -122,7 +122,7 @@ class ReverseBytesInstruction(InstructionBase):
 
     def elab(self, m):
         for n in range(4):
-            m.d.comb += self.output.word_select(3-n, 8).eq(
+            m.d.comb += self.output.word_select(3 - n, 8).eq(
                 self.in0.word_select(n, 8))
         m.d.comb += self.done.eq(1)
 
@@ -148,7 +148,7 @@ class ReverseBitsInstruction(InstructionBase):
 
     def elab(self, m):
         for n in range(32):
-            m.d.comb += self.output[31-n].eq(self.in0[n])
+            m.d.comb += self.output[31 - n].eq(self.in0[n])
         m.d.comb += self.done.eq(1)
 
 
@@ -193,7 +193,7 @@ class FibInstruction2Test(InstructionTestBase):
 
 
 def make_cfu():
-    return Cfu({
+    return SimpleCfu({
         0: SumBytesInstruction(),
         1: ReverseBytesInstruction(),
         2: ReverseBitsInstruction(),
@@ -208,12 +208,12 @@ class CfuTest(CfuTestBase):
     def test(self):
         DATA = [
             ((0, 0x01020304, 0x0a0b0c0d), 56),
-            ((1, 0x01020304, 0),          0x04030201),
-            ((2, 0x01020304, 0),          0x20c04080),
-            ((3, 0x05,       0),          5),
-            ((3, 0x06,       0),          8),
-            ((3, 46,         0),          1836311903),  # Max input
-            ((3, 47,         0),          0),           # Input too large
+            ((1, 0x01020304, 0), 0x04030201),
+            ((2, 0x01020304, 0), 0x20c04080),
+            ((3, 0x05, 0), 5),
+            ((3, 0x06, 0), 8),
+            ((3, 46, 0), 1836311903),  # Max input
+            ((3, 47, 0), 0),           # Input too large
         ]
         return self.run_ops(DATA)
 

--- a/proj/example_cfu/cfu.py
+++ b/proj/example_cfu/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, simple_cfu, CfuTestBase
 
 import unittest
 
@@ -193,7 +193,7 @@ class FibInstruction2Test(InstructionTestBase):
 
 
 def make_cfu():
-    return SimpleCfu({
+    return simple_cfu({
         0: SumBytesInstruction(),
         1: ReverseBytesInstruction(),
         2: ReverseBitsInstruction(),

--- a/proj/hps_accel/cfu.py
+++ b/proj/hps_accel/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, simple_cfu, CfuTestBase
 import unittest
 
 # See proj_example for further example instructions
@@ -45,7 +45,7 @@ class TemplateInstructionTest(InstructionTestBase):
 
 
 def make_cfu():
-    return SimpleCfu({
+    return simple_cfu({
         # Add instructions here...
         0: TemplateInstruction(),
     })

--- a/proj/hps_accel/cfu.py
+++ b/proj/hps_accel/cfu.py
@@ -14,14 +14,16 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, Cfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
 import unittest
 
 # See proj_example for further example instructions
 
+
 class TemplateInstruction(InstructionBase):
     """Template instruction
     """
+
     def elab(self, m):
         with m.If(self.start):
             m.d.sync += self.output.eq(self.in0 + self.in1)
@@ -43,7 +45,7 @@ class TemplateInstructionTest(InstructionTestBase):
 
 
 def make_cfu():
-    return Cfu({
+    return SimpleCfu({
         # Add instructions here...
         0: TemplateInstruction(),
     })

--- a/proj/mnv2_first/gateware/mnv2_cfu.py
+++ b/proj/mnv2_first/gateware/mnv2_cfu.py
@@ -15,7 +15,7 @@
 
 from nmigen import Signal
 from nmigen.lib.fifo import SyncFIFOBuffered
-from nmigen_cfu import SimpleCfu, DualPortMemory, is_pysim_run
+from nmigen_cfu import simple_cfu, DualPortMemory, is_pysim_run
 
 from . import config
 from .macc import Accumulator, ByteToWordShifter, Madd4Pipeline
@@ -232,6 +232,6 @@ class Mnv2RegisterInstruction(RegisterFileInstruction):
         ]
 
 def make_cfu():
-    return SimpleCfu({
+    return simple_cfu({
             0: Mnv2RegisterInstruction(),
         })

--- a/proj/mnv2_first/gateware/mnv2_cfu.py
+++ b/proj/mnv2_first/gateware/mnv2_cfu.py
@@ -15,7 +15,7 @@
 
 from nmigen import Signal
 from nmigen.lib.fifo import SyncFIFOBuffered
-from nmigen_cfu import Cfu, DualPortMemory, is_pysim_run
+from nmigen_cfu import SimpleCfu, DualPortMemory, is_pysim_run
 
 from . import config
 from .macc import Accumulator, ByteToWordShifter, Madd4Pipeline
@@ -230,7 +230,7 @@ class Mnv2RegisterInstruction(RegisterFileInstruction):
         ]
 
 
-class Mnv2Cfu(Cfu):
+class Mnv2Cfu(SimpleCfu):
     """Simple CFU for Mnv2.
 
     Most functionality is provided through a single set of registers.

--- a/proj/mnv2_first/gateware/mnv2_cfu.py
+++ b/proj/mnv2_first/gateware/mnv2_cfu.py
@@ -87,7 +87,8 @@ class Mnv2RegisterInstruction(RegisterFileInstruction):
         return dps, fvset.count, fvset.updated
 
     def _make_input_store(self, m, name, restart_signal, input_depth_words):
-        m.submodules[f'{name}'] = ins = InputStore(config.MAX_PER_PIXEL_INPUT_WORDS)
+        m.submodules[f'{name}'] = ins = InputStore(
+            config.MAX_PER_PIXEL_INPUT_WORDS)
         m.submodules[f'{name}_set'] = insset = InputStoreSetter()
         m.d.comb += insset.connect(ins)
         self.register_xetter(25, insset)
@@ -158,7 +159,8 @@ class Mnv2RegisterInstruction(RegisterFileInstruction):
         fv_mems, fv_count, fv_updated = self._make_filter_value_store(
             m, 24, 'store_filter_values', restart)
 
-        m.submodules['fvf'] = fvf = FilterValueFetcher(config.FILTER_DATA_MEM_DEPTH)
+        m.submodules['fvf'] = fvf = FilterValueFetcher(
+            config.FILTER_DATA_MEM_DEPTH)
         m.d.comb += fvf.connect_read_ports(fv_mems)
         m.d.comb += [
             # fetcher only works for multiples of 4, and only for multiples of
@@ -229,21 +231,7 @@ class Mnv2RegisterInstruction(RegisterFileInstruction):
             oq_enable.eq(seq.out_word_done),
         ]
 
-
-class Mnv2Cfu(SimpleCfu):
-    """Simple CFU for Mnv2.
-
-    Most functionality is provided through a single set of registers.
-    """
-
-    def __init__(self):
-        super().__init__({
+def make_cfu():
+    return SimpleCfu({
             0: Mnv2RegisterInstruction(),
         })
-
-    def elab(self, m):
-        super().elab(m)
-
-
-def make_cfu():
-    return Mnv2Cfu()

--- a/proj/proj_accel_1/cfu.py
+++ b/proj/proj_accel_1/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import SimpleElaboratable, InstructionBase, TestBase, InstructionTestBase, Cfu, CfuTestBase
+from nmigen_cfu import InstructionBase, TestBase, SimpleCfu, CfuTestBase
 
 import unittest
 
@@ -330,7 +330,7 @@ class MultiplyAccumulateFourInstructionTest(TestBase):
         self.run_sim(process, True)
 
 
-class ProjAccel1Cfu(Cfu):
+class ProjAccel1Cfu(SimpleCfu):
     def __init__(self):
         self.dc = DoubleCompareInstruction()
         self.store = StoreInstruction()

--- a/proj/proj_template/cfu.py
+++ b/proj/proj_template/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, simple_cfu, CfuTestBase
 import unittest
 
 # See proj_example for further example instructions
@@ -45,7 +45,7 @@ class TemplateInstructionTest(InstructionTestBase):
 
 
 def make_cfu():
-    return SimpleCfu({
+    return simple_cfu({
         # Add instructions here...
         0: TemplateInstruction(),
     })

--- a/proj/proj_template/cfu.py
+++ b/proj/proj_template/cfu.py
@@ -14,14 +14,16 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, Cfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
 import unittest
 
 # See proj_example for further example instructions
 
+
 class TemplateInstruction(InstructionBase):
     """Template instruction
     """
+
     def elab(self, m):
         with m.If(self.start):
             m.d.sync += self.output.eq(self.in0 + self.in1)
@@ -43,7 +45,7 @@ class TemplateInstructionTest(InstructionTestBase):
 
 
 def make_cfu():
-    return Cfu({
+    return SimpleCfu({
         # Add instructions here...
         0: TemplateInstruction(),
     })

--- a/proj/tail_rom/cfu.py
+++ b/proj/tail_rom/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, simple_cfu, CfuTestBase
 import unittest
 
 # See proj_example for further example instructions
@@ -43,7 +43,7 @@ class TemplateInstructionTest(InstructionTestBase):
 
 
 def make_cfu():
-    return SimpleCfu({
+    return simple_cfu({
         # Add instructions here...
         0: TemplateInstruction(),
     })

--- a/proj/tail_rom/cfu.py
+++ b/proj/tail_rom/cfu.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from nmigen import *
-from nmigen_cfu import InstructionBase, InstructionTestBase, Cfu, CfuTestBase
+from nmigen_cfu import InstructionBase, InstructionTestBase, SimpleCfu, CfuTestBase
 import unittest
 
 # See proj_example for further example instructions
@@ -43,7 +43,7 @@ class TemplateInstructionTest(InstructionTestBase):
 
 
 def make_cfu():
-    return Cfu({
+    return SimpleCfu({
         # Add instructions here...
         0: TemplateInstruction(),
     })

--- a/python/nmigen_cfu/cfu.py
+++ b/python/nmigen_cfu/cfu.py
@@ -192,7 +192,7 @@ class Cfu(SimpleElaboratable):
             self.reset
         ]
 
-    def elab_instructions(self, m: Module) -> dict[int, InstructionBase]:
+    def elab_instructions(self, m):
         """Make instructions this CFU will execute.
 
         Returns:
@@ -200,7 +200,7 @@ class Cfu(SimpleElaboratable):
         """
         return dict()
 
-    def __build_instructions(self, m: Module) -> list[InstructionBase]:
+    def __build_instructions(self, m):
         """Builds the list of eight instructions"""
         instruction_dict = self.elab_instructions(m)
 
@@ -358,7 +358,7 @@ def simple_cfu(instructions):
     saved_instructions = instructions.copy()
 
     class _ASimpleCfu(Cfu):
-        def elab_instructions(self, m: Module) -> dict[int, InstructionBase]:
+        def elab_instructions(self, m):
 
             for i, instruction in saved_instructions.items():
                 m.submodules[f"fn{i}"] = instruction

--- a/python/nmigen_cfu/test_cfu.py
+++ b/python/nmigen_cfu/test_cfu.py
@@ -22,7 +22,7 @@ import math
 from nmigen import Signal
 from nmigen.sim import Delay
 
-from .cfu import SimpleCfu, InstructionBase, InstructionTestBase
+from .cfu import simple_cfu, InstructionBase, InstructionTestBase
 from .util import TestBase
 
 
@@ -135,7 +135,7 @@ class _SyncAddInstruction(InstructionBase):
 
 class _CfuTest(TestBase):
     def create_dut(self):
-        return SimpleCfu({
+        return simple_cfu({
             0: _SumBytesInstruction(),
             1: _ReverseBytesInstruction(),
             2: _ReverseBitsInstruction(),

--- a/python/nmigen_cfu/test_cfu.py
+++ b/python/nmigen_cfu/test_cfu.py
@@ -22,7 +22,7 @@ import math
 from nmigen import Signal
 from nmigen.sim import Delay
 
-from .cfu import Cfu, InstructionBase, InstructionTestBase
+from .cfu import SimpleCfu, InstructionBase, InstructionTestBase
 from .util import TestBase
 
 
@@ -135,7 +135,7 @@ class _SyncAddInstruction(InstructionBase):
 
 class _CfuTest(TestBase):
     def create_dut(self):
-        return Cfu({
+        return SimpleCfu({
             0: _SumBytesInstruction(),
             1: _ReverseBytesInstruction(),
             2: _ReverseBitsInstruction(),


### PR DESCRIPTION
Brings API into line with other nmigen code by discouraging passing of modules between components.

A simple API for making CFUs with independent instructions is preserved via the simple_cfu() function, but CFUs with interdependent instructions should use a subclass of the CFU class, and instantiate their instructions in the elab_instructions() method. avg_pdti8/cfu.py has an example of a Cfu subclass.