### PR TITLE
Add Workflow for the Fomu.

### DIFF
--- a/common/_common_soc/kosagi_fomu/ld/linker.ld
+++ b/common/_common_soc/kosagi_fomu/ld/linker.ld
@@ -1,0 +1,64 @@
+INCLUDE output_format.ld
+ENTRY(_start)
+
+__DYNAMIC = 0;
+
+INCLUDE regions.ld
+
+
+SECTIONS
+{
+    /* .data first to take precedence for explicit code we want in SRAM. */
+    .data : AT (_erodata) /* Loaded in spiflash but runtime copied to SRAM. */
+    {
+        . = ALIGN(4);
+        _fdata = .;  /* Start of .data in SRAM, copied to in crt0. */
+
+        *(.ramtext .ramtext*)
+
+        /* 
+         * We need to ensure .data starts at > 0, otherwise a pointer to the
+         * first element of .data will be mistaken for a nullptr.
+         */
+        . = MAX(., 0x4); 
+
+        *(.data .data*)
+        *(.sdata .sdata*)
+
+        . = ALIGN(4);
+        _edata = .;  /* End of .data in SRAM, end of copying in crt0. */
+    } > sram
+
+    /* Start .text at 4 byte boundary after gateware. */
+    _ftext = (ORIGIN(spiflash) + 0x60000 + 3) & ~3;
+    .text _ftext :
+    {
+        *(.text.start)
+        *(.text .text*)
+    } > spiflash
+
+    .rodata :
+    {
+        *(.rodata .rodata*)
+        *(.srodata .srodata*)
+
+        . = ALIGN(4);
+        _erodata = .;  /* Start of .data in spiflash, copied from in crt0. */
+    } > spiflash
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _fbss = .;  /* Start of zeroing in crt0. */
+
+        *(.bss .bss*)
+        *(.sbss .sbss*)
+
+        *(COMMON)
+        
+        . = ALIGN(4);
+        _ebss = .;  /* End of zeroing in crt0. */
+    } > sram
+}
+
+PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -51,6 +51,7 @@ export PROJ       := $(lastword $(subst /, ,${CURDIR}))
 export CFU_ROOT   := $(realpath $(CURDIR)/../..)
 export PLATFORM   ?= common_soc
 export TARGET     ?= digilent_arty
+export TTY        ?= $(or $(wildcard /dev/ttyUSB?), $(wildcard /dev/ttyACM?))
 
 RUN_MENU_ITEMS    ?=1 1 1
 TEST_MENU_ITEMS   ?=5
@@ -76,7 +77,6 @@ export DEFINES    += PLATFORM_$(PLATFORM)
 export DEFINES    += PLATFORM=$(PLATFORM)
 
 SHELL           := /bin/bash
-TTY             := $(or $(wildcard /dev/ttyUSB?), $(wildcard /dev/ttyACM?))
 CRC             := 
 #CRC             := --no-crc
 
@@ -297,6 +297,7 @@ else
 $(RUN_TARGETS):
 	@echo Error: could not determine unique TTY
 	@echo TTY possibilities: $(TTY)
+	@echo Optionally, manually specify TTY= on the command line
 endif
 else
 # $(PLATFORM) == 'sim'

--- a/soc/board_specific_workflows/__init__.py
+++ b/soc/board_specific_workflows/__init__.py
@@ -16,6 +16,7 @@
 from digilent_arty import DigilentArtySoCWorkflow
 from general import GeneralSoCWorkflow
 from icebreaker import IcebreakerSoCWorkflow
+from kosagi_fomu import KosagiFomuSoCWorkflow
 from lattice_crosslink_nx_evn import LatticeCrossLinkNXEVNSoCWorkflow
 from workflow_args import parse_workflow_args
 
@@ -33,6 +34,7 @@ def workflow_factory(target: str) -> GeneralSoCWorkflow:
     return {
         'digilent_arty': DigilentArtySoCWorkflow,
         '1bitsquared_icebreaker': IcebreakerSoCWorkflow,
+        'kosagi_fomu': KosagiFomuSoCWorkflow,
         'lattice_crosslink_nx_evn': LatticeCrossLinkNXEVNSoCWorkflow,
     }.get(target, GeneralSoCWorkflow)
 
@@ -41,6 +43,7 @@ __all__ = [
     'DigilentArtySoCWorkflow',
     'GeneralSoCWorkflow',
     'IcebreakerSoCWorkflow',
+    'KosagiFomuSoCWorkflow',
     'LatticeCrossLinkNXEVNSoCWorkflow',
     'parse_workflow_args'
     'workflow_factory',

--- a/soc/board_specific_workflows/kosagi_fomu.py
+++ b/soc/board_specific_workflows/kosagi_fomu.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import ice40up5k
+import io
+from litex.build import dfu, generic_programmer
+from litex.soc.integration import soc as litex_soc
+from litex.soc.integration import builder
+from typing import BinaryIO, Callable, Collection
+
+
+def create_image(gateware: BinaryIO, software: BinaryIO,
+                 software_offset: int) -> Collection[bytes]:
+    """Creates an image file that combines gateware and software.
+
+    Args:
+        gateware: BinaryIO object that contains the gateware bitstream.
+        software: BinaryIO object that contains the software binary.
+        software_offset: Offset from the start of the output image
+            that the software begins at.
+    
+    Returns:
+        A Collection of bytes that contains the gateware followed by the
+        software beginning at `software_offset` bytes from the start of the
+        output.
+    
+    Raises:
+        ValueError: `gateware` is too large and will be partially overwritten
+            by `software`.
+    """
+    with io.BytesIO() as output_image:
+        bitstream = gateware.read()
+        if len(bitstream) > software_offset:
+            raise ValueError(('Gateware file overflowed by '
+                              f'{len(bitstream) - software_offset} bytes.'))
+        output_image.write(bitstream)
+        output_image.write(
+            bytes(0xff for _ in range(software_offset - len(bitstream))))
+        output_image.write(software.read())
+        return bytes(output_image.getvalue())
+
+
+def fomu_image_builder(gateware_filename: str, software_filename: str,
+                       image_filename: str, offset: int) -> None:
+    """Creates and writes an image file for the Fomu.
+    
+    This is a thin wrapper around create_image that is useful for testing.
+
+    Args:
+        gateware_filename: The file that contains the gateware.
+        software_filename: The file that contains the software.
+        image_filename: The file that will hold the output image.
+        offset: Offset from the start of the output image
+            that the software begins at.
+    
+    Raises:
+        ValueError: `gateware` is too large and will be partially overwritten
+            by `software`.
+    """
+    with open(gateware_filename, 'rb') as gateware, \
+         open(software_filename, 'rb') as software, \
+         open(image_filename, 'wb') as image:
+        image.write(create_image(gateware, software, offset))
+
+
+class KosagiFomuSoCWorkflow(ice40up5k.Ice40UP5KWorkflow):
+    """Workflow for the Fomu board."""
+    def __init__(self,
+                 args: argparse.Namespace,
+                 soc_constructor: Callable[..., litex_soc.LiteXSoC],
+                 builder_constructor: Callable[..., builder.Builder] = None,
+                 warn: bool = True) -> None:
+        super().__init__(args,
+                         soc_constructor,
+                         builder_constructor=builder_constructor,
+                         warn=warn)
+        # Fomu requires larger flash offset -- first 0x40000 bytes are reserved
+        self.bios_flash_offset = 0x60000
+
+    def load(self,
+             soc: litex_soc.LiteXSoC,
+             soc_builder: builder.Builder,
+             programmer: generic_programmer.GenericProgrammer = None) -> None:
+        """For the Fomu, this is a no-op.
+
+           Because the Fomu requires a power cycle between flashes, loading the
+           bios is skipped to simplify loading software.
+        """
+
+    def software_load(self,
+                      filename: str,
+                      programmer: generic_programmer.GenericProgrammer = None,
+                      image_builder=fomu_image_builder) -> None:
+        """Loads software for the Fomu.
+        
+        Args:
+            filename: The software binary.
+            programmer: The programmer used to flash the board. If none
+                specified, DFUProg will be used.
+            image_builder: The function used to create the image file. Used for
+                dependency injection.
+        """
+        gateware_filename = (f'{self.args.output_dir}'
+                             '/gateware/kosagi_fomu_pvt.bin')
+        image_filename = f'{self.args.output_dir}/image.bin'
+
+        image_builder(gateware_filename=gateware_filename,
+                      software_filename=filename,
+                      image_filename=image_filename,
+                      offset=self.bios_flash_offset - 0x40000)
+
+        prog = programmer or dfu.DFUProg(pid='5bf0', vid='1209')
+        prog.load_bitstream(image_filename)

--- a/soc/board_specific_workflows/test_kosagi_fomu.py
+++ b/soc/board_specific_workflows/test_kosagi_fomu.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import kosagi_fomu
+import unittest
+from litex.build import dfu
+from litex.soc.integration import builder
+from unittest import mock
+
+
+class CreateImageTest(unittest.TestCase):
+    """TestCase for the create_image function."""
+    def test_simple_image(self):
+        gateware = io.BytesIO(b'gateware')
+        software = io.BytesIO(b'software')
+        offset = 0x100
+        output = kosagi_fomu.create_image(gateware, software, offset)
+        self.assertEqual(output[:len(gateware.getvalue())],
+                         gateware.getvalue())
+        self.assertEqual(output[offset:offset + len(software.getvalue())],
+                         software.getvalue())
+    
+    def test_max_gateware(self):
+        gateware = io.BytesIO(b'gateware')
+        software = io.BytesIO(b'software')
+        offset = len(gateware.getvalue())
+        output = kosagi_fomu.create_image(gateware, software, offset)
+        self.assertEqual(output, gateware.getvalue() + software.getvalue())
+
+    def test_gateware_too_big(self):
+        with self.assertRaises(ValueError):
+            gateware = io.BytesIO(b'gateware')
+            software = io.BytesIO(b'software')
+            offset = 0x1
+            kosagi_fomu.create_image(gateware, software, offset)
+
+
+class KosagiFomuSoCWorkflowWorkflowTest(unittest.TestCase):
+    """TestCase for the KosagiFomuSoCWorkflow."""
+    def simple_init(self):
+        return kosagi_fomu.KosagiFomuSoCWorkflow(mock.MagicMock(),
+                                                 mock.MagicMock,
+                                                 mock.create_autospec(
+                                                     builder.Builder),
+                                                 warn=False)
+
+    def test_software_load(self):
+        workflow = self.simple_init()
+
+        workflow.args.output_dir = 'test_dir'
+        test_filename = 'test_filename'
+        mock_image_builder = mock.create_autospec(
+            kosagi_fomu.fomu_image_builder)
+        mock_programmer = mock.create_autospec(dfu.DFUProg, instance=True)
+
+        workflow.software_load(test_filename, mock_programmer,
+                               mock_image_builder)
+
+        call_kwargs = mock_image_builder.call_args.kwargs
+        self.assertEqual(call_kwargs['gateware_filename'],
+                         'test_dir/gateware/kosagi_fomu_pvt.bin')
+        self.assertEqual(call_kwargs['software_filename'], 'test_filename')
+        self.assertEqual(call_kwargs['offset'],
+                         workflow.bios_flash_offset - 0x40000)
+
+        mock_programmer.load_bitstream.assert_called_once_with(
+            call_kwargs['image_filename'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds an explicit workflow for the Fomu board.

The majority of this process is similar to PR #129 which adds an explicit workflow to the iCEbreaker, the main differences being the bios isn't loaded on the Fomu and the Fomu requires a `TTY=` flag to be set on the command line.