### PR TITLE
tflite.cc: Remove unused code

### DIFF
--- a/common/src/tflite.cc
+++ b/common/src/tflite.cc
@@ -129,22 +129,6 @@ static void tflite_init() {
   //
   static tflite::AllOpsResolver resolver;
   op_resolver = &resolver;
-  // // NOLINTNEXTLINE(runtime-global-variables)
-  // static tflite::MicroMutableOpResolver<8> micro_op_resolver;
-  // micro_op_resolver.AddAveragePool2D();
-  // micro_op_resolver.AddConv2D();
-  // micro_op_resolver.AddDepthwiseConv2D();
-  // micro_op_resolver.AddReshape();
-  // micro_op_resolver.AddSoftmax();
-
-  // // needed for jon's model conv2d/relu, maxpool2d, reshape, fullyconnected,
-  // logistic micro_op_resolver.AddMaxPool2D();
-  // micro_op_resolver.AddFullyConnected();
-  // micro_op_resolver.AddLogistic();
-
-  // // needed for MODEL=magic_wand_full_i8
-  // // micro_op_resolver.AddQuantize();
-  // op_resolver = &micro_op_resolver;
 
   // profiler
   static ProgressProfiler micro_profiler;


### PR DESCRIPTION
Removes commented-out OpResolver code. Since we are committed to using
the AllOpResolver, we do not need to add individual ops.