### PR TITLE
Fix `make renode` recipe

### DIFF
--- a/.github/includes/actions/run-in-renode/action.yml
+++ b/.github/includes/actions/run-in-renode/action.yml
@@ -40,7 +40,7 @@ runs:
       run:
         pwd && source environment && cd proj/${{ inputs.proj-name }} &&
         make ${{ inputs.build-params }} PLATFORM=${{ inputs.platform }} TARGET=${{ matrix.target }} -j8 software &&
-        make renode-scripts TARGET=${{ matrix.target }}
+        make renode-scripts ${{ inputs.build-params }} PLATFORM=${{ inputs.platform }} TARGET=${{ matrix.target }}
 
     - name: Run tests
       timeout-minutes: 5

--- a/.github/workflows/test-projects.yml
+++ b/.github/workflows/test-projects.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Setup environment
       run: bash scripts/setup -ci
     - name: Build sample & generate Renode scripts
-      run: pwd && source environment && cd proj/proj_template && make  PLATFORM=common_soc TARGET=${{ matrix.target }} -j8 software && make renode-scripts TARGET=${{ matrix.target }}
+      run: pwd && source environment && cd proj/proj_template && make  PLATFORM=common_soc TARGET=${{ matrix.target }} -j8 software && make renode-scripts  PLATFORM=common_soc TARGET=${{ matrix.target }}
     - name: Run tests
       timeout-minutes: 5
       uses: antmicro/renode-actions/test-in-renode@main
@@ -122,7 +122,7 @@ jobs:
     - name: Setup environment
       run: bash scripts/setup -ci
     - name: Build sample & generate Renode scripts
-      run: pwd && source environment && cd proj/mnv2_first && make SW_ONLY=1 PLATFORM=common_soc TARGET=${{ matrix.target }} -j8 software && make renode-scripts TARGET=${{ matrix.target }}
+      run: pwd && source environment && cd proj/mnv2_first && make SW_ONLY=1 PLATFORM=common_soc TARGET=${{ matrix.target }} -j8 software && make renode-scripts SW_ONLY=1 PLATFORM=common_soc TARGET=${{ matrix.target }}
     - name: Run tests
       timeout-minutes: 5
       uses: antmicro/renode-actions/test-in-renode@main
@@ -166,7 +166,7 @@ jobs:
     - name: Setup environment
       run: bash scripts/setup -ci
     - name: Build sample & generate Renode scripts
-      run: pwd && source environment && cd proj/mnv2_first && make SW_ONLY=1 PLATFORM=hps TARGET=${{ matrix.target }} -j8 software && make renode-scripts TARGET=${{ matrix.target }}
+      run: pwd && source environment && cd proj/mnv2_first && make SW_ONLY=1 PLATFORM=hps TARGET=${{ matrix.target }} -j8 software && make renode-scripts SW_ONLY=1 PLATFORM=hps TARGET=${{ matrix.target }}
     - name: Run tests
       timeout-minutes: 5
       uses: antmicro/renode-actions/test-in-renode@main

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -162,20 +162,16 @@ endif
 TARGET_REPL := $(BUILD_DIR)/renode/$(TARGET)_generated.repl
 
 .PHONY:	renode 
-renode: $(SOFTWARE_ELF) renode-scripts
+renode: renode-scripts
 	@echo Running interactively under renode
 	$(COPY) $(SOFTWARE_ELF) $(PROJ_DIR)/renode/
 	pushd $(PROJ_DIR)/build/renode/ && $(RENODE_DIR)/renode -e "s @$(TARGET).resc" && popd
 
 .PHONY: renode-scripts
-renode-scripts:
-ifneq ("$(wildcard $(SOC_BUILD_DIR)/csr.csv)","")
+renode-scripts: $(SOFTWARE_ELF)
 	@mkdir -p $(BUILD_DIR)/renode
 	$(CFU_ROOT)/scripts/generate_renode_scripts.py $(SOC_BUILD_DIR)/csr.csv $(TARGET) $(BUILD_DIR)/renode/ --repl $(TARGET_REPL)
 	@echo Generating Renode scripts finished
-else
-	@echo $(SOC_BUILD_DIR)/csr.csv not found
-endif
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This fixes #175.
The `renode-scripts` recipe always requires `csr.csv`, so its prerequisite is now `$(SOFTWARE_ELF)` and we can assume that `csr.csv` will be present after a successful prerequisite run.
