### PR TITLE
hps_accel: use accelerated multiply_accumulate() in convolution

### DIFF
--- a/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv.h
+++ b/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv.h
@@ -70,6 +70,7 @@ inline void ConvPerChannel(
 #ifdef ACCEL_CONV
   // Use specialised implementation if possible.
   if (params.padding_type == PaddingType::kValid &&
+      (input_depth == 1 || input_depth % 4 == 0) &&
       filter_width == 4 &&
       filter_height == 4 &&
       dilation_width_factor == 1 &&

--- a/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv.h
+++ b/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv.h
@@ -69,7 +69,8 @@ inline void ConvPerChannel(
 
 #ifdef ACCEL_CONV
   // Use specialised implementation if possible.
-  if (filter_width == 4 &&
+  if (params.padding_type == PaddingType::kValid &&
+      filter_width == 4 &&
       filter_height == 4 &&
       dilation_width_factor == 1 &&
       dilation_height_factor == 1) {


### PR DESCRIPTION
@alanvgreen do you think it's okay to limit this to padding=valid for now and ignore padding=same? I see there was a discussion where we settled on padding=valid as a temporary solution, but I guess we will need padding=same support sooner or later?

Also worth noting that this causes the model evaluation to fail because the CFU ops are not fully implemented. If you switch it to software CFU implementation (not turned on by default currently) the golden tests pass but this is a severe speed regression. Should we fix that before merging this PR?