### PR TITLE
Add script to do local install of PrjOxide toolchain.

### DIFF
--- a/environment
+++ b/environment
@@ -29,3 +29,11 @@ for i in "${CFU_ROOT}/third_party/python"/* "${CFU_ROOT}/python/"* "${CFU_ROOT}/
 done
 export PYTHONPATH
 
+
+if [ -d "${CFU_ROOT}/third_party/usr/local/bin" ] ; then
+    if [ ! `echo ${PATH} | grep third_party/usr/local/bin` ] ; then
+        PATH="${CFU_ROOT}/third_party/usr/local/bin:${PATH}"
+        echo UPDATED PATH: ${PATH}
+        export PATH
+    fi
+fi

--- a/environment
+++ b/environment
@@ -29,11 +29,10 @@ for i in "${CFU_ROOT}/third_party/python"/* "${CFU_ROOT}/python/"* "${CFU_ROOT}/
 done
 export PYTHONPATH
 
-
-if [ -d "${CFU_ROOT}/third_party/usr/local/bin" ] ; then
-    if [ ! `echo ${PATH} | grep third_party/usr/local/bin` ] ; then
-        PATH="${CFU_ROOT}/third_party/usr/local/bin:${PATH}"
-        echo UPDATED PATH: ${PATH}
-        export PATH
+pathadd() {
+    if [ -d "$1" ] && [[ ":$PATH:" != *":$1:"* ]]; then
+        export PATH="${1}${PATH:+":$PATH"}"
+        echo "Updated PATH: ${PATH}"
     fi
-fi
+}
+pathadd "${CFU_ROOT}/third_party/usr/local/bin"

--- a/scripts/install_oxide
+++ b/scripts/install_oxide
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+CFU_ROOT="$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))"
+
+
+UPDATE=
+if [ $# -gt 1 ] ; then
+  echo "Usage: install_oxide [update]"
+  exit 1
+fi
+if [ $# -gt 0 ] ; then
+  if [ $1 == "update" ] ; then
+    UPDATE=1
+  else
+    echo "Usage: install_oxide [update]"
+    exit 1
+  fi
+fi
+
+
+
+if [ -z "$UPDATE" ] ; then
+
+  echo -n "Install Project Oxide open source toolchain? (ctrl-C to exit)" >&2
+  echo
+  echo "CLONING REPOSITORIES"
+  cd ${CFU_ROOT}/third_party
+  if [ ! -d yosys ]; then
+    git clone --recursive https://github.com/YosysHQ/yosys.git
+    git -C yosys pull --ff-only origin master
+    git -C yosys submodule update
+  fi
+  if [ ! -d prjoxide ]; then
+    git clone --recursive https://github.com/gatecat/prjoxide.git
+    git -C prjoxide pull --ff-only origin master
+    git -C prjoxide submodule update
+  fi
+  if [ ! -d nextpnr ]; then
+    git clone --recursive https://github.com/YosysHQ/nextpnr.git
+    git -C nextpnr pull --ff-only origin master
+    git -C nextpnr submodule update
+  fi
+
+else
+
+  echo
+  echo "UPDATING REPOSITORIES"
+  cd ${CFU_ROOT}/third_party
+  git -C yosys pull --ff-only origin master
+  git -C yosys submodule update
+  git -C prjoxide pull --ff-only origin master
+  git -C prjoxide submodule update
+  git -C nextpnr pull --ff-only origin master
+  git -C nextpnr submodule update
+
+fi
+
+DESTDIR=${CFU_ROOT}/third_party
+
+echo
+echo "BUILDING YOSYS"
+cd ${CFU_ROOT}/third_party/yosys
+make -j
+make DESTDIR=${DESTDIR} install
+
+echo
+echo "BUILDING PRJOXIDE"
+OXIDE_INSTALL_PREFIX=${CFU_ROOT}/third_party/.cargo
+mkdir -p ${OXIDE_INSTALL_PREFIX}
+cd ${CFU_ROOT}/third_party/prjoxide/libprjoxide
+cargo install --path prjoxide --root ${OXIDE_INSTALL_PREFIX}
+cp ${CFU_ROOT}/third_party/.cargo/bin/prjoxide ${DESTDIR}/usr/local/bin
+
+echo
+echo "BUILDING NEXTPNR-NEXUS"
+cd ${CFU_ROOT}/third_party/nextpnr
+cmake -DARCH=nexus -DOXIDE_INSTALL_PREFIX=${OXIDE_INSTALL_PREFIX} .
+make -j
+make DESTDIR=${DESTDIR} install
+

--- a/scripts/install_oxide
+++ b/scripts/install_oxide
@@ -22,7 +22,6 @@ fi
 
 if [ -z "$UPDATE" ] ; then
 
-  echo -n "Install Project Oxide open source toolchain? (ctrl-C to exit)" >&2
   echo
   echo "CLONING REPOSITORIES"
   cd ${CFU_ROOT}/third_party

--- a/soc/common_soc.mk
+++ b/soc/common_soc.mk
@@ -43,6 +43,13 @@ OUT_DIR:=   build/$(SOC_NAME)
 UART_ARGS=  --uart-baudrate $(UART_SPEED)
 LITEX_ARGS= --output-dir $(OUT_DIR) --csr-csv $(OUT_DIR)/csr.csv $(CFU_ARGS) $(UART_ARGS) $(TARGET_ARGS)
 
+ifdef USE_OXIDE
+LITEX_ARGS += --toolchain oxide --yosys-abc9
+endif
+ifdef USE_YOSYS
+LITEX_ARGS += --synth-mode yosys
+endif
+
 ifdef USE_SYMBIFLOW
 LITEX_ARGS += --toolchain symbiflow
 else 

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -51,12 +51,7 @@ endif
 
 #==== Specify complete open source toolchain: Yosys + NextPnR
 ifdef USE_OXIDE
-LITEX_ARGS += --toolchain oxide
-ifndef IGNORE_TIMING
-LITEX_ARGS += --nextpnr-timingstrict
-endif
-else ifdef USE_SYMBIFLOW
-LITEX_ARGS += --toolchain oxide
+LITEX_ARGS += --toolchain oxide --yosys-abc9
 ifndef IGNORE_TIMING
 LITEX_ARGS += --nextpnr-timingstrict
 endif


### PR DESCRIPTION
Usage:
```
./scripts/install_oxide           # initial install
./scripts/install_oxide update    # pull any changes and rebuild and reinstall
```
Initial installation takes about 10 minutes on my gLinux laptop.

The three required repositories are cloned, not added as submodules, under third_party/.

All generated executables are also located under third_party, installed under third_party/usr/local/bin/.  The `environment` script has been updated to use them.

Once the installation is done, you can use them as follows:
```
make PLATFORM=hps USE_OXIDE=1 prog    # use full yosys/nextpnr-nexus flow
make PLATFORM=hps USE_YOSYS=1 prog    # use yosys + radiant pnr
```





Signed-off-by: Tim Callahan <tcal@google.com>