### PR TITLE
Add CFU definition to `index.rst`.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,8 +10,15 @@ The CFU Playground is a collection of software, gateware and hardware configured
 make it easy to:
 
 * Run ML models
+
 * Benchmark and profile performance
+
 * Make incremental improvements
+
+  * In software by modifying source code
+
+  * In gateware with a Custom Function Unit (CFU)
+
 * Measure the results of changes
 
 ML acceleration on microcontroller-class hardware is a new area, and one that, due

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,13 @@
 The CFU Playground: Accelerate ML models on FPGAs
 =================================================
 
-The CFU Playground is a collection of software, gateware and hardware configured to
-make it easy to:
+"CFU" stands for Custom Function Unit: accelerator hardware that is tightly
+coupled into the pipeline of a CPU core, to add new custom function
+instructions that complement the CPU’s standard functions (such as
+arithmetic/logic operations).
+
+The CFU Playground is a collection of software, gateware and hardware
+configured to make it easy to:
 
 * Run ML models
 
@@ -17,7 +22,7 @@ make it easy to:
 
   * In software by modifying source code
 
-  * In gateware with a Custom Function Unit (CFU)
+  * In gateware with a CFU
 
 * Measure the results of changes
 


### PR DESCRIPTION
This PR adds a definition for CFU to `index.rst` in our docs so new readers don't need to guess what it means. The extra whitespace is added as a `.rst` formatting quirk to allow nested unordered lists without making the previous list element bold.

The new modified section is shown below:
![image](https://user-images.githubusercontent.com/65669542/127372613-12adb965-e56b-4fc4-86ba-948d3578f6fb.png)

Resolves #201 