### PR TITLE
add flush_cpu_dcache(), flush_l2_cache() to sync cache content

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -27,6 +27,7 @@ BUILD_DIR      := $(abspath .)
 LIBBASE_DIR    := $(SOC_SOFTWARE_DIR)/libbase
 LITEX_DIR      := $(CFU_ROOT)/third_party/python/litex/litex
 VEX_SRC_DIR    := $(LITEX_DIR)/soc/cores/cpu/vexriscv
+LITEX_HW_DIR   := $(LITEX_DIR)/soc/software/include
 PYRUN          := $(CFU_ROOT)/scripts/pyrun
 FIX_CFU_DIS    := $(PYRUN) $(CFU_ROOT)/scripts/fix_cfu_dis.py
 XXD            := $(PYRUN) $(CFU_ROOT)/scripts/xxd.py
@@ -53,6 +54,8 @@ SHARED_FLAGS := \
 	-I$(SRC_DIR)/third_party/ruy \
 	-I$(SRC_DIR)/third_party/kissfft \
 	-I$(SOC_SOFTWARE_DIR)/include \
+    -I$(LITEX_HW_DIR) \
+    -I$(VEX_SRC_DIR) \
 	-ffunction-sections \
 	-fdata-sections \
 	-fno-common \
@@ -75,12 +78,11 @@ SHARED_FLAGS := \
 	-g \
 	-O3 \
 	-fno-builtin 
-	
+
 CFLAGS  := \
 	$(SHARED_FLAGS)\
 	-I$(LITEX_DIR)/soc/software/include/base \
-	-I$(LITEX_DIR)/soc/software/include \
-	-I$(VEX_SRC_DIR) 
+	-I$(LITEX_DIR)/soc/software/include
 
 CXXFLAGS   := \
 	$(SHARED_FLAGS) \

--- a/common/src/fb_util.c
+++ b/common/src/fb_util.c
@@ -22,6 +22,7 @@
 #include <generated/csr.h>
 #include <generated/soc.h>
 #include <generated/mem.h>
+#include <system.h>
 
 #include "menu.h"
 #include "perf.h"
@@ -71,7 +72,6 @@ static void dotfont_init()
 
     dotfont_initilized = 1;
 }
-
 
 void fb_init()
 {
@@ -439,12 +439,16 @@ void fb_fill(void)
 {
     fb_fill_rect(0, 0, 320, 240, 0x00FF0000);
     fb_fill_rect(320, 240, 320, 240, 0x00FF0000);
+    flush_cpu_dcache();
+    flush_l2_cache();
 }
 
 void fb_draw(void)
 {
     fb_draw_rect(0, 0, 320, 240, 0x00FFFF00);
     fb_draw_rect(320, 240, 320, 240, 0x00FF0000);
+    flush_cpu_dcache();
+    flush_l2_cache();
 }
 
 void fb_line(void)
@@ -454,6 +458,8 @@ void fb_line(void)
     fb_draw_line(0, 100, 100, 100, 0x0000FFFF, 1);
     fb_draw_line(0, 0, 320, 240, 0x000FFFFF, 1);
     fb_draw_line(0, 240, 320, 0, 0x00FFFFFF, 1);
+    flush_cpu_dcache();
+    flush_l2_cache();
 }
 
 void fb_msg(void)
@@ -466,6 +472,8 @@ void fb_msg(void)
     if (x == 0)
         fb_clear();
     color += 0x1234;
+    flush_cpu_dcache();
+    flush_l2_cache();
 }
 
 /*

--- a/common/src/models/mnv2/mnv2.cc
+++ b/common/src/models/mnv2/mnv2.cc
@@ -120,7 +120,11 @@ static void do_classify_special() {
 
 static void do_golden_tests() {
   bool failed = false;
+
+#ifdef CSR_VIDEO_FRAMEBUFFER_BASE
   char msg_buff[256] = { 0 };
+#endif  
+
   for (size_t i = 0; i < NUM_GOLDEN; i++) {
     tflite_set_input_unsigned(golden_tests[i].data);
     int actual = mnv2_classify();

--- a/common/src/models/pdti8/pdti8.cc
+++ b/common/src/models/pdti8/pdti8.cc
@@ -92,7 +92,6 @@ static void do_classify_person() {
 static int32_t golden_results[NUM_GOLDEN] = {-144, 50, 226};
 
 static void do_golden_tests() {
-  char msg_buff[256] = { 0 };
   int32_t actual[NUM_GOLDEN];
 
   tflite_set_input_zeros();
@@ -102,6 +101,8 @@ static void do_golden_tests() {
   actual[1] = pdti8_classify();
 
 #ifdef CSR_VIDEO_FRAMEBUFFER_BASE
+  char msg_buff[256] = { 0 };
+
   fb_clear();
   fb_draw_string(0,  10, 0x007FFF00, "Classify Not Person");
   fb_draw_buffer(0,  50, 96, 96, (const uint8_t *)g_no_person_data, 1);

--- a/common/src/models/pdti8/pdti8.cc
+++ b/common/src/models/pdti8/pdti8.cc
@@ -24,6 +24,10 @@
 #include "tensorflow/lite/micro/examples/person_detection/person_image_data.h"
 #include "tflite.h"
 
+extern "C" {
+#include "fb_util.h"
+};
+
 // Initialize everything once
 // deallocate tensors when done
 static void pdti8_init(void) {
@@ -51,6 +55,18 @@ static void do_classify_no_person() {
   tflite_set_input(g_no_person_data);
   int32_t result = pdti8_classify();
   printf("  result is %ld\n", result);
+  
+#ifdef CSR_VIDEO_FRAMEBUFFER_BASE
+  char msg_buff[256] = { 0 };
+
+  snprintf(msg_buff, sizeof(msg_buff), "Result is %ld", result);
+  fb_clear();
+  fb_draw_string(0,  10, 0x007FFF00, "Classify Not Person");
+  fb_draw_buffer(0,  50, 96, 96, (const uint8_t *)g_no_person_data, 1);
+  fb_draw_string(0, 220, 0x007FFF00, (const char *)msg_buff);
+  flush_cpu_dcache();
+  flush_l2_cache();
+#endif  
 }
 
 static void do_classify_person() {
@@ -58,19 +74,57 @@ static void do_classify_person() {
   tflite_set_input(g_person_data);
   int32_t result = pdti8_classify();
   printf("  result is %ld\n", result);
+
+#ifdef CSR_VIDEO_FRAMEBUFFER_BASE
+  char msg_buff[256] = { 0 };
+
+  snprintf(msg_buff, sizeof(msg_buff), "Result is %ld", result);
+  fb_clear();
+  fb_draw_string(0,  10, 0x007FFF00, "Classify Person");
+  fb_draw_buffer(0,  50, 96, 96, (const uint8_t *)g_person_data, 1);
+  fb_draw_string(0, 220, 0x007FFF00, (const char *)msg_buff);
+  flush_cpu_dcache();
+  flush_l2_cache();
+#endif  
 }
 
 #define NUM_GOLDEN 3
 static int32_t golden_results[NUM_GOLDEN] = {-144, 50, 226};
 
 static void do_golden_tests() {
+  char msg_buff[256] = { 0 };
   int32_t actual[NUM_GOLDEN];
+
   tflite_set_input_zeros();
   actual[0] = pdti8_classify();
+
   tflite_set_input(g_no_person_data);
   actual[1] = pdti8_classify();
+
+#ifdef CSR_VIDEO_FRAMEBUFFER_BASE
+  fb_clear();
+  fb_draw_string(0,  10, 0x007FFF00, "Classify Not Person");
+  fb_draw_buffer(0,  50, 96, 96, (const uint8_t *)g_no_person_data, 1);
+  memset(msg_buff, 0x00, sizeof(msg_buff));
+  snprintf(msg_buff, sizeof(msg_buff), "Result is %ld, Expected is %ld", actual[1], golden_results[1]);
+  fb_draw_string(0, 220, 0x007FFF00, (const char *)msg_buff);
+  flush_cpu_dcache();
+  flush_l2_cache();
+#endif 
+  
   tflite_set_input(g_person_data);
   actual[2] = pdti8_classify();
+
+#ifdef CSR_VIDEO_FRAMEBUFFER_BASE
+  fb_clear();
+  fb_draw_string(0,  10, 0x007FFF00, "Classify Person");
+  fb_draw_buffer(0,  50, 96, 96, (const uint8_t *)g_person_data, 1);
+  memset(msg_buff, 0x00, sizeof(msg_buff));
+  snprintf(msg_buff, sizeof(msg_buff), "Result is %ld, Expected is %ld", actual[2], golden_results[2]);
+  fb_draw_string(0, 220, 0x007FFF00, (const char *)msg_buff);
+  flush_cpu_dcache();
+  flush_l2_cache();
+#endif 
 
   bool failed = false;
   for (size_t i = 0; i < NUM_GOLDEN; i++) {
@@ -104,5 +158,12 @@ static struct Menu MENU = {
 // For integration into menu system
 void pdti8_menu() {
   pdti8_init();
+
+#ifdef CSR_VIDEO_FRAMEBUFFER_BASE
+  fb_init();
+  flush_cpu_dcache();
+  flush_l2_cache();
+#endif
+  
   menu_run(&MENU);
 }


### PR DESCRIPTION
Hi, 

after some try and error, to solve cache content not sync with main memory. there two parts have to modified. 

1. according to https://github.com/litex-hub/linux-on-litex-vexriscv/issues/228
     the l2_cache_reverse has to be added in litex_boards/target/xxx_board.py in self.add_sdram() function setting.
2. add flush_cpu_dcache(), flush_l2_cache() after framebuffer function execution. 

the fb_util.c is been added two flush functions.

BR, Akio