### PR TITLE
common: add perf_get_mcycle64 function

### DIFF
--- a/common/src/perf.cc
+++ b/common/src/perf.cc
@@ -20,19 +20,19 @@
 
 unsigned CFU_start_counts[NUM_PERF_COUNTERS];
 
-void perf_print_human(unsigned n) {
+void perf_print_human(uint64_t n) {
   if (n > 9999999) {
-    printf("%6uM", (n + 500000) / 1000000);
+    printf("%6lluM", (n + 500000) / 1000000);
   } else if (n > 9999) {
-    printf("%6uk", (n + 500) / 1000);
+    printf("%6lluk", (n + 500) / 1000);
   } else {
-    printf("%6u ", n);
+    printf("%6llu ", n);
   }
 }
 
-void perf_print_value(unsigned n) {
+void perf_print_value(uint64_t n) {
   perf_print_human(n);
-  printf(" (%12u)", n);
+  printf(" (%12llu)", n);
 }
 
 // Set each individual perf counter to zero

--- a/common/src/tensorflow/lite/micro/micro_time.cc
+++ b/common/src/tensorflow/lite/micro/micro_time.cc
@@ -13,31 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "perf.h"
 #include "tensorflow/lite/micro/micro_time.h"
-
-// Read the cycle counter.
-//
-// The value of the counter is stored across two 32-bit registers: `mcycle` and
-// `mcycleh`. This function is guaranteed to return a valid 64-bit cycle
-// counter value, even if `mcycle` overflows before reading `mcycleh`.
-//
-// Adapted from: The RISC-V Instruction Set Manual, Volume I: Unprivileged ISA
-// V20191213, pp. 61.
-static inline uint64_t get_mcycle() {
-  uint32_t cycle_low = 0;
-  uint32_t cycle_high = 0;
-  uint32_t cycle_high_2 = 0;
-  asm volatile(
-      "read%=:"
-      "  csrr %0, mcycleh;"     // Read `mcycleh`.
-      "  csrr %1, mcycle;"      // Read `mcycle`.
-      "  csrr %2, mcycleh;"     // Read `mcycleh` again.
-      "  bne  %0, %2, read%=;"  // Try again if `mcycle` overflowed before
-                                // reading `mcycleh`.
-      : "+r"(cycle_high), "=r"(cycle_low), "+r"(cycle_high_2)
-      :);
-  return (uint64_t) cycle_high << 32 | cycle_low;
-}
 
 namespace tflite {
 
@@ -45,6 +22,6 @@ namespace tflite {
 int32_t ticks_per_second() { return 100000000 / 1024; }
 
 // 1 "tick" = 1024 clock cycles
-int32_t GetCurrentTimeTicks() { return get_mcycle() >> 10; }
+int32_t GetCurrentTimeTicks() { return perf_get_mcycle64() >> 10; }
 
 }  // namespace tflite

--- a/common/src/tflite.cc
+++ b/common/src/tflite.cc
@@ -243,11 +243,11 @@ void tflite_classify() {
   perf_reset_all_counters();
 
   // perf_set_mcycle is a no-op for some boards, start and end used instead.
-  uint32_t start = perf_get_mcycle();
+  uint64_t start = perf_get_mcycle64();
   if (kTfLiteOk != interpreter->Invoke()) {
     puts("Invoke failed.");
   }
-  uint32_t end = perf_get_mcycle();
+  uint64_t end = perf_get_mcycle64();
 #ifndef NPROFILE
   printf("\n");
   profiler->LogCsv();


### PR DESCRIPTION
Moves the 64 bit get_mcycle() instruction from micro_time.cc to perf.h
so that it is accessible in other contexts. In particular, use it to
print a more accurate time for long running model evaluations.

Signed-off-by: Alan Green <avg@google.com>