### PR TITLE
Add Makefile support for SystemVerilog CFUs.

### DIFF
--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -96,7 +96,7 @@ BITSTREAM    := $(SOC_GATEWARE_DIR)/$(PLATFORM).bit
 
 PROJ_DIR        := $(realpath .)
 CFU_GEN         := $(PROJ_DIR)/cfu_gen.py
-CFU_VERILOG     := $(PROJ_DIR)/cfu.v
+CFU_VERILOG     := $(if $(wildcard $(PROJ_DIR)/cfu.sv), $(PROJ_DIR)/cfu.sv, $(PROJ_DIR)/cfu.v)
 BUILD_DIR       := $(PROJ_DIR)/build
 PYRUN           := $(CFU_ROOT)/scripts/pyrun
 

--- a/soc/common_soc.mk
+++ b/soc/common_soc.mk
@@ -33,7 +33,7 @@ ifndef CFU_ROOT
 endif
 
 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
-CFU_V:=     $(PROJ_DIR)/cfu.v
+CFU_V:=     $(if $(wildcard $(PROJ_DIR)/cfu.sv), $(PROJ_DIR)/cfu.sv, $(PROJ_DIR)/cfu.v)
 CFU_ARGS:=  --cpu-cfu $(CFU_V)
 TARGET_ARGS:= --target $(TARGET)
 SOFTWARE_ARGS:= --software-load --software-path $(PROJ_DIR)/build/software.bin

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -33,7 +33,7 @@ ifndef CFU_ROOT
 endif
 
 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
-CFU_V:=     $(PROJ_DIR)/cfu.v
+CFU_V:=     $(if $(wildcard $(PROJ_DIR)/cfu.sv), $(PROJ_DIR)/cfu.sv, $(PROJ_DIR)/cfu.v)
 CFU_ARGS:=  --cpu-cfu $(CFU_V)
 
 SOC_NAME:=  hps.$(PROJ)

--- a/soc/sim.mk
+++ b/soc/sim.mk
@@ -33,7 +33,7 @@ ifndef SOFTWARE_BIN
 endif
 
 PROJ_DIR:=  $(CFU_ROOT)/proj/$(PROJ)
-CFU_V:=     $(PROJ_DIR)/cfu.v
+CFU_V:=     $(if $(wildcard $(PROJ_DIR)/cfu.sv), $(PROJ_DIR)/cfu.sv, $(PROJ_DIR)/cfu.v)
 CFU_ARGS:=  --cpu-cfu $(CFU_V)
 
 SOC_NAME:=  sim.$(PROJ)


### PR DESCRIPTION
This PR adds explicit support for `cfu.sv` files in our build system.

I tested this with projects in `proj/` and my own SystemVerilog CFU.