### PR TITLE
Remove timer from the LiteX build in Fomu workflow.

### DIFF
--- a/soc/board_specific_workflows/kosagi_fomu.py
+++ b/soc/board_specific_workflows/kosagi_fomu.py
@@ -91,9 +91,12 @@ class KosagiFomuSoCWorkflow(ice40up5k.Ice40UP5KWorkflow):
         self.bios_flash_offset = 0x60000
 
     def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
-        """Makes the Fomu SoC without a LedChaser to save LCs."""
-        return super().make_soc(with_led_chaser=False,
+        """Makes the Fomu SoC without a LedChaser or timer to save LCs."""
+        # integrated_rom_init required to avoid compiler errors building bios.
+        return super().make_soc(integrated_rom_init=[None],
                                 spi_flash_module='W25Q128JV',
+                                with_led_chaser=False,
+                                with_timer=False,
                                 **kwargs)
 
     def load(self,

--- a/soc/board_specific_workflows/test_kosagi_fomu.py
+++ b/soc/board_specific_workflows/test_kosagi_fomu.py
@@ -64,9 +64,10 @@ class KosagiFomuSoCWorkflowWorkflowTest(unittest.TestCase):
         self.simple_init().make_soc()
 
         call_kwargs = self.soc_constructor.call_args.kwargs
-        self.assertFalse(call_kwargs['with_led_chaser'])
+        self.assertNotEqual(call_kwargs['integrated_rom_init'], [])
         self.assertEqual(call_kwargs['spi_flash_module'], 'W25Q128JV')
-        pass
+        self.assertFalse(call_kwargs['with_led_chaser'])
+        self.assertFalse(call_kwargs['with_timer'])
 
     def test_software_load(self):
         workflow = self.simple_init()


### PR DESCRIPTION
This PR removes the `timer0` CSRs and related functionality from the LiteX build in the Fomu workflow. The timer is not required for the CFU-Playground, but is necessary for compiling the bios. Thus, the removal of the timer also necessitates the removal of the LiteX bios; this isn't a problem because we didn't use the LiteX bios in the first place with the Fomu.

Overall this change saves us ≈328 LCs which can be utilized in more important applications (like a larger CFU).