### PR TITLE
Add ability to pass extra arguments into board-specific workflows.

### DIFF
--- a/soc/common_soc.mk
+++ b/soc/common_soc.mk
@@ -41,7 +41,7 @@ SOFTWARE_ARGS:= --software-load --software-path $(PROJ_DIR)/build/software.bin
 SOC_NAME:=  $(TARGET).$(PROJ)
 OUT_DIR:=   build/$(SOC_NAME)
 UART_ARGS=  --uart-baudrate $(UART_SPEED)
-LITEX_ARGS= --output-dir $(OUT_DIR) --csr-csv $(OUT_DIR)/csr.csv $(CFU_ARGS) $(UART_ARGS) $(TARGET_ARGS)
+LITEX_ARGS= --output-dir $(OUT_DIR) --csr-csv $(OUT_DIR)/csr.csv $(CFU_ARGS) $(UART_ARGS) $(TARGET_ARGS) $(EXTRA_LITEX_ARGS)
 
 ifdef USE_OXIDE
 LITEX_ARGS += --toolchain oxide --yosys-abc9


### PR DESCRIPTION
This PR adds an `EXTRA_LITEX_ARGS` command line argument to our build system. These extra arguments can be parsed in board-specific workflows to allow for a more flexible building process; ie. `make prog EXTRA_LITEX_ARGS="--variant a7-100"`.

The Arty workflow has been modified to use these extra args to specify the variant of the Arty board (`a7-35` or `a7-100`).