### PR TITLE
scripts/install_oxide: Add some prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,10 @@ report.html
 results-*robot.xml
 robot_output.xml
 *fail.save
+
+# These Project Oxide related things should not be added
+third_party/.cargo
+third_party/nextpnr
+third_party/prjoxide
+third_party/usr/local
+third_party/yosys

--- a/scripts/install_oxide
+++ b/scripts/install_oxide
@@ -3,7 +3,6 @@ set -e
 
 CFU_ROOT="$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))"
 
-
 UPDATE=
 if [ $# -gt 1 ] ; then
   echo "Usage: install_oxide [update]"
@@ -18,9 +17,16 @@ if [ $# -gt 0 ] ; then
   fi
 fi
 
-
-
 if [ -z "$UPDATE" ] ; then
+
+  echo "Sudo Installing pre-requisites"
+  sudo apt install tcl-dev bison flex cmake libboost-all-dev libeigen3-dev
+
+  if ! which cargo ; then
+    echo "Installing Cargo"
+    curl https://sh.rustup.rs -sSf | sh
+    source "${HOME}/.cargo/env"
+  fi
 
   echo
   echo "CLONING REPOSITORIES"
@@ -45,7 +51,7 @@ else
 
   echo
   echo "UPDATING REPOSITORIES"
-  cd ${CFU_ROOT}/third_party
+  cd "${CFU_ROOT}/third_party"
   git -C yosys pull --ff-only origin master
   git -C yosys submodule update
   git -C prjoxide pull --ff-only origin master
@@ -59,22 +65,27 @@ DESTDIR=${CFU_ROOT}/third_party
 
 echo
 echo "BUILDING YOSYS"
-cd ${CFU_ROOT}/third_party/yosys
+cd "${CFU_ROOT}/third_party/yosys"
 make -j
 make DESTDIR=${DESTDIR} install
 
 echo
 echo "BUILDING PRJOXIDE"
-OXIDE_INSTALL_PREFIX=${CFU_ROOT}/third_party/.cargo
-mkdir -p ${OXIDE_INSTALL_PREFIX}
-cd ${CFU_ROOT}/third_party/prjoxide/libprjoxide
-cargo install --path prjoxide --root ${OXIDE_INSTALL_PREFIX}
-cp ${CFU_ROOT}/third_party/.cargo/bin/prjoxide ${DESTDIR}/usr/local/bin
+OXIDE_INSTALL_PREFIX="${CFU_ROOT}/third_party/.cargo"
+mkdir -p "${OXIDE_INSTALL_PREFIX}"
+cd "${CFU_ROOT}/third_party/prjoxide/libprjoxide"
+cargo install --path prjoxide --root "${OXIDE_INSTALL_PREFIX}"
+cp "${CFU_ROOT}/third_party/.cargo/bin/prjoxide" "${DESTDIR}/usr/local/bin"
 
 echo
 echo "BUILDING NEXTPNR-NEXUS"
-cd ${CFU_ROOT}/third_party/nextpnr
-cmake -DARCH=nexus -DOXIDE_INSTALL_PREFIX=${OXIDE_INSTALL_PREFIX} .
+cd "${CFU_ROOT}/third_party/nextpnr"
+cmake -DARCH=nexus -DOXIDE_INSTALL_PREFIX="${OXIDE_INSTALL_PREFIX}" .
 make -j
-make DESTDIR=${DESTDIR} install
+make DESTDIR="${DESTDIR}" install
 
+echo
+echo "IMPORTANT"
+echo "Don't forget to add"
+echo "    source \"${HOME}/.cargo/env\""
+echo "to your .profile"


### PR DESCRIPTION
Adds some prerequisites for the building of yosys, nextpnr and project
oxide. These were found by building on a relatively fresh Debian-based
image. Others attempting the install may find further prerequisites in
future.