### PR TITLE
hps: fix IO standard for spiflash4x resource on proto0

### DIFF
--- a/soc/hps_proto0_platform.py
+++ b/soc/hps_proto0_platform.py
@@ -42,7 +42,7 @@ hps_io = [
         Subsignal("cs_n", Pins("A3")),
         Subsignal("clk", Pins("B4")),
         Subsignal("dq", Pins("B5 C4 B3 B2")),
-        IOStandard("LVCMOS18H")
+        IOStandard("LVCMOS18")
      ),
 ]
 


### PR DESCRIPTION
These pins are in bank 0 which means they can only do LVCMOS18 not
LVCMOS18H. The IO standard was already correctly declared on the
'spiflash' resource, it was just incorrect on 'spiflash4x' (currently
unused).

The proto2 platform definition is already correct, I checked it when
I added it.