### PR TITLE
Update gateware/software CFU and tests in kws_micro_accel.

### DIFF
--- a/proj/kws_micro_accel/mac.sv
+++ b/proj/kws_micro_accel/mac.sv
@@ -1,0 +1,47 @@
+// Copyright 2021 The CFU-Playground Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Optionally SIMD multiply and accumulate unit that adds constant offset to input_vals.
+
+module mac (
+  // Enable bits for SIMD and layer one input offset
+  input logic layer_one_en,
+  input logic simd_en,
+
+  input logic [31:0] input_vals,
+  input logic [31:0] filter_vals,
+  input logic [31:0] curr_acc,
+
+  output logic [31:0] out
+);
+  logic signed [8:0] InputOffest = layer_one_en ? -9'sd83 : 9'sd128;
+
+  // Explicit rather than generated; saves LCs with current Yosys.
+  logic signed [15:0] prod_0, prod_1, prod_2, prod_3;
+  assign prod_0 = (signed'(input_vals[7:0])   + InputOffest) * signed'(filter_vals[7:0]);
+  assign prod_1 = (signed'(input_vals[15:8])  + InputOffest) * signed'(filter_vals[15:8]);
+  assign prod_2 = (signed'(input_vals[23:16]) + InputOffest) * signed'(filter_vals[23:16]);
+  assign prod_3 = (signed'(input_vals[31:24]) + InputOffest) * signed'(filter_vals[31:24]);
+
+  // Conditionally MAC or SIMD MAC.
+  logic signed [31:0] sum_prods;
+  always_comb begin
+    sum_prods = prod_0;
+    if (simd_en) begin
+      sum_prods += prod_1 + prod_2 + prod_3;
+    end
+  end
+
+  assign out = curr_acc + sum_prods;
+endmodule

--- a/proj/kws_micro_accel/rcdbpot.sv
+++ b/proj/kws_micro_accel/rcdbpot.sv
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Rounding clamping divide by power of two. Given a dividend and a (negative)
+// representation of an exponent in the range [9:5], output the dividend
+// divided by 2^-negative_exponent correctly rounded up or down based on sign
+// and remainder. Clamped to the range [127,-128] and shifted by -128.
+
+module rcdbpot (
+  input logic [31:0] dividend,
+  input logic [31:0] negative_exponent,
+
+  output logic [31:0] out
+);
+  logic [3:0] shift;
+  logic signed [31:0] mask, remainder, threshold;
+
+  always_comb begin
+    // Weird ordering is most effective for LC usage.
+    casez (negative_exponent[2:0])
+      3'b111 : shift = 9;
+      3'b?11 : shift = 5;
+      3'b??1 : shift = 7;
+      3'b?1? : shift = 6;
+      default: shift = 8;
+    endcase
+
+    mask = ~({32{1'b1}} << shift);
+    remainder = dividend & mask;
+    threshold = (mask >> 1) + dividend[31];
+    out = signed'(signed'(dividend) >>> shift);
+
+    if (remainder > threshold) out += 1'b1;
+    if (out[31]) out = 32'sd0;
+    else if (|out[31:8]) out = 32'sd255;
+    out -= 32'sd128;
+  end
+endmodule

--- a/proj/kws_micro_accel/rdh.sv
+++ b/proj/kws_micro_accel/rdh.sv
@@ -1,0 +1,24 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Rounding doubling high 32 bits. Given a 64 bit integer as {top, bottom}
+// double and round to the nearest 2^32, outputting only the top half.
+
+module rdh (
+  // 64 bit integer as {top, bottom}
+  input logic [31:0] top,
+  input logic [31:0] bottom,
+
+  output logic [31:0] out
+);
+  assign out = (signed'({top, bottom}) + 32'sh40000000) >> 31;
+endmodule

--- a/proj/kws_micro_accel/src/kws_cfu.h
+++ b/proj/kws_micro_accel/src/kws_cfu.h
@@ -19,16 +19,39 @@
 
 #include "cfu.h"
 
-#define RESET_ACC() cfu_op0(1, 0, 0)
-#define SIMD_MAC(input_val, filter_val) cfu_op0(0, input_val, filter_val)
-#define MAC(input_val, filter_val) cfu_op1(0, input_val, filter_val)
+#define RESET_ACC() cfu_op0(0, 0, 0)
+#define MAC(input, filter) cfu_op1(0, input, filter)
+#define MAC_LAYER_ONE(input, filter) cfu_op1(2, input, filter)
+#define SIMD_MAC(inputs, filters) cfu_op1(1, inputs, filters)
+#define ROUNDING_DOUBLE_HIGH(top, bottom) cfu_op2(0, top, bottom)
+#define ROUNDING_CLAMPING_DIVIDE_BY_POT(shift) cfu_op4(0, 0, shift)
 
-#define RESET_ACC_SW() cfu_op0_sw(1, 0, 0)
-#define SIMD_MAC_SW(input_val, filter_val) cfu_op0_sw(0, input_val, filter_val)
-#define MAC_SW(input_val, filter_val) cfu_op1_sw(0, input_val, filter_val)
+#define RESET_ACC_SW() cfu_op0_sw(0, 0, 0)
+#define MAC_SW(input, filter) cfu_op1_sw(0, input, filter)
+#define MAC_LAYER_ONE_SW(input, filter) cfu_op1_sw(2, input, filter)
+#define SIMD_MAC_SW(inputs, filters) cfu_op1_sw(1, inputs, filters)
+#define ROUNDING_DOUBLE_HIGH_SW(top, bottom) cfu_op2_sw(0, top, bottom)
+#define ROUNDING_CLAMPING_DIVIDE_BY_POT_SW(shift) cfu_op4_sw(0, 0, shift)
 
-#define RESET_ACC_HW() cfu_op0_hw(1, 0, 0)
-#define SIMD_MAC_HW(input_val, filter_val) cfu_op0_hw(0, input_val, filter_val)
-#define MAC_HW(input_val, filter_val) cfu_op1_hw(0, input_val, filter_val)
+#define RESET_ACC_HW() cfu_op0_hw(0, 0, 0)
+#define MAC_HW(input, filter) cfu_op1_hw(0, input, filter)
+#define MAC_LAYER_ONE_HW(input, filter) cfu_op1_hw(2, input, filter)
+#define SIMD_MAC_HW(inputs, filters) cfu_op1_hw(1, inputs, filters)
+#define ROUNDING_DOUBLE_HIGH_HW(top, bottom) cfu_op2_hw(0, top, bottom)
+#define ROUNDING_CLAMPING_DIVIDE_BY_POT_HW(shift) cfu_op4_hw(0, 0, shift)
+
+// Implements TFLM's MultiplyByQuantizedMultiplier function using CFU ops.
+inline int32_t KwsMultiplyByQuantizedMultiplier(int32_t acc, int32_t q_mult,
+                                                int shift) {
+  uint32_t top, bottom;
+  asm("mul  %[bottom], %[acc], %[q_mult]"
+      : [bottom] "=r"(bottom)
+      : [acc] "r"(acc), [q_mult] "r"(q_mult));
+  asm("mulh %[top], %[acc], %[q_mult]"
+      : [top] "=r"(top)
+      : [acc] "r"(acc), [q_mult] "r"(q_mult));
+  ROUNDING_DOUBLE_HIGH(top, bottom);
+  return ROUNDING_CLAMPING_DIVIDE_BY_POT(shift);
+}
 
 #endif  // KWS_CFU_H


### PR DESCRIPTION
With the new resources afforded to the Fomu build (see #215 and #223) the kws_micro_accel CFU has been updated with new features.

- It continues to perform (optionally SIMD) multiply-and-accumulate operations but now with a status bit that controls the `InputOffset` value. This allows the CFU to be used during the first layer of convolution (which requires the different offset).
- The post-processing section of convolution and depthwise convolution has been moved mostly into the CFU with the newly added "rounding clamping divide by power of two" and "rounding doubling high 32 bit" operations.
  - We don't have enough DSP tiles in the FPGA to move the entirety of the post-processing into gateware so we utilize the updated single-cycle multiply in our CPU before passing our inputs to the CFU.

The software emulation of the CFU has been updated to conform to these changes and new tests have been added for the new functionality. Finally, the gateware CFU implementation has been split apart into separate SystemVerilog modules.