### PR TITLE
script/install_oxide: add missing clang dep

### DIFF
--- a/scripts/install_oxide
+++ b/scripts/install_oxide
@@ -20,7 +20,7 @@ fi
 if [ -z "$UPDATE" ] ; then
 
   echo "Sudo Installing pre-requisites"
-  sudo apt install tcl-dev bison flex cmake libboost-all-dev libeigen3-dev
+  sudo apt install tcl-dev bison flex cmake libboost-all-dev libeigen3-dev clang
 
   if ! which cargo ; then
     echo "Installing Cargo"


### PR DESCRIPTION
Without this compilation will complain that clang is missing when building yosys:
```
BUILDING YOSYS
/bin/sh: line 1: clang: command not found
```