### PR TITLE
Use upstream LiteX with local monkey-patch for CPU variant.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/m-labs/migen.git
 [submodule "soc/deps/litex"]
 	path = third_party/python/litex
-	url = https://github.com/tcal-x/litex.git
+	url = https://github.com/enjoy-digital/litex.git
 [submodule "soc/deps/litedram"]
 	path = third_party/python/litedram
 	url = https://github.com/enjoy-digital/litedram.git


### PR DESCRIPTION
In order to make maintenance easier until the Fomu CPU variant is upstreamed, this PR switches off of @tcal-x's LiteX fork and monkey-patches the Fomu variant into the official LiteX at runtime. This patch should be removed once changes have been upstreamed. 🐒