### PR TITLE
hps_accel: fix off-by-one error with max_index signal width

### DIFF
--- a/proj/hps_accel/gateware/input_store.py
+++ b/proj/hps_accel/gateware/input_store.py
@@ -74,7 +74,7 @@ class InputStore(SimpleElaboratable):
             m.d.comb += memory.write_sink.payload.data.eq(self.input.payload),
         with m.If(self.input.is_transferring()):
             m.d.comb += memories[write_index[:2]].write_sink.valid.eq(1),
-            with m.If(write_index == max_index - 1):
+            with m.If(write_index == max_index):
                 # On last word write, wrap back to zero and cause a pre-emptive
                 # read
                 m.d.sync += write_index.eq(0)
@@ -97,14 +97,14 @@ class InputStore(SimpleElaboratable):
         with m.If(self.next):
             m.d.sync += read_required.eq(1)
             m.d.sync += read_index.eq(Mux(read_index ==
-                                      max_index - 4, 0, read_index + 4))
+                                      max_index - 3, 0, read_index + 4))
 
         # Read the value of max_index from num_words sink
         # Reset read and write index too
         m.d.comb += self.num_words.ready.eq(1)
         with m.If(self.num_words.valid):
             m.d.sync += [
-                max_index.eq(self.num_words.payload),
+                max_index.eq(self.num_words.payload - 1),
                 write_index.eq(0),
                 read_index.eq(0),
             ]


### PR DESCRIPTION
This signal was called max_index (implying its value should range up to
N-1 for N input words) but it was actually being used as num_words (its
value would range up to N for N input words).

The logic using the signal was correct, but the signal's width was
wrongly calculated. If num_words was set equal to the maximum capacity
of the input store, the max_index signal would wrap around to 0 instead
of N.

I noticed this when I was unit-testing the filter store, which reuses the same logic. In the filter store unit tests I was setting the store depth equal to the number of words I was filling. The existing input store tests don't catch this because they always fill the store to much less than its capacity.

Amusingly, this is the exact same mistake I made early on when I was writing the filter store too. :-)