### PR TITLE
hps_accel: implement filter store registers

### DIFF
--- a/proj/hps_accel/Makefile
+++ b/proj/hps_accel/Makefile
@@ -20,7 +20,7 @@ export DEFINES :=
 DEFINES += ACCEL_CONV
 
 # Uncomment this line to use software defined CFU functions in software_cfu.cc
-DEFINES += CFU_SOFTWARE_DEFINED
+#DEFINES += CFU_SOFTWARE_DEFINED
 
 # Uncomment this line to skip debug code (large effect on performance)
 DEFINES += NDEBUG

--- a/proj/hps_accel/gateware/constants.py
+++ b/proj/hps_accel/gateware/constants.py
@@ -94,6 +94,17 @@ class Constants:
     INS_GET = 1
     INS_PING = 7
 
+    ###########################################################################
+    # Size limits
+
+    # Maximum number of words in filter
+    # TODO: this has to come down to ~ 2k and then change code to make batches
+    # to match
+    MAX_FILTER_WORDS = 16384
+
+    # Maximum number of words in input
+    MAX_INPUT_WORDS = 256
+
 
 CC_FILE_HEADER = """// Generated file
 // Shared constants generated from gateware/constants.py

--- a/proj/hps_accel/gateware/filter_store.py
+++ b/proj/hps_accel/gateware/filter_store.py
@@ -1,0 +1,118 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from nmigen_cfu.util import SimpleElaboratable
+from nmigen import unsigned, Signal, Module, Array, Mux
+
+from .constants import Constants
+from .stream import Sink, Source, glue_sources
+from .sp_mem import MemoryParameters, SinglePortMemory
+
+
+class FilterStore(SimpleElaboratable):
+    """Stores file values one word at a time and outputs four words at a time.
+
+    Use in this sequence:
+    (1) Set num_words
+    (2) Set num_words words of filter values
+    (3) Read outputs until done
+    (4) Go back to step 1
+
+    Parameters
+    ----------
+
+    depth: int
+      Maximum capacity of the filter store, in 32-bit words.
+      The num_words signal's value must not exceed this depth.
+
+    Attributes
+    ----------
+
+    input: Sink(unsigned(32)), in
+      Words written to input are set into the filter store.
+
+    next: Signal(), in
+      Causes the next four words to be displayed at the output.
+
+    num_words: Sink(unsigned(32)), in
+      Number of words in input. When set, resets internal storage.
+
+    output: list of 4 Source(unsigned(32)), out
+      The four words of output.
+
+    """
+
+    def __init__(self, depth=Constants.MAX_FILTER_WORDS):
+        self.depth = depth
+        self.input = Sink(unsigned(32))
+        self.next = Signal()
+        self.num_words = Sink(unsigned(32))
+        self.output = [Source(unsigned(32), name=f"output_{i}")
+                       for i in range(4)]
+
+    def elab(self, m: Module):
+        max_index = Signal(range(self.depth))
+        write_index = Signal(range(self.depth))
+        read_index = Signal(range(self.depth))
+        read_required = Signal()  # Set whenever read_index is updated to initiate a read
+
+        # Create four memories
+        memory_params = MemoryParameters(width=32, depth=self.depth // 4)
+        memories = Array([SinglePortMemory(params=memory_params)
+                         for _ in range(4)])
+        for n, memory in enumerate(memories):
+            m.submodules[f"mem_{n}"] = memory
+
+        # On read from input sink
+        m.d.comb += self.input.ready.eq(1)
+        for memory in memories:
+            m.d.comb += memory.write_sink.payload.addr.eq(write_index[2:])
+            m.d.comb += memory.write_sink.payload.data.eq(self.input.payload)
+        with m.If(self.input.is_transferring()):
+            m.d.comb += memories[write_index[:2]].write_sink.valid.eq(1)
+            with m.If(write_index == max_index):
+                # On last word write, wrap back to zero and cause a pre-emptive
+                # read
+                m.d.sync += write_index.eq(0)
+                m.d.sync += read_required.eq(1)
+            with m.Else():
+                m.d.sync += write_index.eq(write_index + 1)
+
+        # When read_required, push new values down output sinks
+        for n, memory in enumerate(memories):
+            m.d.comb += glue_sources(memory.read_data_source, self.output[n])
+            addr_sink = memory.read_addr_sink
+            m.d.sync += addr_sink.payload.eq(read_index[2:])
+            with m.If(read_required):
+                m.d.sync += addr_sink.valid.eq(1)
+                m.d.sync += read_required.eq(0)
+            with m.Elif(addr_sink.is_transferring()):
+                m.d.sync += addr_sink.valid.eq(0)
+
+        # On "next" signal cause next words to be read by setting read_required
+        with m.If(self.next):
+            m.d.sync += read_required.eq(1)
+            m.d.sync += read_index.eq(Mux(read_index == max_index - 3,
+                                          0, read_index + 4))
+
+        # Read the value of max_index from num_words sink
+        # Reset read and write index too
+        m.d.comb += self.num_words.ready.eq(1)
+        with m.If(self.num_words.valid):
+            m.d.sync += [
+                max_index.eq(self.num_words.payload - 1),
+                write_index.eq(0),
+                read_index.eq(0),
+            ]

--- a/proj/hps_accel/gateware/get.py
+++ b/proj/hps_accel/gateware/get.py
@@ -85,6 +85,10 @@ class GetInstruction(InstructionBase):
 
     # The list of all register IDs that may be fetched
     REGISTER_IDS = [
+        Constants.REG_FILTER_0,
+        Constants.REG_FILTER_1,
+        Constants.REG_FILTER_2,
+        Constants.REG_FILTER_3,
         Constants.REG_INPUT_0,
         Constants.REG_INPUT_1,
         Constants.REG_INPUT_2,

--- a/proj/hps_accel/gateware/input_store.py
+++ b/proj/hps_accel/gateware/input_store.py
@@ -16,6 +16,7 @@
 from nmigen_cfu.util import SimpleElaboratable
 from nmigen import unsigned, Signal, Module, Array, Mux
 
+from .constants import Constants
 from .stream import Sink, Source, glue_sources
 from .sp_mem import MemoryParameters, SinglePortMemory
 
@@ -45,7 +46,6 @@ class InputStore(SimpleElaboratable):
       The four words of output.
 
     """
-    MAX_WORDS = 2048
 
     def __init__(self):
         self.input = Sink(unsigned(32))
@@ -55,13 +55,13 @@ class InputStore(SimpleElaboratable):
                        for i in range(4)]
 
     def elab(self, m: Module):
-        max_index = Signal(range(self.MAX_WORDS))
-        write_index = Signal(range(self.MAX_WORDS))
-        read_index = Signal(range(self.MAX_WORDS))
+        max_index = Signal(range(Constants.MAX_INPUT_WORDS))
+        write_index = Signal(range(Constants.MAX_INPUT_WORDS))
+        read_index = Signal(range(Constants.MAX_INPUT_WORDS))
         read_required = Signal()  # Set whenever read_index is updated to initiate a read
 
         # Create four memories
-        memory_params = MemoryParameters(width=32, depth=self.MAX_WORDS // 4)
+        memory_params = MemoryParameters(width=32, depth=Constants.MAX_INPUT_WORDS // 4)
         memories = Array([SinglePortMemory(params=memory_params)
                          for _ in range(4)])
         for n, memory in enumerate(memories):

--- a/proj/hps_accel/gateware/set.py
+++ b/proj/hps_accel/gateware/set.py
@@ -77,8 +77,10 @@ class SetInstruction(InstructionBase):
 
     # The list of all register IDs that may be set
     REGISTER_IDS = [
+        Constants.REG_FILTER_NUM_WORDS,
         Constants.REG_INPUT_NUM_WORDS,
         Constants.REG_INPUT_OFFSET,
+        Constants.REG_SET_FILTER,
         Constants.REG_SET_INPUT,
         Constants.REG_MACC_INPUT_0,
         Constants.REG_MACC_INPUT_1,

--- a/proj/hps_accel/gateware/test_filter_store.py
+++ b/proj/hps_accel/gateware/test_filter_store.py
@@ -1,0 +1,194 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from nmigen_cfu import TestBase
+
+from .filter_store import FilterStore
+
+
+class FilterStoreTest(TestBase):
+    def create_dut(self):
+        return FilterStore(depth=12)
+
+    # Test data which we fill into the store in reset_and_fill()
+    # and expect to read back out of it in read()
+    filter_values = list(range(11, 11 + 12))
+
+    def reset_and_fill(self):
+        self.assertEqual((yield self.dut.num_words.ready), 1)
+        yield self.dut.num_words.payload.eq(len(self.filter_values))
+        yield self.dut.num_words.valid.eq(1)
+        # Need to wait 1 cycle before sending the first input
+        yield
+        yield self.dut.num_words.valid.eq(0)
+        yield self.dut.input.valid.eq(1)
+        for filter_value in self.filter_values:
+            self.assertEqual((yield self.dut.input.ready), 1)
+            yield self.dut.input.payload.eq(filter_value)
+            yield
+        yield self.dut.input.valid.eq(0)
+
+    def read_out(self):
+        for i in range(0, len(self.filter_values), 4):
+            while (yield self.dut.output[0].valid) != 1:
+                yield
+            self.assertEqual((yield self.dut.output[0].valid), 1)
+            self.assertEqual((yield self.dut.output[1].valid), 1)
+            self.assertEqual((yield self.dut.output[2].valid), 1)
+            self.assertEqual((yield self.dut.output[3].valid), 1)
+            self.assertEqual((yield self.dut.output[0].payload), self.filter_values[i + 0])
+            self.assertEqual((yield self.dut.output[1].payload), self.filter_values[i + 1])
+            self.assertEqual((yield self.dut.output[2].payload), self.filter_values[i + 2])
+            self.assertEqual((yield self.dut.output[3].payload), self.filter_values[i + 3])
+            yield self.dut.output[0].ready.eq(1)
+            yield self.dut.output[1].ready.eq(1)
+            yield self.dut.output[2].ready.eq(1)
+            yield self.dut.output[3].ready.eq(1)
+            yield self.dut.next.eq(1)
+            yield
+            yield self.dut.next.eq(0)
+            yield
+
+    def test_it(self):
+        def process():
+            yield from self.reset_and_fill()
+            yield from self.read_out()
+        self.run_sim(process)
+
+    def test_it_can_stream_output(self):
+        def process():
+            yield from self.reset_and_fill()
+            # Set up for streaming output. We will receive four output words every cycle.
+            yield self.dut.output[0].ready.eq(1)
+            yield self.dut.output[1].ready.eq(1)
+            yield self.dut.output[2].ready.eq(1)
+            yield self.dut.output[3].ready.eq(1)
+            yield self.dut.next.eq(1)
+            # Currently 3 cycle delay before streaming starts
+            yield
+            yield
+            for i in range(0, len(self.filter_values), 4):
+                yield
+                self.assertEqual((yield self.dut.output[0].valid), 1)
+                self.assertEqual((yield self.dut.output[1].valid), 1)
+                self.assertEqual((yield self.dut.output[2].valid), 1)
+                self.assertEqual((yield self.dut.output[3].valid), 1)
+                self.assertEqual((yield self.dut.output[0].payload), self.filter_values[i + 0])
+                self.assertEqual((yield self.dut.output[1].payload), self.filter_values[i + 1])
+                self.assertEqual((yield self.dut.output[2].payload), self.filter_values[i + 2])
+                self.assertEqual((yield self.dut.output[3].payload), self.filter_values[i + 3])
+        self.run_sim(process)
+
+    def test_it_wraps_back_to_the_start_when_reading(self):
+        def process():
+            yield from self.reset_and_fill()
+            yield from self.read_out()
+            yield from self.read_out()
+        self.run_sim(process)
+
+    def test_it_can_tolerate_delays_while_filling(self):
+        def process():
+            yield self.dut.num_words.payload.eq(len(self.filter_values))
+            yield self.dut.num_words.valid.eq(1)
+            yield
+            yield self.dut.num_words.valid.eq(0)
+            for filter_value in self.filter_values:
+                # Delay before we present each value
+                yield self.dut.input.valid.eq(0)
+                for _ in range(10):
+                    self.assertEqual((yield self.dut.input.ready), 1)
+                    yield
+                yield self.dut.input.valid.eq(1)
+                yield self.dut.input.payload.eq(filter_value)
+                yield
+            yield self.dut.input.valid.eq(0)
+            yield from self.read_out()
+        self.run_sim(process)
+
+    def test_it_can_tolerate_delays_while_reading(self):
+        def process():
+            yield from self.reset_and_fill()
+            for i in range(0, len(self.filter_values), 4):
+                yield self.dut.output[0].ready.eq(0)
+                yield self.dut.output[1].ready.eq(0)
+                yield self.dut.output[2].ready.eq(0)
+                yield self.dut.output[3].ready.eq(0)
+                yield self.dut.next.eq(0)
+                # Delay before consuming each value
+                # (Delaying for an odd number of cycles is more likely to catch
+                # bugs, since the store contains an even number of elements)
+                for _ in range(13):
+                    yield
+                self.assertEqual((yield self.dut.output[0].valid), 1)
+                self.assertEqual((yield self.dut.output[1].valid), 1)
+                self.assertEqual((yield self.dut.output[2].valid), 1)
+                self.assertEqual((yield self.dut.output[3].valid), 1)
+                self.assertEqual((yield self.dut.output[0].payload), self.filter_values[i + 0])
+                self.assertEqual((yield self.dut.output[1].payload), self.filter_values[i + 1])
+                self.assertEqual((yield self.dut.output[2].payload), self.filter_values[i + 2])
+                self.assertEqual((yield self.dut.output[3].payload), self.filter_values[i + 3])
+                yield self.dut.output[0].ready.eq(1)
+                yield self.dut.output[1].ready.eq(1)
+                yield self.dut.output[2].ready.eq(1)
+                yield self.dut.output[3].ready.eq(1)
+                yield self.dut.next.eq(1)
+                yield
+        self.run_sim(process)
+
+    def test_it_can_be_reset_while_filling(self):
+        def process():
+            # Reset and partially fill some elements
+            yield self.dut.num_words.payload.eq(len(self.filter_values))
+            yield self.dut.num_words.valid.eq(1)
+            yield
+            yield self.dut.num_words.valid.eq(0)
+            self.assertEqual((yield self.dut.input.ready), 1)
+            yield self.dut.input.payload.eq(99)
+            yield self.dut.input.valid.eq(1)
+            yield
+            self.assertEqual((yield self.dut.input.ready), 1)
+            yield self.dut.input.payload.eq(99)
+            yield
+            # Now reset and fill again from the start
+            yield from self.reset_and_fill()
+            yield from self.read_out()
+        self.run_sim(process)
+
+    # TODO(dcallagh): fix reset logic so that this case passes.
+    # It currently breaks because the first output values get stuck at their
+    # output sources after the first fill, and remain stuck there during the
+    # second fill and up to the subsequent read.
+    def xtest_it_can_be_reset_after_filling(self):
+        def process():
+            yield from self.reset_and_fill()
+            yield from self.reset_and_fill()
+            yield from self.read_out()
+        self.run_sim(process)
+
+    # TODO(dcallagh): as above, fix reset logic
+    def xtest_it_can_be_reset_while_reading(self):
+        def process():
+            yield from self.reset_and_fill()
+            # Read past the first values
+            while (yield self.dut.output[0].valid) != 1:
+                yield
+            yield self.dut.next.eq(1)
+            yield
+            yield self.dut.next.eq(0)
+            yield
+            # Now reset and fill again from the start
+            yield from self.reset_and_fill()
+            yield from self.read_out()
+        self.run_sim(process)

--- a/proj/hps_accel/gateware/test_hps_cfu.py
+++ b/proj/hps_accel/gateware/test_hps_cfu.py
@@ -43,7 +43,7 @@ VERIFY = Constants.REG_VERIFY
 class HpsCfuTest(CfuTestBase):
 
     def create_dut(self):
-        return make_cfu()
+        return make_cfu(filter_store_depth=100)
 
     def test_simple(self):
         """Tests some simple cases"""
@@ -105,4 +105,17 @@ class HpsCfuTest(CfuTestBase):
                 yield ((GET, Constants.REG_INPUT_2, 0, 0), n+2)
                 yield ((GET, Constants.REG_INPUT_3, 0, 0), n+3)
 
+        self.run_ops(op_generator(), True)
+
+    def test_simple_filter_store(self):
+        """Tests simple filter store use case"""
+        def op_generator():
+            yield ((SET, Constants.REG_FILTER_NUM_WORDS, 20, 0), 0)
+            for n in range(100, 120):
+                yield ((SET, Constants.REG_SET_FILTER, n, 0), 0)
+            for n in range(100, 120, 4):
+                yield ((GET, Constants.REG_FILTER_0, 0, 0), n + 0)
+                yield ((GET, Constants.REG_FILTER_1, 0, 0), n + 1)
+                yield ((GET, Constants.REG_FILTER_2, 0, 0), n + 2)
+                yield ((GET, Constants.REG_FILTER_3, 0, 0), n + 3)
         self.run_ops(op_generator(), True)

--- a/proj/hps_accel/src/blocks.cc
+++ b/proj/hps_accel/src/blocks.cc
@@ -99,18 +99,18 @@ void LoadFilter(size_t in_channels, size_t out_channels, const int8_t* values) {
   const uint32_t* values_as_words = reinterpret_cast<const uint32_t*>(values);
   size_t filter_words =
       FILTER_WIDTH * FILTER_HEIGHT / 4 * in_channels * out_channels;
-  cfu_set_sw(REG_FILTER_NUM_WORDS, filter_words);
+  cfu_set(REG_FILTER_NUM_WORDS, filter_words);
   const uint32_t* end = values_as_words + filter_words;
   while (values_as_words != end) {
-    cfu_set_sw(REG_SET_FILTER, *values_as_words++);
+    cfu_set(REG_SET_FILTER, *values_as_words++);
   }
 }
 
 Vector16 GetFilter() {
-  uint32_t word0 = cfu_get_sw(REG_FILTER_0);
-  uint32_t word1 = cfu_get_sw(REG_FILTER_1);
-  uint32_t word2 = cfu_get_sw(REG_FILTER_2);
-  uint32_t word3 = cfu_get_sw(REG_FILTER_3);
+  uint32_t word0 = cfu_get(REG_FILTER_0);
+  uint32_t word1 = cfu_get(REG_FILTER_1);
+  uint32_t word2 = cfu_get(REG_FILTER_2);
+  uint32_t word3 = cfu_get(REG_FILTER_3);
   return Vector16{{word0, word1, word2, word3}};
 }
 

--- a/proj/hps_accel/src/blocks.h
+++ b/proj/hps_accel/src/blocks.h
@@ -27,14 +27,6 @@ namespace hps_accel {
 constexpr size_t FILTER_WIDTH = 4;
 constexpr size_t FILTER_HEIGHT = 4;
 
-// Maximum number of words in filter
-// TODO: this has to come down to ~ 2k and then change code to make batches to
-// match
-constexpr size_t MAX_FILTER_WORDS = 16384;
-
-// Maximum number of words in input
-constexpr size_t MAX_INPUT_WORDS = 256;
-
 // Encodes 16 signed 8-bit values in a 4x32 bit words
 struct Vector16 {
   // Each 32 bit value holds four 8 bit signed values, in little endian order.

--- a/proj/hps_accel/src/hps_cfu.h
+++ b/proj/hps_accel/src/hps_cfu.h
@@ -23,10 +23,6 @@
 #define cfu_set(reg, val) cfu_op(INS_SET, reg, val, 0)
 #define cfu_get(reg) cfu_op(INS_GET, reg, 0, 0)
 
-// Get/set, but force software CFU
-#define cfu_set_sw(reg, val) cfu_op_sw(INS_SET, reg, val, 0)
-#define cfu_get_sw(reg) cfu_op_sw(INS_GET, reg, 0, 0)
-
 // Ping instructions for checking CFU is available
 #define cfu_ping(val1, val2) cfu_op(INS_PING, 0, val1, val2)
 

--- a/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv_accel.cc
+++ b/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv_accel.cc
@@ -17,6 +17,7 @@
 
 #include "tensorflow/lite/kernels/internal/reference/integer_ops/conv_accel.h"
 #include "blocks.h"
+#include "gateware_constants.h"
 
 using hps_accel::Vector16;
 using hps_accel::multiply_accumulate;
@@ -71,8 +72,8 @@ void ConvPerChannel4x4(
   const int output_width = output_shape.Dims(2);
 
   TFLITE_DCHECK_LE(
-      (size_t) input_depth * filter_height * filter_width * output_depth / 4,
-      hps_accel::MAX_FILTER_WORDS);
+      input_depth * filter_height * filter_width * output_depth / 4,
+      MAX_FILTER_WORDS);
   hps_accel::LoadFilter(input_depth, output_depth, filter_data);
 
   for (int batch = 0; batch < batches; ++batch) {
@@ -88,8 +89,8 @@ void ConvPerChannel4x4(
             Offset(input_shape, batch, in_y_origin, in_x_origin, 0);
 
         TFLITE_DCHECK_LE(
-            (size_t) input_depth * filter_height * filter_width / 4,
-            hps_accel::MAX_INPUT_WORDS);
+            input_depth * filter_height * filter_width / 4,
+            MAX_INPUT_WORDS);
         hps_accel::LoadInput(input_width, input_depth, current_input_data);
 
         for (int out_channel = 0; out_channel < output_depth; ++out_channel) {

--- a/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv_accel.cc
+++ b/proj/hps_accel/src/tensorflow/lite/kernels/internal/reference/integer_ops/conv_accel.cc
@@ -69,7 +69,12 @@ void ConvPerChannel4x4(
 
   const int output_height = output_shape.Dims(1);
   const int output_width = output_shape.Dims(2);
+
+  TFLITE_DCHECK_LE(
+      (size_t) input_depth * filter_height * filter_width * output_depth / 4,
+      hps_accel::MAX_FILTER_WORDS);
   hps_accel::LoadFilter(input_depth, output_depth, filter_data);
+
   for (int batch = 0; batch < batches; ++batch) {
     for (int out_y = 0; out_y < output_height; ++out_y) {
       const int in_y_origin = out_y * stride_height;
@@ -81,7 +86,12 @@ void ConvPerChannel4x4(
         TFLITE_DCHECK_LE(in_x_origin + filter_width, input_width);
         const int8_t *current_input_data = input_data +
             Offset(input_shape, batch, in_y_origin, in_x_origin, 0);
+
+        TFLITE_DCHECK_LE(
+            (size_t) input_depth * filter_height * filter_width / 4,
+            hps_accel::MAX_INPUT_WORDS);
         hps_accel::LoadInput(input_width, input_depth, current_input_data);
+
         for (int out_channel = 0; out_channel < output_depth; ++out_channel) {
           int32_t acc = 0;
           for (int i = 0; i < filter_height * filter_width * input_depth / 16; ++i) {


### PR DESCRIPTION
This is largely a copy-paste from the input store implementation, with constants and memory depth tweaked, as a starting point. We expect the two implementations will start to diverge after this (particularly since the filter store will need to be shrunk to fit inside the fewer EBRAMs on HPS).

The tests in test_filter_store.py are independently implemented, which is why they look quite different to test_input_store.py.

This includes two x'ed out test cases which cover some edge cases around reset behaviour, which I think *should* work, but currently don't. It's probably not too important because we can easily avoid the problematic sequence of operations by just making sure we don't ever do that in software.