### PR TITLE
hps_accel/test_hps_cfu: turn off vcd file

### DIFF
--- a/proj/hps_accel/gateware/test_hps_cfu.py
+++ b/proj/hps_accel/gateware/test_hps_cfu.py
@@ -105,4 +105,4 @@ class HpsCfuTest(CfuTestBase):
                 yield ((GET, Constants.REG_INPUT_2, 0, 0), n+2)
                 yield ((GET, Constants.REG_INPUT_3, 0, 0), n+3)
 
-        self.run_ops(op_generator(), True)
+        self.run_ops(op_generator(), False)


### PR DESCRIPTION
Turns off VCD file generation - this should not have been checked in.

Signed-off-by: Alan Green <avg@google.com>