### PR TITLE
Switch Renode GH Action to a new repo

### DIFF
--- a/.github/workflows/test-projects.yml
+++ b/.github/workflows/test-projects.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Run tests
       timeout-minutes: 5
-      uses: antmicro/renode-actions/test-in-renode@main
+      uses: antmicro/renode-test-action@v1.0.0
       with:
         renode-version: '1.12.0+20210403git44d6786'
         tests-to-run: proj/${{ matrix.proj_name }}/build/renode/${{ matrix.target }}.robot


### PR DESCRIPTION
We created a new repo hosting a single renode-test action that we
suggest should be used from now on.

It's also versioned, so it's better than just referencing `main`