### PR TITLE
hps_accel: shrink filter store to 2048 words

### DIFF
--- a/proj/hps_accel/gateware/constants.py
+++ b/proj/hps_accel/gateware/constants.py
@@ -98,9 +98,7 @@ class Constants:
     # Size limits
 
     # Maximum number of words in filter
-    # TODO: this has to come down to ~ 2k and then change code to make batches
-    # to match
-    MAX_FILTER_WORDS = 16384
+    MAX_FILTER_WORDS = 2048
 
     # Maximum number of words in input
     MAX_INPUT_WORDS = 256


### PR DESCRIPTION
The first 18 convolution layers of the HPS model can still load all
their filter values in one go, outside the loop. The final 9 larger
layers will instead need to load the filter in batches inside the loop,
to fit within the 2048-word capacity.

This gets the filter store down to consuming 4 EBRAMs on HPS.