### PR TITLE
Enable builds of hps_accel using oxide toolchain

### DIFF
--- a/environment
+++ b/environment
@@ -35,3 +35,4 @@ pathadd() {
     fi
 }
 pathadd "${CFU_ROOT}/third_party/usr/local/bin"
+pathadd "${CFU_ROOT}/scripts"

--- a/scripts/parallel-nextpnr-nexus
+++ b/scripts/parallel-nextpnr-nexus
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs multiple nextpnrs, stopping on the first successful run
+
+# TODO: Better argument handling
+# TODO: Include support for device, timefailarg and ignoreloops parameters
+# TODO: Include support for setting seed (or baseseed in this case)
+if [[ $# -ne 4 ]]; then
+  echo "Expected 4 arguments"
+  exit 255
+fi
+
+JSON="$1"
+PDC="$2"
+RESULT_FASM="$3"
+SEED_COUNT="$4"
+
+4324declare -a CHILD_PIDS
+declare -A PID_TO_SEED
+
+# Launch a number of nextpnrs
+echo "$(basename $0): running ${SEED_COUNT} nextpnr-nexus instances."
+rm -rf runs 
+mkdir runs
+seed_base=$((RANDOM % 100 * 100))
+for s in $(seq ${SEED_COUNT}); do
+  seed=$((seed_base + s))
+  DIR="runs/seed-${seed}"
+  mkdir "${DIR}"
+  ( 
+    nextpnr-nexus \
+        --json "${JSON}" \
+        --pdc "${PDC}" \
+        --fasm "${DIR}/output.fasm" \
+        --device LIFCL-17-8UWG72C \
+        --seed "${seed}" 2>&1 | \
+      (while read line; do 
+        echo "$(date +%H:%M:%S) ${line}"; done
+      ) > "${DIR}/nextpnr-nexus.log"
+  ) &
+  PID=$!
+  CHILD_PIDS+=(${PID})
+  echo "Launched nextpnr with output to ${DIR}"
+  PID_TO_SEED[${PID}]="${seed}"
+done
+
+# Removes terminated PID from CHILD_PIDS variable
+update_pids() {
+  new_CHILD_PIDS=()
+  for p in "${CHILD_PIDS[@]}"; do
+    if [[ "${p}" -ne "${TERMINATED}" ]]; then
+      new_CHILD_PIDS+=("${p}")
+    fi
+  done
+  CHILD_PIDS=("${new_CHILD_PIDS[@]}")
+}
+
+# Wait for a child to finish then check for success or failure
+while [[ ${#CHILD_PIDS} -gt 1 ]]; do
+  wait -n -p TERMINATED "${CHILD_PIDS[@]}"
+  result=$?
+  update_pids
+  if [[ "${result}" -eq "0" ]]; then
+    # Child succeeded - copy result and finish
+    seed="${PID_TO_SEED[${TERMINATED}]}"
+    echo "SUCCESS: nextpnr with seed=${seed}"
+    cp "runs/seed-${seed}/output.fasm" $RESULT_FASM
+    cp "runs/seed-${seed}/nextpnr-nexus.log" nextpnr-nexus.log
+    # TODO: find a more elegant solution for halting all children
+    for p in "${CHILD_PIDS[@]}"; do pkill -P $p; done
+    exit 0
+  else
+    # Child failed - remove TERMINATED from list of PIDS
+    seed="${PID_TO_SEED[${TERMINATED}]}"
+    echo "FAIL: nextpnr with seed=${seed}"
+  fi
+done
+
+# No success found
+echo "All seeds failed"

--- a/soc/hps_proto2_platform.py
+++ b/soc/hps_proto2_platform.py
@@ -82,8 +82,8 @@ class _CRG(Module):
 
 
 class Platform(LatticePlatform):
-    # The NX-17 has a 450 MHz clock. Our system clock should be a divisor of that.
-    clk_divisor = 7
+    # The NX-17 has a 450 MHz oscillator. Our system clock should be a divisor of that.
+    clk_divisor = 12
     sys_clk_freq = int(450e6 / clk_divisor)
 
     def __init__(self, toolchain="radiant"):


### PR DESCRIPTION
Enable builds of hps_accel using oxide toolchain

Reduces clock divisor
Runs many nextpnr-nexus in parallel


Tested with

```
cd proj/hps_accel
time make PLATFORM=hps bitstream
```

For me this runs 54 separate copies of nextpnr and terminates in 14 minutes:

```
make[1]: Leaving directory '/usr/local/google/home/avg/src/CFU-Playground/soc'

real    14m17.820s
user    778m42.951s
sys     1m17.644s
```


