### PR TITLE
Separate perf CSRs from NPROFILE flag.

### DIFF
--- a/common/src/perf.cc
+++ b/common/src/perf.cc
@@ -49,8 +49,10 @@ void perf_print_all_counters() {
   for (int i = 0; i < NUM_PERF_COUNTERS; ++i) {
     perf_disable_counter(i);
   }
-  printf(" Counter |  Total | Starts | Average |     Raw\n");
-  printf("---------+--------+--------+---------+--------------\n");
+  if (NUM_PERF_COUNTERS > 0) {
+    printf(" Counter |  Total | Starts | Average |     Raw\n");
+    printf("---------+--------+--------+---------+--------------\n");
+  }
   for (int i = 0; i < NUM_PERF_COUNTERS; ++i) {
     unsigned total = perf_get_counter(i);
     unsigned starts = perf_get_start_count(i);

--- a/common/src/perf.h
+++ b/common/src/perf.h
@@ -24,7 +24,12 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_CPU_PERF_CSRS
 #define NUM_PERF_COUNTERS 8
+#else
+#define NUM_PERF_COUNTERS 0
+#endif
+
 
 extern unsigned CFU_start_counts[NUM_PERF_COUNTERS];
 
@@ -74,8 +79,7 @@ inline void perf_set_mcycle(unsigned cyc) {
 
 inline unsigned perf_get_counter(int counter_num) {
   unsigned count = 0;
-#ifndef NPROFILE
-#ifndef CONFIG_CPU_VARIANT_FOMU
+#ifdef CONFIG_CPU_PERF_CSRS
   switch (counter_num) {
     case 0:
       asm volatile("csrr %0, 0xB04" : "=r"(count));
@@ -104,14 +108,12 @@ inline unsigned perf_get_counter(int counter_num) {
     default:;
   }
 #endif
-#endif
   return count;
 }
 
 inline unsigned perf_get_counter_enable(int counter_num) {
   unsigned en = 0;
-#ifndef NPROFILE
-#ifndef CONFIG_CPU_VARIANT_FOMU
+#ifdef CONFIG_CPU_PERF_CSRS
   switch (counter_num) {
     case 0:
       asm volatile("csrr %0, 0xB05" : "=r"(en));
@@ -140,13 +142,11 @@ inline unsigned perf_get_counter_enable(int counter_num) {
     default:;
   }
 #endif
-#endif
   return en;
 }
 
 inline void perf_set_counter(int counter_num, unsigned count) {
-#ifndef NPROFILE
-#ifndef CONFIG_CPU_VARIANT_FOMU
+#ifdef CONFIG_CPU_PERF_CSRS
   switch (counter_num) {
     case 0:
       asm volatile("csrw 0xB04, %0" ::"r"(count));
@@ -175,15 +175,13 @@ inline void perf_set_counter(int counter_num, unsigned count) {
     default:;
   }
 #endif
-#endif
 }
 
 inline void perf_set_counter_enable(int counter_num, unsigned en) {
+#ifdef CONFIG_CPU_PERF_CSRS
   if (en) {
     CFU_start_counts[counter_num]++;
   }
-#ifndef NPROFILE
-#ifndef CONFIG_CPU_VARIANT_FOMU
   switch (counter_num) {
     case 0:
       asm volatile("csrw 0xB05, %0" ::"r"(en));
@@ -211,7 +209,6 @@ inline void perf_set_counter_enable(int counter_num, unsigned en) {
       break;
     default:;
   }
-#endif
 #endif
 }
 


### PR DESCRIPTION
Now acessing perf CSRs is controlled by a LiteX-defined
flag CONFIG_CPU_PERF_CSRS instead of NPROFILE.
This makes it safe to enable profiling on CPU variants
without perf CSRs (such as fomu and slim).

Signed-off-by: Tim Callahan <tcal@google.com>