### PR TITLE
Monkey patching for CPU variants incl. slim, perf.

### DIFF
--- a/proj/hps_accel/Makefile
+++ b/proj/hps_accel/Makefile
@@ -52,9 +52,6 @@ DEFINES += INCLUDE_MODEL_HPS
 RUN_MENU_ITEMS=1 1 c
 TEST_MENU_ITEMS=3 a
 
-# Ensure perf_csrs logic is present
-DEFINES += CONFIG_CPU_PERF_CSRS
-
 # Customise arguments to Litex:
 export EXTRA_LITEX_ARGS
 ifeq '$(TARGET)' 'digilent_arty'

--- a/proj/mnv2_first/Makefile
+++ b/proj/mnv2_first/Makefile
@@ -56,7 +56,7 @@ DEFINES += ACCEL_CONV
 # Used by soc/hps.mk
 # Choose the slimmer version of VexRiscv to fit with this large CFU
 ifeq 'hps' '$(PLATFORM)'
-export SLIM_CPU:=1
+export EXTRA_LITEX_ARGS='--cpu-variant=slim+cfu'
 endif
 
 include ../proj.mk

--- a/soc/board_specific_workflows/general.py
+++ b/soc/board_specific_workflows/general.py
@@ -18,7 +18,9 @@ import os
 from litex.soc.integration import builder
 from litex.soc.integration import soc as litex_soc
 from litex.soc.integration import soc_core
+from litex.soc.cores.cpu.vexriscv import core
 from typing import Callable
+from patch_cpu_variant import patch_cpu_variant
 
 
 class GeneralSoCWorkflow():
@@ -50,6 +52,7 @@ class GeneralSoCWorkflow():
         self.args = args
         self.soc_constructor = soc_constructor
         self.builder_constructor = builder_constructor or builder.Builder
+        patch_cpu_variant()
 
     def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
         """Utilizes self.soc_constructor to make a LiteXSoC.

--- a/soc/board_specific_workflows/ice40up5k.py
+++ b/soc/board_specific_workflows/ice40up5k.py
@@ -41,8 +41,9 @@ def patch_cpu_fomu_variant():
         if 'fomu' in self.variant:
             soc.add_config('CPU_DIV_UNIMPLEMENTED')
 
+            # Fomu variant has *no* Dcache.
             # This is here to avoid the dcache flush instruction (system.h).
-            soc.add_config('CPU_VARIANT_LITE')
+            soc.constants.pop('CONFIG_CPU_HAS_DCACHE', None)
 
     core.VexRiscv.add_soc_components = new_add_soc_components
 

--- a/soc/board_specific_workflows/ice40up5k.py
+++ b/soc/board_specific_workflows/ice40up5k.py
@@ -23,7 +23,7 @@ from litex.soc.integration import builder
 from typing import Callable
 
 
-def patch_cpu_variant():
+def patch_cpu_fomu_variant():
     """Monkey patches the fomu variant into LiteX."""
     core.CPU_VARIANTS.update({
         'fomu': 'VexRiscv_Fomu',
@@ -34,14 +34,10 @@ def patch_cpu_variant():
         'fomu+cfu': '-march=rv32im -mabi=ilp32 -mno-div',
     })
 
+    old_add_soc_components = core.VexRiscv.add_soc_components
+
     def new_add_soc_components(self, soc, soc_region_cls):
-        if 'debug' in self.variant:
-            soc.bus.add_slave('vexriscv_debug',
-                              self.debug_bus,
-                              region=soc_region_cls(
-                                  origin=soc.mem_map.get('vexriscv_debug'),
-                                  size=0x100,
-                                  cached=False))
+        old_add_soc_components(self, soc, soc_region_cls)
         if 'fomu' in self.variant:
             soc.add_config('CPU_DIV_UNIMPLEMENTED')
 
@@ -65,10 +61,10 @@ class Ice40UP5KWorkflow(general.GeneralSoCWorkflow):
                  warn: bool = True) -> None:
 
         # Remove if/when the new CPU variant is upstreamed.
-        patch_cpu_variant()
+        patch_cpu_fomu_variant()
 
         if warn and args.cpu_variant != 'fomu+cfu':
-            warnings.warn('Only fomu+cfu variant of Vexriscv supported for' +
+            warnings.warn('Only fomu+cfu variant of Vexriscv supported for ' +
                           f'{type(self).__name__}, not {args.cpu_variant}.\n' +
                           'Using fomu+cfu.')
         args.cpu_variant = 'fomu+cfu'

--- a/soc/board_specific_workflows/workflow_args.py
+++ b/soc/board_specific_workflows/workflow_args.py
@@ -64,7 +64,7 @@ def parse_workflow_args(input: List[str] = None) -> argparse.Namespace:
     parser.set_defaults(csr_csv='csr.csv',
                         uart_name='serial',
                         uart_baudrate=921600,
-                        cpu_variant='full+cfu+debug',
+                        cpu_variant='full+cfu',
                         with_etherbone=False)
     # Return only the known args
     if input:

--- a/soc/common_soc.py
+++ b/soc/common_soc.py
@@ -34,7 +34,7 @@ def get_soc_constructor(target: str) -> Callable[..., soc.LiteXSoC]:
 
 def main():
     parser = argparse.ArgumentParser(
-        'Determine purpose (load software or hardware).')
+        'Determine purpose (load software or hardware).', add_help=False)
     parser.add_argument('--software-load',
                         action='store_true',
                         help='Perform pre-lxterm loading procedures.')

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -54,7 +54,7 @@ endif
 endif
 
 ifdef SLIM_CPU
-LITEX_ARGS += --slim_cpu
+$(error SLIM_CPU no longer supported.   Instead use "EXTRA_LITEX_ARGS='--cpu-variant=slim+cfu'")
 endif
 
 PYRUN:=     $(CFU_ROOT)/scripts/pyrun

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -223,7 +223,7 @@ def main():
     parser.add_argument("--debug", action="store_true",
                         help="Enable debug mode")
     parser.add_argument("--slim_cpu", action="store_true",
-                        help="Use slimmer VexRiscv (required for mnv2_first)")
+                        help="DEPRECATED: use '--cpu-variant=slim+cfu' instead (Use slimmer VexRiscv (required for mnv2_first))")
     parser.add_argument("--build", action="store_true",
                         help="Whether to do a full build, including the bitstream")
     parser.add_argument("--toolchain", default="oxide",

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -235,6 +235,7 @@ def main():
                         action="store_false", default=True,
                         help="Use Litex minimal SPI flash instead of Litespi")
     parser.add_argument("--cpu-cfu", default=None, help="Specify file containing CFU Verilog module")
+    parser.add_argument("--cpu-variant", default=None, help="Which CPU variant to use")
     parser.add_argument("--execute-from-lram", action="store_true",
                         help="Make the CPU execute from integrated ROM stored in LRAM instead of flash")
     parser.add_argument("--integrated-rom-init", metavar="FILE",
@@ -248,7 +249,9 @@ def main():
         integrated_rom_init = []
 
     if args.cpu_cfu:
-        if args.slim_cpu:
+        if args.cpu_variant:
+            variant = args.cpu_variant
+        elif args.slim_cpu:
             variant = "slim+cfu+debug" if args.debug else "slim+cfu"
         else:
             variant = "full+cfu+debug" if args.debug else "full+cfu"
@@ -260,7 +263,10 @@ def main():
                      execute_from_lram=args.execute_from_lram,
                      integrated_rom_init=integrated_rom_init)
     else:
-        variant = "full+debug" if args.debug else "full"
+        if args.cpu_variant:
+            variant = args.cpu_variant
+        else:
+            variant = "full+debug" if args.debug else "full"
         soc = HpsSoC(Platform(args.toolchain),
                      debug=args.debug,
                      litespi_flash=args.litespi_flash,

--- a/soc/patch_cpu_variant.py
+++ b/soc/patch_cpu_variant.py
@@ -36,7 +36,7 @@ def patch_cpu_variant():
     print("general patch:\n", core.CPU_VARIANTS)
 
 
-    ########### ADD code to existing add_soc_components #######
+    ########### ADD code to existing add_soc_components() #######
     old_add_soc_components = core.VexRiscv.add_soc_components
 
     def new_add_soc_components(self, soc, soc_region_cls):

--- a/soc/patch_cpu_variant.py
+++ b/soc/patch_cpu_variant.py
@@ -19,15 +19,16 @@
 
 from litex.soc.cores.cpu.vexriscv import core
 
+
 def patch_cpu_variant():
     """Monkey patches custom variants into LiteX."""
     core.CPU_VARIANTS.update({
-        'slim+cfu':       'VexRiscv_SlimCfu',
-        'slim+cfu+debug': 'VexRiscv_SlimCfuDebug',
-        'perf+cfu':       'VexRiscv_PerfCfu',
-        'perf+cfu+debug': 'VexRiscv_PerfCfuDebug',
-        'slimperf+cfu':       'VexRiscv_SlimPerfCfu',
-        'slimperf+cfu+debug': 'VexRiscv_SlimPerfCfuDebug',
+        'slim+cfu':             'VexRiscv_SlimCfu',
+        'slim+cfu+debug':       'VexRiscv_SlimCfuDebug',
+        'perf+cfu':             'VexRiscv_PerfCfu',
+        'perf+cfu+debug':       'VexRiscv_PerfCfuDebug',
+        'slimperf+cfu':         'VexRiscv_SlimPerfCfu',
+        'slimperf+cfu+debug':   'VexRiscv_SlimPerfCfuDebug',
     })
     core.GCC_FLAGS.update({
         'slim+cfu':             '-march=rv32im -mabi=ilp32',
@@ -38,7 +39,6 @@ def patch_cpu_variant():
         'slimperf+cfu+debug':   '-march=rv32im -mabi=ilp32',
     })
     print("general patch:\n", core.CPU_VARIANTS)
-
 
     ########### ADD code to existing add_soc_components() #######
     old_add_soc_components = core.VexRiscv.add_soc_components

--- a/soc/patch_cpu_variant.py
+++ b/soc/patch_cpu_variant.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Disable pylint's E1101, which breaks completely on migen
+# pylint:disable=E1101
+
+from litex.soc.cores.cpu.vexriscv import core
+
+def patch_cpu_variant():
+    """Monkey patches custom variants into LiteX."""
+    core.CPU_VARIANTS.update({
+        'slim+cfu':       'VexRiscv_SlimCfu',
+        'slim+cfu+debug': 'VexRiscv_SlimCfuDebug',
+        'perf+cfu':       'VexRiscv_PerfCfu',
+        'perf+cfu+debug': 'VexRiscv_PerfCfuDebug',
+    })
+    core.GCC_FLAGS.update({
+        'slim+cfu':             '-march=rv32im -mabi=ilp32',
+        'slim+cfu+debug':       '-march=rv32im -mabi=ilp32',
+        'perf+cfu':             '-march=rv32im -mabi=ilp32',
+        'perf+cfu+debug':       '-march=rv32im -mabi=ilp32',
+    })
+    print("general patch:\n", core.CPU_VARIANTS)
+
+
+    ########### ADD code to existing add_soc_components #######
+    old_add_soc_components = core.VexRiscv.add_soc_components
+
+    def new_add_soc_components(self, soc, soc_region_cls):
+        old_add_soc_components(self, soc, soc_region_cls)
+        if 'perf' in self.variant:
+            soc.add_config('CPU_PERF_CSRS', 8)
+
+    core.VexRiscv.add_soc_components = new_add_soc_components

--- a/soc/patch_cpu_variant.py
+++ b/soc/patch_cpu_variant.py
@@ -26,12 +26,16 @@ def patch_cpu_variant():
         'slim+cfu+debug': 'VexRiscv_SlimCfuDebug',
         'perf+cfu':       'VexRiscv_PerfCfu',
         'perf+cfu+debug': 'VexRiscv_PerfCfuDebug',
+        'slimperf+cfu':       'VexRiscv_SlimPerfCfu',
+        'slimperf+cfu+debug': 'VexRiscv_SlimPerfCfuDebug',
     })
     core.GCC_FLAGS.update({
         'slim+cfu':             '-march=rv32im -mabi=ilp32',
         'slim+cfu+debug':       '-march=rv32im -mabi=ilp32',
         'perf+cfu':             '-march=rv32im -mabi=ilp32',
         'perf+cfu+debug':       '-march=rv32im -mabi=ilp32',
+        'slimperf+cfu':         '-march=rv32im -mabi=ilp32',
+        'slimperf+cfu+debug':   '-march=rv32im -mabi=ilp32',
     })
     print("general patch:\n", core.CPU_VARIANTS)
 


### PR DESCRIPTION
Now there is monkey patching both at the general level, plus more
that is ice40-specific.

In both cases, when updating core.VexRiscv.add_soc_components, 
call the previous version rather than completely replacing it.

Signed-off-by: Tim Callahan <tcal@google.com>