### PR TITLE
hps_accel: reduce clock on Arty to 80MHz

### DIFF
--- a/proj/hps_accel/Makefile
+++ b/proj/hps_accel/Makefile
@@ -52,6 +52,13 @@ DEFINES += INCLUDE_MODEL_HPS
 RUN_MENU_ITEMS=1 1 c
 TEST_MENU_ITEMS=3 a
 
+# Customise arguments to Litex:
+export EXTRA_LITEX_ARGS
+ifeq '$(TARGET)' 'digilent_arty'
+# Cannot meet timing at 100MHz, reduce to 80MHz
+EXTRA_LITEX_ARGS += --sys-clk-freq 80000000
+endif
+
 BUILD_DIR_EXTRA_DEP = $(BUILD_DIR)/src/gateware_constants.h
 include ../proj.mk
 

--- a/soc/board_specific_workflows/general.py
+++ b/soc/board_specific_workflows/general.py
@@ -71,6 +71,8 @@ class GeneralSoCWorkflow():
         base_soc_kwargs.update(soc_core.soc_core_argdict(self.args))
         if self.args.toolchain:
             base_soc_kwargs['toolchain'] = self.args.toolchain
+        if self.args.sys_clk_freq:
+            base_soc_kwargs['sys_clk_freq'] = self.args.sys_clk_freq
 
         base_soc_kwargs.update(kwargs)
         return self.soc_constructor(**base_soc_kwargs)

--- a/soc/board_specific_workflows/workflow_args.py
+++ b/soc/board_specific_workflows/workflow_args.py
@@ -38,6 +38,8 @@ def parse_workflow_args(input: List[str] = None) -> argparse.Namespace:
     parser.add_argument('--toolchain',
                         help=('Specify toolchain for implementing '
                               'gateware (\'vivado\' or \'symbiflow\')'))
+    parser.add_argument('--sys-clk-freq', type=float,
+                        help='System clock frequency')
     builder_args(parser)
     soc_core_args(parser)
     vivado_build_args(parser)


### PR DESCRIPTION
Vivado has been unable to make timing for `proj/hps_accel` on the `main` branch since commit c55db9a9, but we didn't notice due to #254. Reducing the clock to 80MHz gets it passing again.