### PR TITLE
Fix #260, remove unnecessary copy of software.elf to ./renode/.

### DIFF
--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -167,7 +167,6 @@ TARGET_REPL := $(BUILD_DIR)/renode/$(TARGET)_generated.repl
 .PHONY:	renode 
 renode: renode-scripts
 	@echo Running interactively under renode
-	$(COPY) $(SOFTWARE_ELF) $(PROJ_DIR)/renode/
 	pushd $(PROJ_DIR)/build/renode/ && $(RENODE_DIR)/renode -e "s @$(TARGET).resc" && popd
 
 .PHONY: renode-scripts


### PR DESCRIPTION
Fixes #260.    There was a copy in the make recipe from the old way of doing things,
and it would cause an error when there was not already a ./renode directory.

Signed-off-by: Tim Callahan <tcal@google.com>