### PR TITLE
Renode expect support

### DIFF
--- a/common/interact.expect
+++ b/common/interact.expect
@@ -19,6 +19,11 @@ if { [lindex $argv 0] == "s" } {
   set choices [lrange $argv 1 end]
   set simpid [spawn make PLATFORM=sim load]
   send_user "Sim PID $simpid\n"
+} elseif { [lindex $argv 0] == "r" } {
+  set choices [lrange $argv 1 end]
+  set simpid [spawn make TARGET=$env(TARGET) renode-headless]
+  send_user "Sim PID $simpid\n"
+  send "\n"
 } else {
   spawn ../../soc/bin/litex_term --speed [lindex $argv 2] --kernel [lindex $argv 0] [lindex $argv 1]
   set choices [lrange $argv 3 end]

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -164,10 +164,14 @@ endif
 
 TARGET_REPL := $(BUILD_DIR)/renode/$(TARGET)_generated.repl
 
-.PHONY:	renode 
+.PHONY:	renode
 renode: renode-scripts
 	@echo Running interactively under renode
 	pushd $(PROJ_DIR)/build/renode/ && $(RENODE_DIR)/renode -e "s @$(TARGET).resc" && popd
+
+.PHONY:	renode-headless
+renode-headless: renode-scripts
+	pushd $(PROJ_DIR)/build/renode/ && $(RENODE_DIR)/renode --console --disable-xwt --hide-log -e "s @$(TARGET).resc ; uart_connect sysbus.uart" && popd
 
 .PHONY: renode-scripts
 renode-scripts: $(SOFTWARE_ELF)
@@ -253,7 +257,7 @@ endif
 litex-software: $(CFU_VERILOG)
 	$(SOC_MK) litex-software
 
-RUN_TARGETS := load unit run
+RUN_TARGETS := load unit run unit-renode run-renode
 .PHONY: $(RUN_TARGETS) prog bitstream
 
 ifneq 'sim' '$(PLATFORM)'
@@ -272,6 +276,14 @@ run: $(SOFTWARE_BIN)
 unit: $(SOFTWARE_BIN)
 	@echo Running unit test on board
 	$(BUILD_DIR)/interact.expect $(SOFTWARE_BIN) $(TTY) $(UART_SPEED) $(TEST_MENU_ITEMS) |& tee $(UNITTEST_LOG)
+
+run-renode: $(SOFTWARE_ELF) renode-scripts
+	@echo Running automated test in Renode
+	$(BUILD_DIR)/interact.expect r $(RUN_MENU_ITEMS) |& tee $(SOFTWARE_LOG)
+
+unit-renode: $(SOFTWARE_ELF) renode-scripts
+	@echo Running unit test in Renode simulation
+	$(BUILD_DIR)/interact.expect r $(TEST_MENU_ITEMS) |& tee $(UNITTEST_LOG)
 
 ifeq 'hps' '$(PLATFORM)'
 load: $(SOFTWARE_BIN)


### PR DESCRIPTION
This adds 3 targets:

- renode-headless, which just runs Renode in a single console
- unit-renode, same as `make unit` but running in Renode
- run-renode, similar to `make run`, added for completeness

All of these accept the `TARGET` variable to select the actual target.

Closes #271

