### PR TITLE
demangle C++ symbols in disassembler dumps

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -150,8 +150,8 @@ $(SOFTWARE_ELF): $(OBJECTS) $(LDSCRIPTS)
 	$(QUIET) echo "  LD       $@"
 	$(QUIET) $(CXX) $(OBJECTS) $(LFLAGS) -o $@
 	$(QUIET) echo "  OBJDUMP  $@.dis"
-	$(QUIET) $(OBJDUMP) -d -S -l $(SOFTWARE_ELF) | $(FIX_CFU_DIS) > $(SOFTWARE_ELF).dis_with_source
-	$(QUIET) $(OBJDUMP) -d $(SOFTWARE_ELF) | $(FIX_CFU_DIS) > $(SOFTWARE_ELF).dis
+	$(QUIET) $(OBJDUMP) -d -S -l $(SOFTWARE_ELF) | c++filt | $(FIX_CFU_DIS) > $(SOFTWARE_ELF).dis_with_source
+	$(QUIET) $(OBJDUMP) -d $(SOFTWARE_ELF) | c++filt | $(FIX_CFU_DIS) > $(SOFTWARE_ELF).dis
 	$(QUIET) echo "  OBJDUMP  $@.sym"
 	$(QUIET) $(OBJDUMP) -s $(SOFTWARE_ELF) > $(SOFTWARE_ELF).sym
 


### PR DESCRIPTION
The software.elf.dis and software.elf.dis_with_source disassembler dumps
refer to a lot of C++ symbols from TFLM. The dump is easier to read if
we pass it through c++filt to demangle the C++ symbol names.

Before:

```
...
40072f5c <_ZN6tflite21reference_integer_ops17ConvPerChannel4x4ERKNS_10ConvParamsEPKlS5_RKNS_12RuntimeShapeEPKaS8_SA_S8_S5_S8_Pa>:
40072f5c:       f7010113                addi      sp,sp,-144
40072f60:       0006a883                lw        a7,0(a3)
40072f64:       00068e13                mv        t3,a3
...
40073178:       3ef7860b                cfu[31,0]  a2, a5, a5
4007317c:       60f7960b                cfu[48,1]  a2, a5, a5
40073180:       00170713                addi      a4,a4,1
40073184:       00c686b3                add       a3,a3,a2
40073188:       fe8718e3                bne       a4,s0,40073178 <_ZN6tflite21reference_integer_ops17ConvPerChannel4x4ERKNS_10ConvParamsEPKlS5_RKNS_12RuntimeShapeEPKaS8_SA_S8_S5_S8_Pa+0x21c>
...
```

After:

```
...
40072f5c <tflite::reference_integer_ops::ConvPerChannel4x4(tflite::ConvParams const&, long const*, long const*, tflite::RuntimeShape const&, signed char const*, tflite::RuntimeShape const&, signed char const*, tflite::RuntimeShape const&, long const*, tflite::RuntimeShape const&, signed char*)>:
40072f5c:       f7010113                addi      sp,sp,-144
40072f60:       0006a883                lw        a7,0(a3)
40072f64:       00068e13                mv        t3,a3
...
40073178:       3ef7860b                cfu[31,0]  a2, a5, a5
4007317c:       60f7960b                cfu[48,1]  a2, a5, a5
40073180:       00170713                addi      a4,a4,1
40073184:       00c686b3                add       a3,a3,a2
40073188:       fe8718e3                bne       a4,s0,40073178 <tflite::reference_integer_ops::ConvPerChannel4x4(tflite::ConvParams const&, long const*, long const*, tflite::RuntimeShape const&, signed char const*, tflite::RuntimeShape const&, signed char const*, tflite::RuntimeShape const&, long const*, tflite::RuntimeShape const&, signed char*)+0x21c>
...
```