### PR TITLE
Remove all instances of the payload_response_ok signal

### DIFF
--- a/common/renode-verilator-integration/sim_main.cpp
+++ b/common/renode-verilator-integration/sim_main.cpp
@@ -44,7 +44,6 @@ RenodeAgent *Init() {
     bus->req_data1 = (uint32_t *)&top->cmd_payload_inputs_1;
     bus->resp_valid = &top->rsp_valid;
     bus->resp_ready = &top->rsp_ready;
-    bus->resp_ok = &top->rsp_payload_response_ok;
     bus->resp_data = (uint32_t *)&top->rsp_payload_outputs_0;
     bus->rst = &top->reset;
     bus->clk = &top->clk;

--- a/docs/source/step-by-step.rst
+++ b/docs/source/step-by-step.rst
@@ -543,7 +543,6 @@ are high.
     CPU                                 CFU
         <--- rsp_valid ---------------<
         >--- rsp_ready --------------->
-        <--- rsp_response_ok ---------<
         <--- rsp_outputs_0[31:0] -----<
 
 With the previous specification in mind, here's an implementation of our
@@ -559,7 +558,6 @@ SIMD multiply-and-accumulate instruction:
       input      [31:0]   cmd_payload_inputs_1,
       output reg          rsp_valid,
       input               rsp_ready,
-      output              rsp_payload_response_ok,
       output reg [31:0]   rsp_payload_outputs_0,
       input               reset,
       input               clk
@@ -582,7 +580,6 @@ SIMD multiply-and-accumulate instruction:
     
       // Only not ready for a command when we have a response.
       assign cmd_ready = ~rsp_valid;
-      assign rsp_payload_response_ok = 1'b1;
     
       always @(posedge clk) begin
         if (reset) begin

--- a/proj/example_cfu_v/cfu.v
+++ b/proj/example_cfu_v/cfu.v
@@ -22,7 +22,6 @@ module Cfu (
   input      [31:0]   cmd_payload_inputs_1,
   output              rsp_valid,
   input               rsp_ready,
-  output              rsp_payload_response_ok,
   output     [31:0]   rsp_payload_outputs_0,
   input               clk,
   input               reset
@@ -30,7 +29,6 @@ module Cfu (
 
   assign rsp_valid = cmd_valid;
   assign cmd_ready = rsp_ready;
-  assign rsp_payload_response_ok = 1'b1;
 
   //  byte sum (unsigned)
   wire [31:0] cfu0;

--- a/proj/kws_micro_accel/cfu.sv
+++ b/proj/kws_micro_accel/cfu.sv
@@ -26,7 +26,6 @@ module Cfu (
   input logic [31:0] cmd_payload_inputs_1,
 
   // CFU output signals
-  output logic        rsp_payload_response_ok,
   output logic [31:0] rsp_payload_outputs_0,
 
   // CFU <---> CPU handshaking
@@ -76,7 +75,6 @@ module Cfu (
 
   // Only not ready for a command when we have a response.
   assign cmd_ready = ~rsp_valid;
-  assign rsp_payload_response_ok = '1;
 
   // Single cycle CFU handshaking.
   always_ff @(posedge clk) begin

--- a/proj/proj_template_v/cfu.v
+++ b/proj/proj_template_v/cfu.v
@@ -22,7 +22,6 @@ module Cfu (
   input      [31:0]   cmd_payload_inputs_1,
   output              rsp_valid,
   input               rsp_ready,
-  output              rsp_payload_response_ok,
   output     [31:0]   rsp_payload_outputs_0,
   input               reset,
   input               clk
@@ -31,7 +30,6 @@ module Cfu (
   // Trivial handshaking for a combinational CFU
   assign rsp_valid = cmd_valid;
   assign cmd_ready = rsp_ready;
-  assign rsp_payload_response_ok = 1'b1;
 
   //
   // select output -- note that we're not fully decoding the 3 function_id bits

--- a/python/nmigen_cfu/cfu.py
+++ b/python/nmigen_cfu/cfu.py
@@ -161,7 +161,6 @@ class Cfu(SimpleElaboratable):
         input      [31:0]   cmd_payload_inputs_1,
         output              rsp_valid,
         input               rsp_ready,
-        output              rsp_payload_response_ok,
         output     [31:0]   rsp_payload_outputs_0,
         input               clk
         input               reset
@@ -176,7 +175,6 @@ class Cfu(SimpleElaboratable):
         self.cmd_in1 = Signal(32, name='cmd_payload_inputs_1')
         self.rsp_valid = Signal(name='rsp_valid')
         self.rsp_ready = Signal(name='rsp_ready')
-        self.rsp_ok = Signal(name='rsp_payload_response_ok')
         self.rsp_out = Signal(32, name='rsp_payload_outputs_0')
         self.reset = Signal(name='reset')
         self.ports = [
@@ -187,7 +185,6 @@ class Cfu(SimpleElaboratable):
             self.cmd_in1,
             self.rsp_valid,
             self.rsp_ready,
-            self.rsp_ok,
             self.rsp_out,
             self.reset
         ]
@@ -227,9 +224,6 @@ class Cfu(SimpleElaboratable):
         current_function_id = Signal(3)
         current_function_done = Signal()
         stored_output = Signal(32)
-
-        # Response is always OK.
-        m.d.comb += self.rsp_ok.eq(1)
 
         instructions = self.__build_instructions(m)
         instruction_outputs = Array(Signal(32) for _ in range(8))
@@ -328,8 +322,6 @@ class CfuTestBase(TestBase):
                 yield self.dut.rsp_ready.eq(0)
 
                 # Ensure no errors, and output as expected
-                ok = (yield self.dut.rsp_ok)
-                self.assertTrue(ok, f"op{n} response ok")
                 if expected is not None:
                     actual = (yield self.dut.rsp_out)
                     self.assertEqual(actual, expected & 0xffff_ffff,

--- a/python/nmigen_cfu/test_cfu.py
+++ b/python/nmigen_cfu/test_cfu.py
@@ -250,10 +250,6 @@ class _CfuTest(TestBase):
                     self.assertEqual((yield self.dut.rsp_out), exp_result)
                 if exp_rsp_valid is not None:
                     self.assertEqual((yield self.dut.rsp_valid), exp_rsp_valid)
-                    # We don't currently support returning non-OK responses, so
-                    # if our response is valid, it must be OK.
-                    if exp_rsp_valid:
-                        self.assertTrue((yield self.dut.rsp_ok))
                 if exp_cmd_ready is not None:
                     self.assertEqual((yield self.dut.cmd_ready), exp_cmd_ready)
                 yield

--- a/soc/cfu/Cfu.v
+++ b/soc/cfu/Cfu.v
@@ -22,7 +22,6 @@ module Cfu (
   input      [31:0]   cmd_payload_inputs_1,
   output              rsp_valid,
   input               rsp_ready,
-  output              rsp_payload_response_ok,
   output     [31:0]   rsp_payload_outputs_0,
   input               clk,
   input               reset
@@ -30,7 +29,6 @@ module Cfu (
 
   assign rsp_valid = cmd_valid;
   assign cmd_ready = rsp_ready;
-  assign rsp_payload_response_ok = 1'b1;
 
   //  byte sum (unsigned)
   wire [31:0] cfu0;


### PR DESCRIPTION
Since https://github.com/enjoy-digital/litex/pull/1039 was merged, remove all mentions and instances of this signal from the documentation and source code.