### PR TITLE
hps_accel: fix the on-device tests for the macc unit

### DIFF
--- a/proj/hps_accel/src/blocks_test.cc
+++ b/proj/hps_accel/src/blocks_test.cc
@@ -58,6 +58,7 @@ bool test_multiply(Vector16 input, Vector16 filter, int32_t input_offset,
   hps_accel::LoadInputOffset(input_offset);
   hps_accel::LoadFilter(1, 1, reinterpret_cast<const int8_t*>(filter.values));
   hps_accel::LoadInput(1, 4, reinterpret_cast<const int8_t*>(input.values));
+  hps_accel::AdvanceFilterInput();
   int32_t actual = multiply_accumulate();
   if (actual == expected) {
     return true;


### PR DESCRIPTION
This line was accidentally dropped in commit 7fd3e19a. We need it due to
commit 8f308c35.