### PR TITLE
hps: router1, no abc9, 64MHz

### DIFF
--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -39,7 +39,8 @@ LITEX_ARGS= --output-dir $(OUT_DIR) \
         --csr-json $(OUT_DIR)/csr.json $(CFU_ARGS) $(EXTRA_LITEX_ARGS)
 
 # Open source toolchain (Yosys + Nextpnr) is used by default
-LITEX_ARGS += --yosys-abc9
+# Avoid abc9 temporarily to work around https://github.com/google/CFU-Playground/issues/306
+#LITEX_ARGS += --yosys-abc9
 ifndef IGNORE_TIMING
 LITEX_ARGS += --nextpnr-timingstrict
 endif

--- a/soc/hps_proto2_platform.py
+++ b/soc/hps_proto2_platform.py
@@ -110,7 +110,7 @@ _oxide_router1_build_template = [
 class Platform(LatticePlatform):
     # The NX-17 has a 450 MHz oscillator. Our system clock should be a divisor
     # of that.
-    clk_divisor = 12
+    clk_divisor = 7
     sys_clk_freq = int(450e6 / clk_divisor)
 
     def __init__(self, toolchain="radiant", parallel_pnr=False):


### PR DESCRIPTION
This is the configuration I am using to get numbers in our tracking spreadsheet.

Alan, you may prefer to keep the parallel router2 runs by default? I found it unnecessary but maybe it gives better results? I note that the parallel-nextpnr script doesn't look for a seed that gives the *best* result, just whichever one completes first.