### PR TITLE
Remove pin from nextpnr-nexus since default 'main' is now correct.

### DIFF
--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - litex-hub::flterm
   - litex-hub::openocd
   - litex-hub::verilator
-  - litex-hub::nextpnr-nexus=v0.0_3810_gd9a71083
+  - litex-hub::nextpnr-nexus
   - litex-hub::yosys
   - python=3.7
   - pip


### PR DESCRIPTION
Signed-off-by: Tim Callahan <tcal@google.com>