### PR TITLE
hps: SPI DDR, 64MHz, nextpnr timing reports, consistent software building

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -116,7 +116,7 @@ LFLAGS     := \
 	-Wl,--build-id=none 
 	
 
-find_srcs = $(shell find $(SRC_DIR) -name \*.$(1))
+find_srcs = $(shell find $(SRC_DIR) -name \*.$(1) | LC_ALL=C sort)
 CSOURCES   := $(call find_srcs,c) 
 CPPSOURCES := $(call find_srcs,cpp)
 CCSOURCES  := $(call find_srcs,cc) 
@@ -195,4 +195,4 @@ $(OBJECTS): | $(MODEL_INCS) $(DATA_INCS)
 	$(QUIET) echo "  AS  $(notdir $<)	$(notdir $@)"
 	$(QUIET) $(CC) -x assembler-with-cpp -c $< $(CFLAGS) -o $@ -MMD
 
-include $(shell find src -name *.d)
+include $(call find_srcs,d)

--- a/proj/hps_accel/Makefile
+++ b/proj/hps_accel/Makefile
@@ -61,6 +61,7 @@ TEST_MENU_ITEMS=3 q
 
 # Customise arguments to Litex:
 export EXTRA_LITEX_ARGS
+EXTRA_LITEX_ARGS += --cpu-variant=slim+cfu
 ifeq '$(TARGET)' 'digilent_arty'
 # Cannot meet timing at 100MHz, reduce to 75MHz
 EXTRA_LITEX_ARGS += --sys-clk-freq 75000000

--- a/python/nmigen_cfu/cfu.py
+++ b/python/nmigen_cfu/cfu.py
@@ -259,7 +259,9 @@ class Cfu(SimpleElaboratable):
                     m.d.sync += stored_function_id.eq(
                         self.cmd_function_id[:3])
                     m.d.comb += instruction_starts[current_function_id].eq(1)
-                    check_instruction_done()
+                    m.d.sync += stored_output.eq(
+                        instruction_outputs[current_function_id])
+                    m.next = "WAIT_INSTRUCTION"
             with m.State("WAIT_INSTRUCTION"):
                 # An instruction is executing on the CFU. We're waiting until it
                 # completes.

--- a/scripts/nextpnr-timing.py
+++ b/scripts/nextpnr-timing.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import json
+import argparse
+
+arg = argparse.ArgumentParser()
+
+arg.add_argument('file', help='JSON timing report')
+arg.add_argument('--src', default='', help='Source name')
+arg.add_argument('--dst', default='', help='Destination name')
+arg.add_argument('--results', default=100, type=int, help='Number of paths reported')
+arg.add_argument('--tgt-len', default=0.0, type=float, help='List paths that are longer than this value (in ns)')
+
+args = vars(arg.parse_args())
+
+data = dict()
+
+with open(args['file'], 'r') as file:
+    data = json.load(file)
+
+paths = []
+
+for net in data['detailed_net_timings']:
+    if args['src'] in net['driver']:
+        src = net['driver']
+        for endpoint in net['endpoints']:
+            if args['dst'] in endpoint['cell']:
+                dly = endpoint['delay']
+                tgt = endpoint['cell']
+                if args['tgt_len'] < dly:
+                    paths.append((src, tgt, dly))
+
+paths.sort(key=lambda tup: tup[2], reverse=True)
+
+for path in paths[:args['results']]:
+    src, tgt, dly = path
+    print(f"{src} -> {tgt} : {dly}")

--- a/scripts/parallel-nextpnr-nexus
+++ b/scripts/parallel-nextpnr-nexus
@@ -62,6 +62,8 @@ for s in $(seq ${SEED_COUNT}); do
         --pdc "${PDC}" \
         --fasm "${DIR}/output.fasm" \
         --device LIFCL-17-8UWG72C \
+        --report="${DIR}/report.json" \
+        --detailed-timing-report \
         --seed "${seed}" 2>&1 | \
       (while read line; do 
         echo "$(date +%H:%M:%S) ${line}"; done
@@ -95,6 +97,7 @@ while [[ ${#CHILD_PIDS} -gt 1 ]]; do
     echo "SUCCESS: nextpnr with seed=${seed}"
     cp "runs/seed-${seed}/output.fasm" $RESULT_FASM
     cp "runs/seed-${seed}/nextpnr-nexus.log" nextpnr-nexus.log
+    cp "runs/seed-${seed}/report.json" report.json
     # TODO: find a more elegant solution for halting all children
     for p in "${CHILD_PIDS[@]}"; do pkill -P $p; done
     exit 0

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -38,8 +38,6 @@ OUT_DIR:=   build/$(SOC_NAME)
 LITEX_ARGS= --output-dir $(OUT_DIR) \
         --csr-json $(OUT_DIR)/csr.json $(CFU_ARGS) $(EXTRA_LITEX_ARGS)
 
-# Open source toolchain (Yosys + Nextpnr) is used by default
-LITEX_ARGS += --yosys-abc9
 ifndef IGNORE_TIMING
 LITEX_ARGS += --nextpnr-timingstrict
 endif

--- a/soc/hps_proto2_platform.py
+++ b/soc/hps_proto2_platform.py
@@ -94,7 +94,7 @@ _build_template = [
 class Platform(LatticePlatform):
     # The NX-17 has a 450 MHz oscillator. Our system clock should be a divisor
     # of that.
-    clk_divisor = 12
+    clk_divisor = 7
     sys_clk_freq = int(450e6 / clk_divisor)
 
     def __init__(self, toolchain="radiant", parallel_pnr=True):

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -161,7 +161,9 @@ class HpsSoC(LiteXSoC):
         self.submodules.spiflash_phy = LiteSPIPHY(
             self.platform.request("spiflash4x"),
             GD25LQ128D(Codes.READ_1_1_4),
-            default_divisor=0)
+            default_divisor=1,
+            rate="1:2",
+            extra_latency=1)
         self.submodules.spiflash_mmap  = LiteSPI(phy=self.spiflash_phy,
             mmap_endianness = self.cpu.endianness)
         self.csr.add("spiflash_mmap")


### PR DESCRIPTION
This PR adds a few changes:

* Updates HPS SoC definiton to use faster LiteSPI mode of operation (the one that uses DDR IO buffers)
* Makes software builds consistent by sorting lists of sources (without that different PCs built different binaries from the same sources)
* Disables abc9 to work around issue from #306
* Modifies Cfu code to generate  `rsp_valid` using only registered values inside Cfu (to remove direct path from `cmd_valid` to `rsp_valid`)
* Increases HPS `sys_clk` frequency to 64MHz
* Modifies `parallel-nextpnr-nexus` to generate JSON timing report and provides `scripts/nextpnr-timing.py` which can be used to for example list paths longer than 13ns
```
./scripts/nextpnr-timing.py soc/build/hps.hps_accel/gateware/report.json --tgt-len 13
VexRiscv.IBusCachedPlugin_fetchPc_pc_WIDEFN9_Z_5$widefn_comb[0]$ -> VexRiscv.IBusCachedPlugin_fetchPc_pcReg_FD1P3IX_Q_3 : 13.645999908447266
VexRiscv.IBusCachedPlugin_cache._zz_fetchStage_read_banksValue_0_dataMem_WIDEFN9_Z_6$widefn_comb[0]$ -> VexRiscv.IBusCachedPlugin_cache.ways_0_tags.0.0.0 : 13.229000091552734
VexRiscv.IBusCachedPlugin_cache._zz_fetchStage_read_banksValue_0_dataMem_WIDEFN9_Z_7$widefn_comb[0]$ -> VexRiscv.IBusCachedPlugin_cache.banks_0.1.0.0 : 13.218999862670898
VexRiscv.CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr_FD1P3IX_Q_31_D_WIDEFN9_Z$widefn_comb[0]$ -> VexRiscv.CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr_FD1P3IX_Q_31 : 13.107000350952148
VexRiscv.IBusCachedPlugin_cache._zz_fetchStage_read_banksValue_0_dataMem_WIDEFN9_Z_7$widefn_comb[0]$ -> VexRiscv.IBusCachedPlugin_fetchPc_pcReg_FD1P3IX_Q_24 : 13.079000473022461
```

With those changes I was able to get a build that reached 73.28Mhz (using seed `3101` and a modified Vex_SlimCfu with 4KiB of ICache)
```
11:59:32 Info: Max frequency for clock 'por_clk$glb_clk': 73.28 MHz (PASS at 70.72 MHz)
```
and works correctly on HW
```
Running Golden tests (check for expected outputs)
Testing input cat: Set 76800 bytes at 0x40002c60
[...]
Perf counters not enabled.
   179M (   179150449) cycles total
OK
Testing input diagram: Set 76800 bytes at 0x40002c60
[...]
Perf counters not enabled.
   179M (   179160683) cycles total
OK
Testing input zeroes: Zeroed 76800 bytes at 0x40002c60
[...]
Perf counters not enabled.
   179M (   179060545) cycles total
OK
OK   Golden tests passed
```