### PR TITLE
hps_accel: use slim CPU

### DIFF
--- a/proj/hps_accel/Makefile
+++ b/proj/hps_accel/Makefile
@@ -61,6 +61,7 @@ TEST_MENU_ITEMS=3 q
 
 # Customise arguments to Litex:
 export EXTRA_LITEX_ARGS
+EXTRA_LITEX_ARGS += --cpu-variant slim+cfu
 ifeq '$(TARGET)' 'digilent_arty'
 # Cannot meet timing at 100MHz, reduce to 75MHz
 EXTRA_LITEX_ARGS += --sys-clk-freq 75000000


### PR DESCRIPTION
This buys us a lot more breathing room in terms of avoiding FPGA
congestion, at a cost of about 35% slower model evaluation time.