### PR TITLE
common/Makefile: sort find output

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -116,7 +116,7 @@ LFLAGS     := \
 	-Wl,--build-id=none 
 	
 
-find_srcs = $(shell find $(SRC_DIR) -name \*.$(1))
+find_srcs = $(shell find $(SRC_DIR) -name \*.$(1) | LC_ALL=C sort)
 CSOURCES   := $(call find_srcs,c) 
 CPPSOURCES := $(call find_srcs,cpp)
 CCSOURCES  := $(call find_srcs,cc) 
@@ -195,4 +195,4 @@ $(OBJECTS): | $(MODEL_INCS) $(DATA_INCS)
 	$(QUIET) echo "  AS  $(notdir $<)	$(notdir $@)"
 	$(QUIET) $(CC) -x assembler-with-cpp -c $< $(CFLAGS) -o $@ -MMD
 
-include $(shell find src -name *.d)
+include $(call find_srcs,d)


### PR DESCRIPTION
This PR modifies the Makefile used for building software to sort found sources.
This ensures that the object files will be linked in the same order on all machines - without that binaries built on different hosts can get different model evaluation times.