### PR TITLE
cfu: generate rsp_valid without using cmd_valid

### DIFF
--- a/python/nmigen_cfu/cfu.py
+++ b/python/nmigen_cfu/cfu.py
@@ -259,7 +259,9 @@ class Cfu(SimpleElaboratable):
                     m.d.sync += stored_function_id.eq(
                         self.cmd_function_id[:3])
                     m.d.comb += instruction_starts[current_function_id].eq(1)
-                    check_instruction_done()
+                    m.d.sync += stored_output.eq(
+                        instruction_outputs[current_function_id])
+                    m.next = "WAIT_INSTRUCTION"
             with m.State("WAIT_INSTRUCTION"):
                 # An instruction is executing on the CFU. We're waiting until it
                 # completes.


### PR DESCRIPTION
This PR removes combinational path from `cmd_valid` to `rsp_valid` which slightly improves fMax (1-2MHz in recent tests) and FWIW doesn't impact model evaluation time.