### PR TITLE
Add command line support for verilator trace in Renode

### DIFF
--- a/common/renode-verilator-integration/CMakeLists.txt
+++ b/common/renode-verilator-integration/CMakeLists.txt
@@ -6,8 +6,11 @@ project(cfu)
 # C/C++ source files to be compiled
 set(CSOURCES sim_main.cpp)
 
-# Additional compiling, linking or verilating arguments (respectively)
-set(VERI_LIB_ARGS -Wno-WIDTH -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP)
+# Additional verilating arguments
+if(TRACE_DEPTH_VAL)
+    set(TRACE_DEPTH --trace-depth ${TRACE_DEPTH_VAL})
+endif()
+set(VERI_LIB_ARGS ${ENABLE_TRACE} ${TRACE_DEPTH} -Wno-WIDTH -Wno-CASEINCOMPLETE -Wno-CASEOVERLAP)
 
 find_package(verilator)
 

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -166,6 +166,10 @@ endif
 
 TARGET_REPL := $(BUILD_DIR)/renode/$(TARGET)_generated.repl
 
+ifneq '$(VERILATOR_TRACE_DEPTH)' ''
+	ENABLE_TRACE_ARG := --trace
+endif
+
 .PHONY:	renode
 renode: renode-scripts
 	@echo Running interactively under renode
@@ -179,7 +183,9 @@ renode-headless: renode-scripts
 renode-scripts: $(SOFTWARE_ELF)
 	@mkdir -p $(BUILD_DIR)/renode
 ifneq '$(SW_ONLY)' '1'
-	pushd $(BUILD_DIR)/renode && cmake -DCMAKE_BUILD_TYPE=Release -DINCLUDE_DIR="$(PROJ_DIR)" -DVTOP="$(CFU_VERILOG)" -DVIL_DIR="$(VIL_DIR)" $${VERILATOR_PATH:+"-DUSER_VERILATOR_DIR=$$VERILATOR_PATH"} "$(RVI_DIR)" && make libVtop && popd
+	pushd $(BUILD_DIR)/renode && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TRACE=$(ENABLE_TRACE_ARG) -DTRACE_DEPTH_VAL=$(VERILATOR_TRACE_DEPTH) \
+		-DINCLUDE_DIR="$(PROJ_DIR)" -DVTOP="$(CFU_VERILOG)" -DVIL_DIR="$(VIL_DIR)" $${VERILATOR_PATH:+"-DUSER_VERILATOR_DIR=$$VERILATOR_PATH"} \
+		"$(RVI_DIR)" && make libVtop && popd
 	$(CFU_ROOT)/scripts/generate_renode_scripts.py $(SOC_BUILD_DIR)/csr.json $(TARGET) $(BUILD_DIR)/renode/ --repl $(TARGET_REPL)
 else
 	$(CFU_ROOT)/scripts/generate_renode_scripts.py $(SOC_BUILD_DIR)/csr.json $(TARGET) $(BUILD_DIR)/renode/ --repl $(TARGET_REPL) --sw-only


### PR DESCRIPTION
This PR provides a makefile flag `VERILATOR_TRACE_DEPTH` that can be provided by user to enable tracing in Renode/Verilator co-simulation. Value assigned to that flag describes trace depth. For more details, take a look at [Verilator documentation](https://verilator.org/guide/latest/exe_verilator.html#cmdoption-trace-depth).

FYI @tcal-x 