### PR TITLE
Use Conda to get Oxide tools in CI

### DIFF
--- a/.github/workflows/oxide.yml
+++ b/.github/workflows/oxide.yml
@@ -12,7 +12,9 @@ jobs:
           python-version: '3.7'
       - run: bash scripts/setup -ci
       - run: which pip3 && which python3 && which pip
-      - run: riscv64-unknown-elf-gcc --version
       - run: make env
+      - run: which pip3 && which python3 && which pip
+      - run: riscv64-unknown-elf-gcc --version
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && yosys --version && nextpnr-nexus --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && pip3 list && make PLATFORM=hps bitstream
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 &&  cd proj/hps_accel && pip3 list && make PLATFORM=hps bitstream || true


### PR DESCRIPTION
(instead of building from scratch each time).
