### PR TITLE
Add ice40 and riscv toolchain support to the conda env;

### DIFF
--- a/.github/workflows/fomu.yml
+++ b/.github/workflows/fomu.yml
@@ -1,0 +1,18 @@
+name: fomu_ci
+on: [push, pull_request]
+jobs:
+  check-multi-proj:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - run: bash scripts/setup -ci
+      - run: which pip3 && which python3 && which pip
+      - run: make env
+      - run: which pip3 && which python3 && which pip
+      - run: riscv64-elf-gcc --version
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && yosys --version && nextpnr-ice40 --version
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && pip3 list && make TARGET=kosagi_fomu bitstream
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/kws_micro_accel && pip3 list && make TARGET=kosagi_fomu bitstream || true

--- a/.github/workflows/fomu.yml
+++ b/.github/workflows/fomu.yml
@@ -11,8 +11,8 @@ jobs:
       - run: bash scripts/setup -ci
       - run: which pip3 && which python3 && which pip
       - run: make env
-      - run: which pip3 && which python3 && which pip
-      - run: riscv32-elf-gcc --version
+      - run: source env/conda/bin/activate cfu-common && which pip3 && which python3 && which pip
+      - run: source env/conda/bin/activate cfu-common && riscv32-elf-gcc --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && yosys --version && nextpnr-ice40 --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && pip3 list && make TARGET=kosagi_fomu bitstream
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/kws_micro_accel && pip3 list && make TARGET=kosagi_fomu bitstream || true

--- a/.github/workflows/fomu.yml
+++ b/.github/workflows/fomu.yml
@@ -12,7 +12,7 @@ jobs:
       - run: which pip3 && which python3 && which pip
       - run: make env
       - run: which pip3 && which python3 && which pip
-      - run: riscv64-elf-gcc --version
+      - run: riscv32-elf-gcc --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && yosys --version && nextpnr-ice40 --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && pip3 list && make TARGET=kosagi_fomu bitstream
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/kws_micro_accel && pip3 list && make TARGET=kosagi_fomu bitstream || true

--- a/common/Makefile
+++ b/common/Makefile
@@ -11,8 +11,14 @@ ifndef SOC_SOFTWARE_DIR
 $(error SOC_SOFTWARE_DIR not set)
 endif
 
+
 # These are found in the PATH
+NEWLIB_RISCV := $(shell command -v riscv32-elf-newlib-gcc 2> /dev/null)
+ifdef NEWLIB_RISCV
 RV64       := riscv32-elf-newlib-
+else
+RV64       := riscv64-unknown-elf-
+endif
 CC         := $(RV64)gcc
 CXX        := $(RV64)g++
 OBJDUMP    := $(RV64)objdump

--- a/common/Makefile
+++ b/common/Makefile
@@ -12,7 +12,7 @@ $(error SOC_SOFTWARE_DIR not set)
 endif
 
 # These are found in the PATH
-RV64       := riscv64-unknown-elf-
+RV64       := riscv32-elf-newlib-
 CC         := $(RV64)gcc
 CXX        := $(RV64)g++
 OBJDUMP    := $(RV64)objdump

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -3,23 +3,16 @@ channels:
   - defaults
   - litex-hub
 dependencies:
-#  - litex-hub::gcc-riscv64-elf-newlib
-#  - litex-hub::toolchain-riscv64-linux-musl
-#  - litex-hub::nextpnr-ecp5
-#  - litex-hub::nextpnr-ice40
+  - litex-hub::gcc-riscv32-elf-newlib
   - litex-hub::dfu-util
   - litex-hub::flterm
   - litex-hub::openocd
   - litex-hub::verilator
   - litex-hub::nextpnr-nexus
+  - litex-hub::nextpnr-ecp5
+  - litex-hub::nextpnr-ice40
   - litex-hub::yosys
   - python=3.7
   - pip
   - pip:
     - -r ./requirements.txt
-#
-# Union of packages needed to build for:
-#  lattice ice40
-#  lattice ecp5
-#  lattice nexus
-#

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -3,3 +3,5 @@ termcolor
 tqdm
 yapf
 requests
+meson
+Pillow


### PR DESCRIPTION
add Fomu GHA that uses new conda-provided gcc.

Signed-off-by: Tim Callahan <tcal@google.com>