### PR TITLE
docs: upgrade to Sphinx 4.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-Sphinx==3.3.0
+Sphinx==4.3.0
 sphinx-material==0.0.32
-sphinx-tabs==1.3.0
+sphinx-tabs==3.2.0
 sphinx-jinja==1.1.1
 recommonmark==0.7.1


### PR DESCRIPTION
Trying to fix breakage in CI due to docutils 0.18 incompatibility.