### PR TITLE
Update software/linker to use separate tensor arena region.

### DIFF
--- a/common/_hps/hps/ld/linker.ld
+++ b/common/_hps/hps/ld/linker.ld
@@ -53,6 +53,13 @@ SECTIONS
 		_ebss = .;
 		_end = .;
 	} > sram
+
+        .arena (NOLOAD) :
+        {
+                _farena = .;
+                *(.arena)
+                _earena = .;
+        } > arena
 }
 
 PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);

--- a/common/src/tflite.cc
+++ b/common/src/tflite.cc
@@ -106,7 +106,11 @@ constexpr int kTensorArenaSize = const_max<int>(
     0 /* When no models defined, we don't need a tensor arena. */
 );
 
+#ifdef CONFIG_SOC_SEPARATE_ARENA
+static uint8_t tensor_arena[kTensorArenaSize] __attribute__((section(".arena")));
+#else
 static uint8_t tensor_arena[kTensorArenaSize];
+#endif
 }  // anonymous namespace
 
 static void tflite_init() {

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -107,8 +107,7 @@ class HpsSoC(LiteXSoC):
             ram_size = RAM_SIZE
             arena_size = 0
         self.setup_ram(size=ram_size)
-        if arena_size > 0:
-            self.setup_arena(size=arena_size)
+        self.setup_arena(size=arena_size)
 
         # SPI Flash
         if litespi_flash:
@@ -152,11 +151,14 @@ class HpsSoC(LiteXSoC):
         self.bus.add_slave("sram_lram", self.lram.bus, region)
         self.bus.add_region("sram", region)
 
+    # define the "arena" region even if it's length-zero
     def setup_arena(self, size):
         region = SoCRegion(self.arena_origin, size, cached=True, linker=True)
-        self.submodules.arena = self.platform.create_ram(32, size)
-        self.bus.add_slave("arena_lram", self.arena.bus, region)
         self.bus.add_region("arena", region)
+        if size > 0:
+            self.submodules.arena = self.platform.create_ram(32, size)
+            self.bus.add_slave("arena_lram", self.arena.bus, region)
+            self.add_config('SOC_SEPARATE_ARENA')
 
     def setup_rom_in_lram(self):
         region = SoCRegion(self.cpu.reset_address, 64 * KB, mode='r',


### PR DESCRIPTION
To use, add this to your make command:
EXTRA_LITEX_ARGS="--separate-arena"

Tested on proto2 both with and without this new option.

Signed-off-by: Tim Callahan <tcal@google.com>