### PR TITLE
Add CI that automatically updates `third_party/tflite-micro`

### DIFF
--- a/.github/workflows/sync-tflm.yml
+++ b/.github/workflows/sync-tflm.yml
@@ -1,0 +1,62 @@
+name: Sync from tflite-micro
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+
+  # Allow manually triggering of the workflow.
+  workflow_dispatch: {}
+
+jobs:
+  sync-tflite-micro:
+    runs-on: ubuntu-latest
+
+    if: |
+      github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+
+    env:
+      GH_SERVICE_ACCOUNT_NAME: "tflite-bot"
+      GH_SERVICE_ACCOUNT_EMAIL: "tflite-bot@antmicro.com"
+
+    steps:
+      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config --global user.name $GH_SERVICE_ACCOUNT_NAME
+          git config --global user.email $GH_SERVICE_ACCOUNT_EMAIL
+
+      - name: Sync the code, commit and push
+        run: |
+          export TFLM_SHA=$(git ls-remote https://github.com/tensorflow/tflite-micro.git main | cut -c1-7)
+          ./scripts/sync_from_tflite_micro.sh
+          git add *
+
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "Sync from tflite-micro at $TFLM_SHA."
+          else
+            echo "no changes"
+          fi
+
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: sync-from-tflite-micro
+          delete-branch: true
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          title: (CFU Playground) Automated sync from github.com/tensorflow/tflite-micro
+          commit-message: Automated sync from github.com/tensorflow/tflite-micro
+          committer: $GH_SERVICE_ACCOUNT_NAME <$GH_SERVICE_ACCOUNT_EMAIL>
+          author: $GH_SERVICE_ACCOUNT_NAME <$GH_SERVICE_ACCOUNT_EMAIL>
+          body: "(CFU Playground) Automated sync from github.com/tensorflow/tflite-micro"
+
+      - name: Enable Pull Request Automerge
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -5,3 +5,5 @@ yapf
 requests
 meson
 Pillow
+six
+Wave

--- a/proj/hps_accel/renode/hps.repl
+++ b/proj/hps_accel/renode/hps.repl
@@ -1,0 +1,19 @@
+cpu: CPU.VexRiscv @ sysbus
+    cpuType: "rv32im"
+
+ctrl: Miscellaneous.LiteX_SoC_Controller @ { sysbus 0xf0000000 }
+
+uart: UART.LiteX_UART @ { sysbus 0xf0002800 }
+    -> cpu@0
+
+timer0: Timers.LiteX_Timer @ { sysbus 0xf0002000 }
+    -> cpu@1
+    frequency: 56250000
+
+sram: Memory.MappedMemory @ { sysbus 0x40000000 }
+    size: 0x00050000
+
+spi: SPI.LiteX_SPI_Flash @ { sysbus 0xf0001800 }
+
+rom: Memory.MappedMemory @ { sysbus 0x20200000 }
+    size: 0x00e00000

--- a/scripts/setup
+++ b/scripts/setup
@@ -113,6 +113,16 @@ if [ ! -e "${VIL_DIR}" ]; then
     patch -p1 ${VIL_DIR}/src/renode.h ${CFU_ROOT}/common/renode-verilator-integration/renode_h.patch
 fi
 
+# To update TFLite Micro, remove the ${TFLM_DIR} directory and run this script.
+TFLM_DIR=${CFU_ROOT}/third_party/tflite-micro
+if [ ! -e "${TFLM_DIR}" ]; then
+    ${CFU_ROOT}/scripts/sync_from_tflite_micro.sh
+else
+    echo ""
+    echo "${TFLM_DIR} found, not updating TensorFlow Lite micro"
+    echo ""
+fi
+
 # Check GCC
 if ! which riscv64-unknown-elf-gcc >/dev/null; then
     echo "Error: RISCV GCC toolchain not found. Please install one, following the instructions at"

--- a/scripts/sync_from_tflite_micro.sh
+++ b/scripts/sync_from_tflite_micro.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Copyright 2021 The CFU-Playground Authors
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Inspiried by https://github.com/tensorflow/tflite-micro-arduino-examples/blob/main/scripts/sync_from_tflite_micro.sh
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CFU_ROOT="$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))"
+cd "${ROOT_DIR}"
+
+TEMP_DIR=$(mktemp -d)
+cd "${TEMP_DIR}"
+
+echo Cloning tflite-micro repo to "${TEMP_DIR}"
+git clone --depth 1 --single-branch "https://github.com/tensorflow/tflite-micro.git"
+cd tflite-micro
+git rev-parse --short HEAD >| ${CFU_ROOT}/conf/tflite-micro.version
+
+make -f tensorflow/lite/micro/tools/make/Makefile clean_downloads
+
+OUTPUT_DIR="${TEMP_DIR}/tflm_tree"
+
+# Create the TFLM base tree, get person_detection for its models
+python3 tensorflow/lite/micro/tools/project_generation/create_tflm_tree.py "${OUTPUT_DIR}"
+
+# Download person_model_int8 third party. URL taken from tflite-micro:
+# https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/tools/make/third_party_downloads.inc
+PERSON_MODEL_INT8_ZIP="tf_lite_micro_person_data_int8_grayscale_2020_12_1.zip"
+PERSON_MODEL_INT8_URL="https://storage.googleapis.com/download.tensorflow.org/data/${PERSON_MODEL_INT8_ZIP}"
+PERSON_MODEL_INT8_MD5="e765cc76889db8640cfe876a37e4ec00"
+
+# source bash_helpers fot `check_md5`
+source tensorflow/lite/micro/tools/make/bash_helpers.sh
+wget ${PERSON_MODEL_INT8_URL} -O ${PERSON_MODEL_INT8_ZIP}
+check_md5 ${PERSON_MODEL_INT8_ZIP} ${PERSON_MODEL_INT8_MD5}
+mkdir person_model_int8
+unzip -a ${PERSON_MODEL_INT8_ZIP}
+
+# Generate keyword benchmark models
+make -f tensorflow/lite/micro/tools/make/Makefile run_keyword_benchmark
+
+# Copy files used by CFU Playground that are not present in TFLM base tree
+cp -r tensorflow/lite/micro/examples ${OUTPUT_DIR}/tensorflow/lite/micro/
+cp tensorflow/lite/micro/kernels/conv_test* ${OUTPUT_DIR}/tensorflow/lite/micro/kernels
+cp tensorflow/lite/micro/kernels/depthwise_conv_test* ${OUTPUT_DIR}/tensorflow/lite/micro/kernels
+cp -r tensorflow/lite/micro/kernels/testdata ${OUTPUT_DIR}/tensorflow/lite/micro/kernels/
+cp -r tensorflow/lite/micro/models ${OUTPUT_DIR}/tensorflow/lite/micro/
+cp -r tensorflow/lite/micro/tools ${OUTPUT_DIR}/tensorflow/lite/micro/
+cp -r person_model_int8/* ${OUTPUT_DIR}/tensorflow/lite/micro/examples/person_detection/
+
+# copy ${OUTPUT_DIR} to the repo
+cp -aT "${OUTPUT_DIR}" "${CFU_ROOT}/third_party/tflite-micro"
+
+rm -rf "${TEMP_DIR}"


### PR DESCRIPTION
This PR should be merged after #343. It introduces new CI workflow that checks if there are any updates possible to apply on `third_party/tflite-micro`.

It also adds a script to update it manually. It is also included in `scripts/setup` so running a setup will also update `tflite-micro`. If there is already existing `third_party/tflite-micro` setup script will prompt a warning to not override an existing one. If user decides to remove it, then setup script will get the latest version.
Current TF Lite Micro version used by CFU Playground will be stored in `conf/tflite-micro.version`.

Since this was tested on Antmicro's fork, there is an Antmicro's bot account set up in CI. You can either let me know what should be a name and email of an account for CFU Playground or you can merge this PR and override it yourself. However you will need to set a secret token `GH_SERVICE_ACCOUNT_TOKEN` for this repo to make it work.

Here is how it looks: https://github.com/antmicro/CFU-Playground/pull/2

It is set up to enable auto-merge but I can also set it to assign someone as a reviewer on every PR created.

FYI @tcal-x 