### PR TITLE
Add SymbiFlow Arty target to CI

### DIFF
--- a/.github/workflows/arty.yml
+++ b/.github/workflows/arty.yml
@@ -1,0 +1,28 @@
+name: arty_ci
+on: [push, pull_request]
+jobs:
+  check-multi-proj:
+    runs-on: ubuntu-latest
+    steps:
+      - run: wget --progress=dot:giga -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
+      - run: echo "/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin" >> $GITHUB_PATH
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - run: bash scripts/setup -ci
+      - run: which pip3 && which python3 && which pip
+      - run: make env
+      - run: source env/conda/bin/activate cfu-common && which pip3 && which python3 && which pip
+      - run: source env/conda/bin/activate cfu-common && riscv32-elf-gcc --version
+      - run: source env/conda/bin/activate cfu-common && conda env update --file third_party/symbiflow-examples/xc7/environment.yml && pip3 install requests
+      - run: source env/conda/bin/activate cfu-common && conda remove gcc-riscv64-elf-newlib -n xc7
+      - run: pwd && source env/conda/bin/activate xc7 && source environment && cd proj/proj_template_v && pip3 list && make TARGET=digilent_arty EXTRA_LITEX_ARGS="--toolchain symbiflow --sys-clk-freq 75000000" bitstream
+      - run: pwd && source env/conda/bin/activate xc7 && source environment && cd proj/proj_template_v && pip3 list && make TARGET=digilent_arty EXTRA_LITEX_ARGS="--toolchain symbiflow --sys-clk-freq 75000000" software
+      - uses: actions/upload-artifact@v2
+        with:
+          name: arty-build
+          path: |
+            soc/build/digilent_arty.proj_template_v/gateware/digilent_arty.bit
+            proj/proj_template_v/build/software.bin
+            proj/proj_template_v/build/software.elf

--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "third_party/python/meson"]
 	path = third_party/python/meson
 	url = https://github.com/mesonbuild/meson
+[submodule "third_party/symbiflow-examples"]
+	path = third_party/symbiflow-examples
+	url = https://github.com/SymbiFlow/symbiflow-examples

--- a/environment
+++ b/environment
@@ -36,3 +36,4 @@ pathadd() {
 }
 pathadd "${CFU_ROOT}/third_party/usr/local/bin"
 pathadd "${CFU_ROOT}/scripts"
+pathadd "${CFU_ROOT}/third_party/symbiflow/xc7/install/bin"

--- a/scripts/setup
+++ b/scripts/setup
@@ -77,6 +77,15 @@ echo "BUILDING FLASHROM"
   make -j4 CONFIG_ENABLE_LIBPCI_PROGRAMMERS=no
 )
 
+SYMBIFLOW_DIR=${CFU_ROOT}/third_party/symbiflow
+# Get files for Arty SymbiFlow toolchain
+if [ ! -d "${SYMBIFLOW_DIR}/xc7/install" ]; then
+    mkdir -p ${SYMBIFLOW_DIR}/xc7/install
+    echo "Installing SymbiFlow tools for Arty"
+    wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/459/20211116-000105/symbiflow-arch-defs-install-ef6fff3c.tar.xz | tar -xJC ${SYMBIFLOW_DIR}/xc7/install
+    wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/459/20211116-000105/symbiflow-arch-defs-xc7a50t_test-ef6fff3c.tar.xz | tar -xJC ${SYMBIFLOW_DIR}/xc7/install
+fi
+
 RENODE_VERSION="1.12.0+20211006gite082694a"
 RENODE_VERSION_SPLIT=${RENODE_VERSION//"+"/ }
 RENODE_VERSION_SPLIT=${RENODE_VERSION_SPLIT//"git"/ }


### PR DESCRIPTION
This PR adds CI run that builds `proj_template_v` for Arty board using SymbiFlow toolchain.
After a successful build outputs are saved as artifacts.