### PR TITLE
Expose 2nd LRAM ports; connect to CFU; testcase.

### DIFF
--- a/.github/workflows/oxide.yml
+++ b/.github/workflows/oxide.yml
@@ -4,8 +4,6 @@ jobs:
   check-multi-proj:
     runs-on: ubuntu-latest
     steps:
-      - run: wget --progress=dot:giga -O- https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14.tar.gz | tar -xzC /opt
-      - run: echo "/opt/riscv64-unknown-elf-gcc-8.3.0-2020.04.1-x86_64-linux-ubuntu14/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -14,8 +12,9 @@ jobs:
       - run: which pip3 && which python3 && which pip
       - run: make env
       - run: which pip3 && which python3 && which pip
-      - run: riscv64-unknown-elf-gcc --version
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && riscv32-elf-newlib-gcc --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && yosys --version && nextpnr-nexus --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && pip3 list && make PLATFORM=hps bitstream
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 &&  cd proj/hps_accel && pip3 list && make PLATFORM=hps bitstream || true
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 &&  cd proj/hps_accel && pip3 list && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=slimopt+cfu" clean bitstream || true
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/mport && pip3 list && make PLATFORM=hps bitstream software

--- a/proj/mport/Makefile
+++ b/proj/mport/Makefile
@@ -1,0 +1,45 @@
+#!/bin/env python
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This variable lists symbols to define to the C preprocessor
+export DEFINES :=
+
+# Uncomment this line to use software defined CFU functions in software_cfu.cc
+#DEFINES += CFU_SOFTWARE_DEFINED
+
+# Uncomment this line to skip debug code (large effect on performance)
+DEFINES += NDEBUG
+
+# Uncomment this line to skip individual profiling output (has minor effect on performance).
+#DEFINES += NPROFILE
+
+# Uncomment to include specified model in built binary
+DEFINES += INCLUDE_MODEL_PDTI8
+#DEFINES += INCLUDE_MODEL_MICRO_SPEECH
+#DEFINES += INCLUDE_MODEL_MAGIC_WAND
+#DEFINES += INCLUDE_MODEL_MNV2
+#DEFINES += INCLUDE_MODEL_HPS
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_ANOMD
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_IMGC
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_KWS
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_VWW
+
+# Uncomment to include all TFLM examples (pdti8, micro_speech, magic_wand)
+#DEFINES += INCLUDE_ALL_TFLM_EXAMPLES
+
+export EXTRA_LITEX_ARGS=--separate-arena --cfu-mport
+export PLATFORM=hps
+
+include ../proj.mk

--- a/proj/mport/cfu.v
+++ b/proj/mport/cfu.v
@@ -1,0 +1,58 @@
+// Copyright 2021 The CFU-Playground Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+
+module Cfu (
+  input               cmd_valid,
+  output              cmd_ready,
+  input      [9:0]    cmd_payload_function_id,
+  input      [31:0]   cmd_payload_inputs_0,
+  input      [31:0]   cmd_payload_inputs_1,
+  output              rsp_valid,
+  input               rsp_ready,
+  output     [31:0]   rsp_payload_outputs_0,
+  input               reset,
+  input               clk,
+  output    [13:0]    port0_addr,
+  output    [13:0]    port1_addr,
+  output    [13:0]    port2_addr,
+  output    [13:0]    port3_addr,
+  input     [31:0]    port0_din,
+  input     [31:0]    port1_din,
+  input     [31:0]    port2_din,
+  input     [31:0]    port3_din,
+);
+
+  reg cmd_valid_delay;
+  always @(posedge clk) if (rsp_ready) cmd_valid_delay <= cmd_valid;
+
+  // one clcok latency on the memory access
+  assign rsp_valid = cmd_valid_delay;
+  assign cmd_ready = rsp_ready;
+
+  // spam address to all banks
+  assign port0_addr = cmd_payload_inputs_1;
+  assign port1_addr = cmd_payload_inputs_1;
+  assign port2_addr = cmd_payload_inputs_1;
+  assign port3_addr = cmd_payload_inputs_1;
+
+  // pick result
+  reg [1:0] bank_sel;
+  always @(posedge clk) if (rsp_ready) bank_sel <= cmd_payload_inputs_0;
+  assign rsp_payload_outputs_0 = bank_sel[1] ? (bank_sel[0] ? port3_din : port2_din)
+                                             : (bank_sel[0] ? port1_din : port0_din);
+
+
+endmodule

--- a/proj/mport/src/README.md
+++ b/proj/mport/src/README.md
@@ -1,0 +1,14 @@
+# Source Overlay directory
+
+The files in this directory will be "overlaid" on a copy of the common source tree and Tensorflow Lite for Microcontrollers. 
+
+For example:
+
+    *   the proj_menu.c file in this directory replaces the proj_menu.c file in
+        common when building.
+    *   to replace the integer 2D convolution implementation, you could create a
+        file with the path:
+
+        tensorflow/lite/kernels/interal/reference/integer_ops/conv.h.
+
+    

--- a/proj/mport/src/proj_menu.cc
+++ b/proj/mport/src/proj_menu.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 The CFU-Playground Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "proj_menu.h"
+
+#include <stdio.h>
+
+#include "cfu.h"
+#include "menu.h"
+
+// to get ARENA_LRAM_BASE
+#include "generated/mem.h"
+
+namespace {
+
+// Template Fn
+
+void do_hello_world(void) { puts("Hello, World!!!\n"); }
+
+// Test mem ports
+void do_mem(void) {
+
+  // first write to arena -- should get striped across banks
+  int *p = ((int*)ARENA_LRAM_BASE);
+  for (int i=0; i<256; ++i) {
+    p[i] = i;
+  }
+
+  // now read from each bank through the CFU
+  for (int b=0; b<4; ++b) {
+    printf("\nBank %d\n", b);
+    for (int i=0; i<64; ++i) {
+      int d = cfu_op0(0, b, i);
+      printf("  offset %3d:  %x\n", i, d);
+    }
+  }
+}
+
+
+
+// Test template instruction
+void do_grid_cfu_op0(void) {
+  puts("\nExercise CFU Op0\n");
+  printf("a   b-->");
+  for (int b = 0; b < 6; b++) {
+    printf("%8d", b);
+  }
+  puts("\n-------------------------------------------------------");
+  for (int a = 0; a < 6; a++) {
+    printf("%-8d", a);
+    for (int b = 0; b < 6; b++) {
+      int cfu = cfu_op0(0, a, b);
+      printf("%8d", cfu);
+    }
+    puts("");
+  }
+}
+
+// Test template instruction
+void do_exercise_cfu_op0(void) {
+  puts("\nExercise CFU Op0\n");
+  int count = 0;
+  for (int a = -0x71234567; a < 0x68000000; a += 0x10012345) {
+    for (int b = -0x7edcba98; b < 0x68000000; b += 0x10770077) {
+      int cfu = cfu_op0(0, a, b);
+      printf("a: %08x b:%08x cfu=%08x\n", a, b, cfu);
+      if (cfu != a) {
+        printf("\n***FAIL\n");
+        return;
+      }
+      count++;
+    }
+  }
+  printf("Performed %d comparisons", count);
+}
+
+struct Menu MENU = {
+    "Project Menu",
+    "project",
+    {
+        MENU_ITEM('m', "exercise direct cfu-mem accesses", do_mem),
+        MENU_ITEM('0', "exercise cfu op0", do_exercise_cfu_op0),
+        MENU_ITEM('g', "grid cfu op0", do_grid_cfu_op0),
+        MENU_ITEM('h', "say Hello", do_hello_world),
+        MENU_END,
+    },
+};
+
+};  // anonymous namespace
+
+extern "C" void do_proj_menu() { menu_run(&MENU); }

--- a/proj/mport/src/software_cfu.cc
+++ b/proj/mport/src/software_cfu.cc
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 The CFU-Playground Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include "software_cfu.h"
+
+//
+// In this function, place C code to emulate your CFU. You can switch between
+// hardware and emulated CFU by setting the CFU_SOFTWARE_DEFINED DEFINE in
+// the Makefile.
+uint32_t software_cfu(int funct3, int funct7, uint32_t rs1, uint32_t rs2)
+{
+  return (funct3 & 1) ? rs2 : rs1;
+}

--- a/soc/board_specific_workflows/general.py
+++ b/soc/board_specific_workflows/general.py
@@ -92,6 +92,11 @@ class GeneralSoCWorkflow():
         Returns:
             The LiteX Builder for the SoC.
         """
+        #for sp in soc.cpu.specials:
+        #    print("CPU special:", sp)
+        print("\n\nTJC\n\n")
+        print("cpu_params", soc.cpu.cpu_params)
+        print("cfu_params", soc.cpu.cfu_params)
         copy_cpu_variant_if_needed(self.args.cpu_variant)
         soc_builder = self.builder_constructor(
             soc, **builder.builder_argdict(self.args))
@@ -118,6 +123,7 @@ class GeneralSoCWorkflow():
     def run(self) -> None:
         """Runs the workflow in order (make_soc -> build_soc -> load)."""
         soc = self.make_soc()
+        print("\n AFTER make_soc(), BEFORE build_soc()\n\n")
         soc_builder = self.build_soc(soc)
         if self.args.load:
             self.load(soc, soc_builder)

--- a/soc/board_specific_workflows/general.py
+++ b/soc/board_specific_workflows/general.py
@@ -92,11 +92,6 @@ class GeneralSoCWorkflow():
         Returns:
             The LiteX Builder for the SoC.
         """
-        #for sp in soc.cpu.specials:
-        #    print("CPU special:", sp)
-        print("\n\nTJC\n\n")
-        print("cpu_params", soc.cpu.cpu_params)
-        print("cfu_params", soc.cpu.cfu_params)
         copy_cpu_variant_if_needed(self.args.cpu_variant)
         soc_builder = self.builder_constructor(
             soc, **builder.builder_argdict(self.args))
@@ -123,7 +118,6 @@ class GeneralSoCWorkflow():
     def run(self) -> None:
         """Runs the workflow in order (make_soc -> build_soc -> load)."""
         soc = self.make_soc()
-        print("\n AFTER make_soc(), BEFORE build_soc()\n\n")
         soc_builder = self.build_soc(soc)
         if self.args.load:
             self.load(soc, soc_builder)

--- a/soc/hps_lattice_nx.py
+++ b/soc/hps_lattice_nx.py
@@ -115,6 +115,10 @@ class NXLRAM(Module):
         print("sel_bits_start ", sel_bits_start)
         print("adr_bits_start ", adr_bits_start)
 
+        if dual_port:
+            self.b_addrs = []
+            self.b_douts = []
+
         # Combine RAMs to increase Depth.
         for d in range(self.depth_cascading):
             self.lram_blocks.append([])
@@ -143,6 +147,8 @@ class NXLRAM(Module):
                     ]
 
                 if dual_port:
+                    b_addr = Signal(14)
+                    b_dout = Signal(32)
                     lram_block = Instance("DPSC512K",
                         p_ECC_BYTE_SEL = "BYTE_EN",
                         i_DIA       = datain,
@@ -155,13 +161,17 @@ class NXLRAM(Module):
                         i_CEOUTA    = 0b0,
                         i_BENA_N    = ~self.bus.sel[4*w:4*(w+1)],
                         o_DOA       = dataout,
-                        # tie off port B for now
-                        i_CEB       = 0b0,
+                        # port B read only
+                        i_ADB       = b_addr,
+                        o_DOB       = b_dout,
+                        i_CEB       = 0b1,
                         i_WEB       = 0b0,
-                        i_CSB       = 0b0,
+                        i_CSB       = 0b1,
                         i_RSTB      = 0b0,
                         i_CEOUTB    = 0b0
                     )
+                    self.b_addrs.append(b_addr)
+                    self.b_douts.append(b_dout)
 
                 else:
                     lram_block = Instance("SP512K",


### PR DESCRIPTION
Signed-off-by: Tim Callahan <tcal@google.com>

Update: I added a project (`proj/mport`) to test the new functionality.  It is tested in CI by the `oxide.yml` workflow.   In that flow I added doing the software compile, which encountered a clash of GCCs as expected (#365), so I removed the SiFive 8.3 toolchain download (there's still more to do for #365).

To enable all of the functionality added in this PR, you need to add both `--separate-arena` and `--cfu-mport` to your Litex flags.   This is already done in the Makefile in `proj/mport`.
