### PR TITLE
Add a pause before connecting to the board. Helps Fomu.

### DIFF
--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -318,7 +318,7 @@ load: $(SOFTWARE_BIN)
 # Load hook allows common_soc.py to provide board-specific changes to load.
 # This isn't ideal, the logic is starting to get too voluminous for a Makefile.
 	$(SOC_MK) load_hook
-	@sleep 2
+	@while [ ! -e $(TTY) ]; do echo "Waiting for UART"; sleep 1; done
 	$(LXTERM) --speed $(UART_SPEED) $(CRC) --kernel $(SOFTWARE_BIN) $(TTY)
 
 connect:

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -318,6 +318,11 @@ load: $(SOFTWARE_BIN)
 # Load hook allows common_soc.py to provide board-specific changes to load.
 # This isn't ideal, the logic is starting to get too voluminous for a Makefile.
 	$(SOC_MK) load_hook
+	@sleep 2
+	$(LXTERM) --speed $(UART_SPEED) $(CRC) --kernel $(SOFTWARE_BIN) $(TTY)
+
+connect:
+	@echo Connecting to board
 	$(LXTERM) --speed $(UART_SPEED) $(CRC) --kernel $(SOFTWARE_BIN) $(TTY)
 endif
 


### PR DESCRIPTION
Fomu requires a second or so after the upload
for the tty to appear at /dev/ttyACM0.

Also add a "connect" target that does just that
(doesn't build anything).

Signed-off-by: Tim Callahan <tcal@google.com>