### PR TITLE
hps_accel/hps_cfu.h: add cfu_setx()

### DIFF
--- a/proj/hps_accel/src/hps_cfu.h
+++ b/proj/hps_accel/src/hps_cfu.h
@@ -21,6 +21,7 @@
 
 // Convenience macros for get/set
 #define cfu_set(reg, val) cfu_op(INS_SET, reg, val, 0)
+#define cfu_setx(reg, val1, val2) cfu_op(INS_SET, reg, val1, val2)
 #define cfu_get(reg) cfu_op(INS_GET, reg, 0, 0)
 
 // Ping instructions for checking CFU is available


### PR DESCRIPTION
Adds cfu_setx() which had been omitted. Adding this allows the build to
succeed.

Signed-off-by: Alan Green <avg@google.com>