### PR TITLE
Update Verilator sim to handle dual-port arena

### DIFF
--- a/common/_sim/sim/ld/linker.ld
+++ b/common/_sim/sim/ld/linker.ld
@@ -1,0 +1,72 @@
+INCLUDE output_format.ld
+ENTRY(_start)
+
+__DYNAMIC = 0;
+
+INCLUDE regions.ld
+
+
+SECTIONS
+{
+	.text :
+	{
+		_ftext = .;
+		*(.text.start)
+		*(.text .stub .text.* .gnu.linkonce.t.*)
+		_etext = .;
+	} > main_ram
+	/*} > rom */
+
+	.rodata :
+	{
+		. = ALIGN(8);
+		_frodata = .;
+		*(.rodata .rodata.* .gnu.linkonce.r.*)
+		*(.rodata1)
+		*(.srodata .srodata.*)
+		. = ALIGN(8);
+		_erodata = .;
+	} > main_ram
+	/*} > rom */
+
+	.data : AT (ADDR(.rodata) + SIZEOF (.rodata))
+	{
+		. = ALIGN(8);
+		_fdata = .;
+		*(.data .data.* .gnu.linkonce.d.*)
+		*(.data1)
+		*(.ramtext .ramtext.*)
+		_gp = ALIGN(16);
+		*(.sdata .sdata.* .gnu.linkonce.s.* .sdata2 .sdata2.*)
+		_edata = ALIGN(16); /* Make sure _edata is >= _gp. */
+	} > main_ram
+	/*} > sram */
+
+	.bss : AT (ADDR(.data) + SIZEOF (.data))
+	{
+		. = ALIGN(16);
+		_fbss = .;
+		*(.dynsbss)
+		*(.sbss .sbss.* .gnu.linkonce.sb.*)
+		*(.scommon)
+		*(.dynbss)
+		*(.bss .bss.* .gnu.linkonce.b.*)
+		*(COMMON)
+		. = ALIGN(8);
+		_ebss = .;
+		_end = .;
+	} > main_ram
+
+
+	/*} > sram */
+        .arena (NOLOAD) :
+        {
+                _farena = .;
+                *(.arena)
+                _earena = .;
+        } > arena
+
+}
+
+PROVIDE(_fstack = ORIGIN(main_ram) + LENGTH(main_ram) - 4);
+/* PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4); */

--- a/soc/sim.mk
+++ b/soc/sim.mk
@@ -45,7 +45,7 @@ LITEX_ARGS= --output-dir $(OUT_DIR) \
 	--sim-trace
 
 PYRUN:=     $(CFU_ROOT)/scripts/pyrun
-SIM_RUN:=   MAKEFLAGS=-j8 $(PYRUN) ./sim.py $(LITEX_ARGS)
+SIM_RUN:=   MAKEFLAGS=-j8 $(PYRUN) ./sim.py $(LITEX_ARGS) $(EXTRA_LITEX_ARGS)
 BIOS_BIN := $(OUT_DIR)/software/bios/bios.bin
 
 .PHONY: run litex-software clean

--- a/soc/sim.py
+++ b/soc/sim.py
@@ -113,7 +113,6 @@ def main():
         for i in range(4):
             newport.append(soc.arena.mem.get_port())
             soc.specials += newport[i]
-            soc.comb += newport[i].adr.eq(0)
 
             p_adr_from_cfu = Signal(14)
             p_adr = Cat(Constant(i,2), p_adr_from_cfu)

--- a/soc/sim.py
+++ b/soc/sim.py
@@ -104,13 +104,14 @@ def main():
 
 
     if args.cfu_mport:
-        print("soc.arena.mem: ", soc.arena.mem)
+        #
+        # add 4 read-only ports with LSBs fixed to 00, 01, 10, and 11.
+        #   and connect them to the CFU
+        #
         newport = []
         for i in range(4):
             newport.append(soc.arena.mem.get_port())
             soc.specials += newport[i]
-            print(f"newport[{i}]: ", newport[i])
-            print(f"newport[{i}].adr: ", newport[i].adr, " len:", len(newport[i].adr))
             soc.comb += newport[i].adr.eq(0)
 
             p_adr_from_cfu = Signal(14)
@@ -123,7 +124,6 @@ def main():
 
             soc.cpu.cfu_params.update(**{ f"o_port{i}_addr" : p_adr_from_cfu})
             soc.cpu.cfu_params.update(**{ f"i_port{i}_din"  : p_dat_r})
-        print("Final soc.cpu.cfu_params: ", soc.cpu.cfu_params)
 
     sim_config = SimConfig()
     sim_config.add_clocker("sys_clk", freq_hz=soc.clk_freq)

--- a/soc/sim.py
+++ b/soc/sim.py
@@ -82,6 +82,7 @@ def main():
     if args.cfu_mport:
         args.separate_arena = True
 
+    copy_cpu_variant_if_needed(args.cpu_variant)
     soc_kwargs = soc_core_argdict(args)
     soc_kwargs["l2_size"] = 8 * 1024
     soc_kwargs["uart_name"] = "sim"


### PR DESCRIPTION
Also fills in some missing sim support, e.g. handling custom VexRiscv variants.