### PR TITLE
hps/linker.ld: Fix large data address

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -44,7 +44,7 @@ GEN_LD_DIR := $(SOC_SOFTWARE_DIR)/include/generated
 LDSCRIPT   := $(LD_DIR)/linker.ld
 LDSCRIPTS  := $(LDSCRIPT) $(GEN_LD_DIR)/output_format.ld $(GEN_LD_DIR)/regions.ld
 
-SRC_DIR    := $(BUILD_DIR)/src
+SRC_DIR    := src
 
 PACKAGE    := software
 
@@ -120,7 +120,8 @@ LFLAGS     := \
 	-Wl,--fatal-warnings \
 	-Wl,--no-warn-mismatch \
 	-Wl,--script=$(LDSCRIPT) \
-	-Wl,--build-id=none 
+	-Wl,--build-id=none \
+	-Wl,-Map=$(PACKAGE).map
 	
 
 find_srcs = $(shell find $(SRC_DIR) -name \*.$(1) | LC_ALL=C sort)

--- a/common/_hps/hps/ld/linker.ld
+++ b/common/_hps/hps/ld/linker.ld
@@ -11,18 +11,30 @@ SECTIONS
 	.text :
 	{
 		_ftext = .;
-		*(.text.start)
-		*(.text .stub .text.* .gnu.linkonce.t.*)
+		*(SORT(.text.start))
+		*(SORT(.text))
+		*(SORT(.stub))
+		*(SORT(.text.*))
+		*(SORT(.gnu.linkonce.t.*))
 		_etext = .;
 	} > rom
 
 	.rodata :
 	{
-		. = ALIGN(8);
+		/*
+		 * Align models and large chunks of data into a constant position
+		 */
+		. = _ftext + 0x80000;
 		_frodata = .;
-		*(.rodata .rodata.* .gnu.linkonce.r.*)
-		*(.rodata1)
-		*(.srodata .srodata.*)
+		src/models/*/*(SORT(.rodata.*))
+		src/conv2d_??.o(SORT(.rodata.*))  /* specific to hps_accel */
+		. = ALIGN(4096);
+		*(SORT(.rodata))
+		*(SORT(.rodata.*))
+		*(SORT(.gnu.linkonce.r.*))
+		*(SORT(.rodata1))
+		*(SORT(.srodata))
+		*(SORT(.srodata.*))
 		. = ALIGN(8);
 		_erodata = .;
 	} > rom
@@ -31,11 +43,18 @@ SECTIONS
 	{
 		. = ALIGN(8);
 		_fdata = .;
-		*(.data .data.* .gnu.linkonce.d.*)
-		*(.data1)
-		*(.ramtext .ramtext.*)
+		*(SORT(.data))
+		*(SORT(.data.*))
+		*(SORT(.gnu.linkonce.d.*))
+		*(SORT(.data1))
+		*(SORT(.ramtext))
+		*(SORT(.ramtext.*))
 		_gp = ALIGN(16);
-		*(.sdata .sdata.* .gnu.linkonce.s.* .sdata2 .sdata2.*)
+		*(SORT(.sdata))
+		*(SORT(.sdata.*))
+		*(SORT(.gnu.linkonce.s.*))
+		*(SORT(.sdata2))
+		*(SORT(.sdata2.*))
 		_edata = ALIGN(16); /* Make sure _edata is >= _gp. */
 	} > sram
 
@@ -43,12 +62,16 @@ SECTIONS
 	{
 		. = ALIGN(16);
 		_fbss = .;
-		*(.dynsbss)
-		*(.sbss .sbss.* .gnu.linkonce.sb.*)
-		*(.scommon)
-		*(.dynbss)
-		*(.bss .bss.* .gnu.linkonce.b.*)
-		*(COMMON)
+		*(SORT(.dynsbss))
+		*(SORT(.sbss))
+		*(SORT(.sbss.*))
+		*(SORT(.gnu.linkonce.sb.*))
+		*(SORT(.scommon))
+		*(SORT(.dynbss))
+		*(SORT(.bss))
+		*(SORT(.bss.*))
+		*(SORT(.gnu.linkonce.b.*))
+		*(SORT(COMMON))
 		. = ALIGN(8);
 		_ebss = .;
 		_end = .;


### PR DESCRIPTION
Fixes large data in address space. This makes loading programs onto
proto2 faster since these data structures do not need to be updated if
they have not changed.

Signed-off-by: Alan Green <avg@google.com>