### PR TITLE
ci: Autobump Renode and TFLM with Personal Access Token

### DIFF
--- a/.github/workflows/sync-renode.yml
+++ b/.github/workflows/sync-renode.yml
@@ -70,3 +70,11 @@ jobs:
           title: (CFU Playground) Automatic Renode update from builds.renode.io
           commit-message: Automatic Renode update from builds.renode.io
           body: "(CFU Playground) Automatic Renode update from builds.renode.io"
+
+      - name: Enable automerge
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.CFU_BOT_TOKEN }}
+          merge-method: rebase
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/.github/workflows/sync-renode.yml
+++ b/.github/workflows/sync-renode.yml
@@ -66,7 +66,7 @@ jobs:
           signoff: true
           committer: CFU Playground Bot <cfu-playground-bot@google.com>
           author: CFU Playground Bot <cfu-playground-bot@google.com>
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CFU_BOT_TOKEN }}
           title: (CFU Playground) Automatic Renode update from builds.renode.io
           commit-message: Automatic Renode update from builds.renode.io
           body: "(CFU Playground) Automatic Renode update from builds.renode.io"

--- a/.github/workflows/sync-tflm.yml
+++ b/.github/workflows/sync-tflm.yml
@@ -59,7 +59,7 @@ jobs:
           base: main
           delete-branch: true
           signoff: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CFU_BOT_TOKEN }}
           committer: CFU Playground Bot <cfu-playground-bot@google.com>
           author: CFU Playground Bot <cfu-playground-bot@google.com>
           title: (CFU Playground) Automated sync from github.com/tensorflow/tflite-micro

--- a/.github/workflows/sync-tflm.yml
+++ b/.github/workflows/sync-tflm.yml
@@ -65,3 +65,11 @@ jobs:
           title: (CFU Playground) Automated sync from github.com/tensorflow/tflite-micro
           commit-message: Automated sync from github.com/tensorflow/tflite-micro
           body: "(CFU Playground) Automated sync from github.com/tensorflow/tflite-micro"
+
+      - name: Enable automerge
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.CFU_BOT_TOKEN }}
+          merge-method: rebase
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
This should allow us to create automergable PRs and help us pass the CLA
wall.