### PR TITLE
Add custom nextpnr params

### DIFF
--- a/.github/workflows/fmax-trials-fresh-build.yml
+++ b/.github/workflows/fmax-trials-fresh-build.yml
@@ -16,7 +16,7 @@ jobs:
       - run: bash scripts/setup -ci
       - run: which pip3 && which python3 && which pip
       - run: riscv64-unknown-elf-gcc --version
-      - run: bash scripts/install_oxide 
+      - run: bash scripts/install_oxide
       - run: source environment && yosys --version && nextpnr-nexus --version
       - run: pwd && source environment && cd proj/proj_template_v && ulimit -S -t 900  && ulimit -H -t 900  && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=full     --nextpnr-seed=1"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
       - run: pwd && source environment && cd proj/proj_template_v && ulimit -S -t 900  && ulimit -H -t 900  && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=full     --nextpnr-seed=22"  clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
@@ -33,3 +33,5 @@ jobs:
       - run: pwd && source environment && cd proj/hps_accel       && ulimit -S -t 1200  && ulimit -H -t 1200  && make PLATFORM=hps EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --nextpnr-seed=1"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
       - run: pwd && source environment && cd proj/hps_accel       && ulimit -S -t 1200  && ulimit -H -t 1200  && make PLATFORM=hps EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --nextpnr-seed=22"  clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
       - run: pwd && source environment && cd proj/hps_accel       && ulimit -S -t 1200  && ulimit -H -t 1200  && make PLATFORM=hps EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --nextpnr-seed=333" clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
+      - run: pwd && source environment && cd proj/hps_accel       && ulimit -S -t 240  && ulimit -H -t 240  && make PLATFORM=hps EXTRA_NEXTPNR_ARGS="--placer-heap-timingweight 52" EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --extra-nextpnr-params"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
+      - run: pwd && source environment && cd proj/hps_accel       && ulimit -S -t 240  && ulimit -H -t 240  && make PLATFORM=hps EXTRA_NEXTPNR_ARGS="--placer-heap-timingweight 52" EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --extra-nextpnr-params --no-compile-software"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true

--- a/.github/workflows/fmax-trials.yml
+++ b/.github/workflows/fmax-trials.yml
@@ -16,8 +16,8 @@ jobs:
       - run: bash scripts/setup -ci
       - run: which pip3 && which python3 && which pip
       - run: riscv64-unknown-elf-gcc --version
-      - run: make env 
-      - run: pwd && source env/conda/bin/activate cfu-common && which yosys && yosys --version && which nextpnr-nexus && nextpnr-nexus --version 
+      - run: make env
+      - run: pwd && source env/conda/bin/activate cfu-common && which yosys && yosys --version && which nextpnr-nexus && nextpnr-nexus --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && ulimit -S -t 900  && ulimit -H -t 900  && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=full     --nextpnr-seed=1"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && ulimit -S -t 900  && ulimit -H -t 900  && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=full     --nextpnr-seed=22"  clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && ulimit -S -t 900  && ulimit -H -t 900  && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=full     --nextpnr-seed=333" clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
@@ -33,3 +33,5 @@ jobs:
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/hps_accel       && ulimit -S -t 1200  && ulimit -H -t 1200  && make PLATFORM=hps EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --nextpnr-seed=1"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/hps_accel       && ulimit -S -t 1200  && ulimit -H -t 1200  && make PLATFORM=hps EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --nextpnr-seed=22"  clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/hps_accel       && ulimit -S -t 1200  && ulimit -H -t 1200  && make PLATFORM=hps EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --nextpnr-seed=333" clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/hps_accel       && ulimit -S -t 240  && ulimit -H -t 240  && make PLATFORM=hps EXTRA_NEXTPNR_ARGS="--placer-heap-timingweight 52" EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --extra-nextpnr-params"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/hps_accel       && ulimit -S -t 240  && ulimit -H -t 240  && make PLATFORM=hps EXTRA_NEXTPNR_ARGS="--placer-heap-timingweight 52" EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --extra-nextpnr-params --no-compile-software"   clean bitstream |& egrep '(Max frequency|Info:.*%)' || true

--- a/.github/workflows/oxide.yml
+++ b/.github/workflows/oxide.yml
@@ -15,6 +15,8 @@ jobs:
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && riscv32-elf-newlib-gcc --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && yosys --version && nextpnr-nexus --version
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/proj_template_v && pip3 list && make PLATFORM=hps bitstream
-      - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 &&  cd proj/hps_accel && pip3 list && make PLATFORM=hps bitstream || true
-      - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 &&  cd proj/hps_accel && pip3 list && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=slimopt+cfu" clean bitstream || true
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 && cd proj/hps_accel && pip3 list && make PLATFORM=hps bitstream || true
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 && cd proj/hps_accel && pip3 list && make PLATFORM=hps EXTRA_LITEX_ARGS="--cpu-variant=slimopt+cfu" clean bitstream || true
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 900 && ulimit -H -t 900 && cd proj/hps_accel && make PLATFORM=hps EXTRA_NEXTPNR_ARGS="--placer-heap-timingweight 52" EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --extra-nextpnr-params" clean bitstream || true
+      - run: pwd && source env/conda/bin/activate cfu-common && source environment && ulimit -S -t 240 && ulimit -H -t 240 && cd proj/hps_accel && make PLATFORM=hps EXTRA_NEXTPNR_ARGS="--placer-heap-timingweight 52" EXTRA_LITEX_ARGS="--separate-arena --cpu-variant=slimopt+cfu --extra-nextpnr-params --no-compile-software" clean bitstream || true
       - run: pwd && source env/conda/bin/activate cfu-common && source environment && cd proj/mport && pip3 list && make PLATFORM=hps bitstream software

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ third_party/nextpnr
 third_party/prjoxide
 third_party/usr/local
 third_party/yosys
+
+# Environment
+env

--- a/scripts/custom-nextpnr-nexus
+++ b/scripts/custom-nextpnr-nexus
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2021 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+JSON="$1"
+PDC="$2"
+RESULT_FASM="$3"
+
+nextpnr-nexus \
+    --json "${JSON}" \
+    --pdc "${PDC}" \
+    --fasm "${RESULT_FASM}" \
+    --device LIFCL-17-8UWG72C \
+    --detailed-timing-report \
+    ${EXTRA_NEXTPNR_ARGS}

--- a/soc/hps_proto2_platform.py
+++ b/soc/hps_proto2_platform.py
@@ -94,6 +94,13 @@ _oxide_parallel_build_template = [
     "prjoxide pack {build_name}.fasm {build_name}.bit"
 ]
 
+# Template for build script that adds custom nextpnr parameters
+_oxide_custom_build_template = [
+    "yosys -l {build_name}.rpt {build_name}.ys",
+    "custom-nextpnr-nexus {build_name}.json {build_name}.pdc {build_name}.fasm",
+    "prjoxide pack {build_name}.fasm {build_name}.bit"
+]
+
 # Template for build script that passes --router router1
 _oxide_router1_build_template = [
     'yosys -l {build_name}.rpt {build_name}.ys',
@@ -119,7 +126,7 @@ class Platform(LatticePlatform):
     clk_divisor = 9
     sys_clk_freq = int(450e6 / clk_divisor)
 
-    def __init__(self, toolchain="radiant", parallel_pnr=False):
+    def __init__(self, toolchain="radiant", parallel_pnr=False, custom_params=False):
         LatticePlatform.__init__(self,
                                  # The HPS actually has the LIFCL-17-7UWG72C, but that doesn't
                                  # seem to be available in Radiant 2.2, at
@@ -129,7 +136,9 @@ class Platform(LatticePlatform):
                                  connectors=[],
                                  toolchain=toolchain)
         if toolchain == "oxide":
-            if parallel_pnr:
+            if custom_params:
+                self.toolchain.build_template = _oxide_custom_build_template
+            elif parallel_pnr:
                 self.toolchain.build_template = _oxide_parallel_build_template
             else:
                 self.toolchain.build_template = _oxide_router1_build_template

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -174,7 +174,7 @@ class HpsSoC(LiteXSoC):
                                             endianness="little", div=4)
         self.bus.add_slave("spiflash", self.spiflash.bus, self.spiflash_region)
         self.csr.add("spiflash")
-        
+
     def setup_litespi_flash(self):
         self.submodules.spiflash_phy = LiteSPIPHY(
             self.platform.request("spiflash4x"),
@@ -288,6 +288,7 @@ def main():
                         help="Which toolchain to use: oxide (default) or radiant")
     parser.add_argument("--parallel-nextpnr", action="store_true",
                         help="Whether to use the parallel nextpnr script with the oxide toolchain")
+    parser.add_argument("--extra-nextpnr-params", action="store_true", help="Enable extra nextpnr parameters")
     parser.add_argument("--synth_mode", default="radiant",
                         help="Which synthesis mode to use with Radiant toolchain: "
                         "radiant/synplify (default), lse, or yosys")
@@ -320,7 +321,7 @@ def main():
     else:
         variant = "full+debug" if args.debug else "full"
     copy_cpu_variant_if_needed(variant)
-    soc = HpsSoC(Platform(args.toolchain, args.parallel_nextpnr),
+    soc = HpsSoC(Platform(args.toolchain, args.parallel_nextpnr, args.extra_nextpnr_params),
                     debug=args.debug,
                     litespi_flash=args.litespi_flash,
                     variant=variant,


### PR DESCRIPTION
This PR adds the possibility to use a different build template that can be used to pass additional parameters to nextpnr

With some experimentation performed using [FPGA tool perf](https://github.com/SymbiFlow/fpga-tool-perf)'s ability to run a set of builds using different combinations of input parameters, one combination among others yielded good results (locally) both in terms of runtime and max frequency was the following:

```
placer-heap-beta: 0.5 (default)
placer-heap-alpha: 0.1 (default)
placer-heap-critexp: 0.7 (default)
placer-heap-timingweight: 52 (custom)
```