### PR TITLE
Wraps: Manually instantiated MULTADDSUB9X9WIDE in MaccBlock to save resources.

### DIFF
--- a/proj/hps_accel/Makefile
+++ b/proj/hps_accel/Makefile
@@ -83,6 +83,9 @@ TEST_MENU_ITEMS=3 q
 export EXTRA_LITEX_ARGS
 EXTRA_LITEX_ARGS += --cpu-variant slim+cfu
 
+# Pass gen argument to cfu_gen
+CFU_GEN_EXTRA_ARGS := gen$(GATEWARE_GEN)
+
 # gen2 needs special build args and only works on hps
 ifeq '$(GATEWARE_GEN)' '2'
 EXTRA_LITEX_ARGS += --separate-arena --cfu-mport
@@ -91,6 +94,7 @@ endif
 
 ifeq '$(PLATFORM)' 'hps'
 EXTRA_LITEX_ARGS += --parallel
+CFU_GEN_EXTRA_ARGS += --specialize-nx
 endif
 
 ifeq '$(TARGET)' 'digilent_arty'
@@ -101,8 +105,6 @@ endif
 # Add constants defined in gateware/constants.py to C++ build
 BUILD_DIR_EXTRA_DEP = $(BUILD_DIR)/src/gateware_constants.h
 
-# Pass gen argument to cfu_gen
-CFU_GEN_EXTRA_ARGS = gen$(GATEWARE_GEN)
 
 #### Base rules ####
 include ../proj.mk

--- a/proj/hps_accel/cfu_gen.py
+++ b/proj/hps_accel/cfu_gen.py
@@ -30,6 +30,7 @@ make_cfu_fns = {
     'gen2': gen2_make_cfu,
 }
 
+
 def read_file():
     if os.path.exists(VERILOG_FILENAME):
         with open(VERILOG_FILENAME, "r") as f:
@@ -40,13 +41,15 @@ def read_file():
 def main():
     gen_list = list(make_cfu_fns.keys()).sort()
     parser = argparse.ArgumentParser(description='Generate cfu.v')
-    parser.add_argument('gen', metavar='GEN', type=str,
-                        choices=gen_list, help=f'Which kind of CFU to generate - one of {gen_list}')
+    parser.add_argument('gen', metavar='GEN', type=str, choices=gen_list,
+                        help=f'Which kind of CFU to generate - one of {gen_list}')
+    parser.add_argument('--specialize-nx', action='store_true',
+                        help='Generate code for Crosslink/NX-17.')
     args = parser.parse_args()
     if args.gen not in make_cfu_fns.keys():
         print(f'Unexpected GEN {args.gen}')
         sys.exit(5)
-    cfu = make_cfu_fns[args.gen]()
+    cfu = make_cfu_fns[args.gen](specialize_nx=args.specialize_nx)
 
     new_verilog = verilog.convert(cfu, name='Cfu', ports=cfu.ports)
     old_verilog = read_file()

--- a/proj/hps_accel/gateware/gen2/accelerator.py
+++ b/proj/hps_accel/gateware/gen2/accelerator.py
@@ -93,6 +93,11 @@ class AcceleratorCore(SimpleElaboratable):
     -   Post Process Parameter Write
     -   FIFO for output values
 
+    Arguments
+    ---------
+    specialize_nx: bool
+        Whether to generate specialized code for the Crosslink/NX-17.
+
     Attributes
     ----------
 
@@ -122,7 +127,8 @@ class AcceleratorCore(SimpleElaboratable):
       algorithm dependent order.
     """
 
-    def __init__(self):
+    def __init__(self, specialize_nx=False):
+        self._specialize_nx = specialize_nx
         self.reset = Signal()
         self.start = Signal()
         self.config = Record(ACCELERATOR_CONFIGURATION_LAYOUT)
@@ -251,7 +257,7 @@ class AcceleratorCore(SimpleElaboratable):
         first, last, activations = self.build_input_fetcher(m, stop_input)
 
         # Plumb in sysarray and its inputs
-        m.submodules['sysarray'] = sa = SystolicArray()
+        m.submodules['sysarray'] = sa = SystolicArray(self._specialize_nx)
         for j, (in_a, activation) in enumerate(zip(sa.input_a, activations)):
             # Assign activation values with input offset
             for i in range(4):

--- a/proj/hps_accel/gateware/gen2/hps_cfu.py
+++ b/proj/hps_accel/gateware/gen2/hps_cfu.py
@@ -225,13 +225,21 @@ class PoolInstruction(InstructionBase):
 class HpsCfu(Cfu):
     """Gen2 accelerator CFU.
     """
+    def __init__(self, specialize_nx=False):
+        """Constructor
+
+        Args:
+           specialize_nx: generate code for the Crosslink/NX-17.
+        """
+        super().__init__()
+        self._specialize_nx = specialize_nx
 
     def elab_instructions(self, m):
         m.submodules['ping'] = ping = PingInstruction()
         m.submodules['set'] = set_ = SetInstruction()
         m.submodules['get'] = get = GetInstruction()
         m.submodules['pool'] = pool = PoolInstruction()
-        m.submodules['core'] = core = AcceleratorCore()
+        m.submodules['core'] = core = AcceleratorCore(self._specialize_nx)
         m.submodules['fifo'] = fifo = StreamFifo(
             depth=Constants.OUTPUT_FIFO_DEPTH, type=unsigned(32))
 
@@ -265,5 +273,10 @@ class HpsCfu(Cfu):
         }
 
 
-def make_cfu():
-    return HpsCfu()
+def make_cfu(specialize_nx):
+    """Returns the gen2 CFU design.
+
+    Args:
+        specialize_nx: generate code for the Crosslink/NX-17.
+    """
+    return HpsCfu(specialize_nx)

--- a/proj/hps_accel/gateware/gen2/macc.py
+++ b/proj/hps_accel/gateware/gen2/macc.py
@@ -16,7 +16,7 @@
 """Multiply Accumulate Blocks for a systolic array"""
 
 
-from nmigen import Mux, Signal, unsigned
+from nmigen import Mux, Signal, unsigned, Const, Instance, ClockSignal, ResetSignal, Cat
 from nmigen_cfu.util import tree_sum, SimpleElaboratable
 
 from .utils import delay
@@ -129,28 +129,70 @@ class MaccBlock(SimpleElaboratable):
     def elab(self, m):
         self._connect_passthrough(m)
 
-        # Pipeline cycle 0: calculate products
-        products = []
-        for i in range(self._n):
-            a_bits = self.input_a.word_select(i, self._a_shape.width)
-            b_bits = self.input_b.word_select(i, self._b_shape.width)
-            a = Signal(self._a_shape, name=f"a_{i}")
-            b = Signal(self._b_shape, name=f"b_{i}")
-            m.d.comb += [
-                a.eq(a_bits),
-                b.eq(b_bits),
-            ]
-            ab = Signal.like(a * b)
-            m.d.sync += ab.eq(a * b)
-            products.append(ab)
-
-        # Pipeline cycle 1: accumulate
-        product_sum = Signal.like(tree_sum(products))
-        m.d.comb += product_sum.eq(tree_sum(products))
-        first_delayed = delay(m, self.input_first, 1)[-1]
         accumulator = Signal(self._accumulator_shape)
-        base = Mux(first_delayed, 0, accumulator)
-        m.d.sync += accumulator.eq(base + product_sum)
+
+        a0 = self.input_a.word_select(0, self._a_shape.width)
+        b0 = self.input_b.word_select(0, self._b_shape.width)
+        a1 = self.input_a.word_select(1, self._a_shape.width)
+        b1 = self.input_b.word_select(1, self._b_shape.width)
+        a2 = self.input_a.word_select(2, self._a_shape.width)
+        b2 = self.input_b.word_select(2, self._b_shape.width)
+        a3 = self.input_a.word_select(3, self._a_shape.width)
+        b3 = self.input_b.word_select(3, self._b_shape.width)
+
+        # Explicitly instantiate the DSP macro
+        m.submodules.dsp = Instance(
+            "MULTADDSUB9X9WIDE",
+
+            i_CLK=ClockSignal(),
+            i_CEA0A1=Const(1),
+            i_CEA2A3=Const(1),
+            i_CEB0B1=Const(1),
+            i_CEB2B3=Const(1),
+            i_CEC=Const(1),
+            i_CEPIPE=Const(1),
+            i_CEOUT=Const(1),
+            i_CECTRL=Const(1),
+
+            i_RSTA0A1=ResetSignal(),
+            i_RSTA2A3=ResetSignal(),
+            i_RSTB0B1=ResetSignal(),
+            i_RSTB2B3=ResetSignal(),
+            i_RSTC=ResetSignal(),
+            i_RSTCTRL=ResetSignal(),
+            i_RSTPIPE=ResetSignal(),
+            i_RSTOUT=ResetSignal(),
+
+            i_SIGNED=Const(1),
+            i_ADDSUB=Const(0, unsigned(4)),
+
+            i_A0=a0,
+            i_B0=Cat(b0, b0[7]),
+            i_A1=a1,
+            i_B1=Cat(b1, b1[7]),
+            i_A2=a2,
+            i_B2=Cat(b2, b2[7]),
+            i_A3=a3,
+            i_B3=Cat(b3, b3[7]),
+
+            i_C=Const(0, unsigned(54)),
+            i_LOADC=self.input_first,
+
+            o_Z=accumulator,
+
+            p_REGINPUTAB0="BYPASS",
+            p_REGINPUTAB1="BYPASS",
+            p_REGINPUTAB2="BYPASS",
+            p_REGINPUTAB3="BYPASS",
+            p_REGINPUTC="BYPASS",
+            p_REGADDSUB="BYPASS",
+            p_REGLOADC="BYPASS",
+            p_REGLOADC2="REGISTER",
+            p_REGPIPELINE="REGISTER",
+            p_REGOUTPUT="REGISTER",
+            p_RESETMODE="SYNC",
+            p_GSR="ENABLED",
+        )
 
         # Pipeline cycle 2: optional accumulator output
         last_delayed = delay(m, self.input_last, 2)[-1]
@@ -159,3 +201,36 @@ class MaccBlock(SimpleElaboratable):
             m.d.sync += self.output_accumulator_new.eq(1)
         with m.Else():
             m.d.sync += self.output_accumulator_new.eq(0)
+
+        # The original RTL code below:
+
+#        # Pipeline cycle 0: calculate products
+#        products = []
+#        for i in range(self._n):
+#            a_bits = self.input_a.word_select(i, self._a_shape.width)
+#            b_bits = self.input_b.word_select(i, self._b_shape.width)
+#            a = Signal(self._a_shape, name=f"a_{i}")
+#            b = Signal(self._b_shape, name=f"b_{i}")
+#            m.d.comb += [
+#                a.eq(a_bits),
+#                b.eq(b_bits),
+#            ]
+#            ab = Signal.like(a * b)
+#            m.d.sync += ab.eq(a * b)
+#            products.append(ab)
+#
+#        # Pipeline cycle 1: accumulate
+#        product_sum = Signal.like(tree_sum(products))
+#        m.d.comb += product_sum.eq(tree_sum(products))
+#        first_delayed = delay(m, self.input_first, 1)[-1]
+#        accumulator = Signal(self._accumulator_shape)
+#        base = Mux(first_delayed, 0, accumulator)
+#        m.d.sync += accumulator.eq(base + product_sum)
+#
+#        # Pipeline cycle 2: optional accumulator output
+#        last_delayed = delay(m, self.input_last, 2)[-1]
+#        with m.If(last_delayed):
+#            m.d.sync += self.output_accumulator.eq(accumulator)
+#            m.d.sync += self.output_accumulator_new.eq(1)
+#        with m.Else():
+#            m.d.sync += self.output_accumulator_new.eq(0)

--- a/proj/hps_accel/gateware/gen2/sysarray.py
+++ b/proj/hps_accel/gateware/gen2/sysarray.py
@@ -17,7 +17,7 @@
 from nmigen import Signal, signed, unsigned
 from nmigen_cfu import SimpleElaboratable
 from .constants import Constants
-from .macc import MaccBlock
+from .macc import get_macc_block_class
 
 
 class SystolicArray(SimpleElaboratable):
@@ -82,6 +82,7 @@ class SystolicArray(SimpleElaboratable):
                  b_size=Constants.SYS_ARRAY_WIDTH, n=4,
                  a_shape=signed(9), b_shape=signed(8),
                  accumulator_shape=signed(32)):
+        self._specialize_nx = specialize_nx
         self._a_size = a_size
         self._b_size = b_size
         self._n = n
@@ -106,7 +107,8 @@ class SystolicArray(SimpleElaboratable):
                  for _ in range(self._a_size)]
         for i in range(self._a_size):
             for j in range(self._b_size):
-                macc = MaccBlock(self._n, self._a_shape, self._b_shape,
+                klass = get_macc_block_class(self._specialize_nx)
+                macc = klass(self._n, self._a_shape, self._b_shape,
                                  self._accumulator_shape)
                 maccs[i][j] = macc
 

--- a/proj/hps_accel/gateware/gen2/sysarray.py
+++ b/proj/hps_accel/gateware/gen2/sysarray.py
@@ -26,6 +26,10 @@ class SystolicArray(SimpleElaboratable):
     Parameters
     ----------
 
+    specialize_nx: bool
+      True to explicitly use Crosslink/NX DSP blocks, otherwise use regular
+      verilog multiply operation.
+
     a_size: int
       The number of A words processed concurrently
 
@@ -74,7 +78,7 @@ class SystolicArray(SimpleElaboratable):
       The accumulator update strobe from each macc unit
     """
 
-    def __init__(self, a_size=Constants.SYS_ARRAY_HEIGHT,
+    def __init__(self, specialize_nx=False, a_size=Constants.SYS_ARRAY_HEIGHT,
                  b_size=Constants.SYS_ARRAY_WIDTH, n=4,
                  a_shape=signed(9), b_shape=signed(8),
                  accumulator_shape=signed(32)):

--- a/proj/hps_accel/gateware/gen2/sysarray.py
+++ b/proj/hps_accel/gateware/gen2/sysarray.py
@@ -104,7 +104,7 @@ class SystolicArray(SimpleElaboratable):
 
     def elab(self, m):
         maccs = [[None for _ in range(self._b_size)]
-                 for _ in range(self._a_size)]
+                  for _ in range(self._a_size)]
         for i in range(self._a_size):
             for j in range(self._b_size):
                 klass = get_macc_block_class(self._specialize_nx)

--- a/proj/hps_accel/gateware/gen2/test_macc.py
+++ b/proj/hps_accel/gateware/gen2/test_macc.py
@@ -23,14 +23,15 @@ from nmigen.sim import Delay
 
 from nmigen_cfu import TestBase
 
-from .macc import MaccBlock
+from .macc import StandardMaccBlock
 
 
 class MaccBlockTest(TestBase):
     """Tests MaccBlock"""
 
     def create_dut(self):
-        return MaccBlock(4, unsigned(8), signed(8), signed(24))
+        # Can only use standard implementation in Amaranth simulator
+        return StandardMaccBlock(4, unsigned(8), signed(8), signed(24))
 
     def test_basic_functions(self):
         D = namedtuple('D', ['a', 'b', 'first', 'last', 'expected'])


### PR DESCRIPTION
Builds on #433 to ensure unit tests pass while allowing the use of the DSP macro when building for Crosslink NX.