### PR TITLE
Turn off LED chaser by default, without removing entirely.

### DIFF
--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -75,6 +75,7 @@ class HpsSoC(LiteXSoC):
     def __init__(self, platform, debug, litespi_flash=True, variant=None,
                  cpu_cfu=None, execute_from_lram=False,
                  separate_arena=False,
+                 with_led_chaser=False,
                  integrated_rom_init=[]):
         LiteXSoC.__init__(self,
                           platform=platform,
@@ -126,10 +127,11 @@ class HpsSoC(LiteXSoC):
             self.setup_rom_in_flash()
 
         # "LEDS" - Just one LED on JTAG port
-        self.submodules.leds = LedChaser(
-            pads=platform.request_all("user_led"),
-            sys_clk_freq=platform.sys_clk_freq)
-        self.csr.add("leds")
+        if with_led_chaser:
+            self.submodules.leds = LedChaser(
+                pads=platform.request_all("user_led"),
+                sys_clk_freq=platform.sys_clk_freq)
+            self.csr.add("leds")
 
 
         # UART


### PR DESCRIPTION
Signed-off-by: Tim Callahan <tcal@google.com>