### PR TITLE
hps: allow removing timer by not building BIOS code

### DIFF
--- a/proj/hps_accel/Makefile
+++ b/proj/hps_accel/Makefile
@@ -102,9 +102,16 @@ ifeq '$(TARGET)' 'digilent_arty'
 EXTRA_LITEX_ARGS += --sys-clk-freq 75000000
 endif
 
+ifeq '$(BUILD_BIOS)' 'yes'
+# By default the BIOS is not built as not required by the HPS app
+EXTRA_LITEX_ARGS += --build-bios
+endif
+
 # Add constants defined in gateware/constants.py to C++ build
 BUILD_DIR_EXTRA_DEP = $(BUILD_DIR)/src/gateware_constants.h
 
+# Number of parllel jobs
+BUILD_JOBS := 1
 
 #### Base rules ####
 include ../proj.mk

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -178,6 +178,8 @@ ifneq '$(VERILATOR_TRACE_DEPTH)' ''
 	ENABLE_TRACE_ARG := --trace
 endif
 
+BUILD_JOBS ?= 1
+
 .PHONY:	renode
 renode: renode-scripts
 	@echo Running interactively under renode
@@ -211,7 +213,7 @@ clean:
 software: $(SOFTWARE_BIN)
 
 $(SOFTWARE_BIN) $(SOFTWARE_ELF): litex-software build-dir
-	$(MAKE) -C $(BUILD_DIR) all
+	$(MAKE) -C $(BUILD_DIR) all -j $(BUILD_JOBS)
 
 # Always run cfu_gen when it exists
 # cfu_gen should not update cfu.v unless it has changed

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -87,4 +87,4 @@ $(BIOS_BIN): $(CFU_V)
 
 $(BITSTREAM): $(CFU_V)
 	@echo Building bitstream for Arty. CFU option: $(CFU_ARGS)
-	$(HPS_RUN) --build
+	$(HPS_RUN) --build --no-compile-software


### PR DESCRIPTION
This PR does the following:

- adds an additional argument for the HPS SoC to control whether the BIOS needs to be built. The default behavior is to not build the BIOS, therefore removing the unnecessary `timer0`, saving up a couple hundreds of LUTs and FFs.
- Adds the `--no-compile-software` flag when building the bitstream. CSRs are still being output, and they are also relevant only when building software. Given that changes either to the gateware or software in terms of CSR requires building both of them, it should be alwasy the case to first do `make clean` and than `make bitstream software`. 
- Adds possibility to build the HPS software parallely by adding the `BUILD_JOBS=<n jobs>` when running `make software`

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>