### PR TITLE
Update Setup Guide for Arty A7 using Symbiflow

### DIFF
--- a/docs/source/setup-guide.rst
+++ b/docs/source/setup-guide.rst
@@ -79,6 +79,12 @@ This starts a subshell; you can leave the environment by typing ``exit``.
 Later when you're building a project bitstream, 
 you need to add USE\_SYMBIFLOW=1 to your make command line.
 
+If you see no errors, but the compiled RISC-V executable does not run on the
+board, you may need to lower the target clock rate.
+This can be done by adding ``EXTRA_LITEX_ARGS="--sys-clk-freq {clockrate}"``
+to the make command, where {clockrate} if the desired clock rate in Hz.
+This will be required if you are using the suggested Arty A7 for the test run
+in Step 6 (try ``75000000`` Hz).
 
 
 Option 4b: Install Conda packages for Lattice FPGAs


### PR DESCRIPTION
Add note about symbiflow route and place tools not completing if
unable to meet timing. This will be likely to occur using the
suggested Arty A7 when completing the Test Run in Step 6 of the
Setup Guide. As this can be confusing for new users, this change
suggests the user can add the command to lower the target clock
rate when completing this step if required.