### PR TITLE
hps: reduce OSCA worst case to 7%

### DIFF
--- a/soc/hps_proto2_platform.py
+++ b/soc/hps_proto2_platform.py
@@ -70,11 +70,11 @@ class _CRG(Module):
         # Clock from HFOSC
         self.submodules.sys_clk = sys_osc = NXOSCA()
         sys_osc.create_hf_clk(self.cd_sys, sys_clk_freq)
-        # We make the period constraint 10% tighter than our actual system
+        # We make the period constraint 7% tighter than our actual system
         # clock frequency, because the CrossLink-NX internal oscillator runs
-        # at ±10% of nominal frequency.
+        # at ±7% of nominal frequency.
         platform.add_period_constraint(self.cd_sys.clk,
-                                       1e9 / (sys_clk_freq * 1.1))
+                                       1e9 / (sys_clk_freq * 1.07))
 
         # Power On Reset
         por_cycles = 4096


### PR DESCRIPTION
The current version of Crosslink-NX Family Data Sheet lists the high
frequency oscillator maximum frequency as 481.5MHz (that is, 7% higher
than its nominal 450MHz):

https://www.latticesemi.com/-/media/LatticeSemi/Documents/DataSheets/CrossLink/FPGA-DS-02049-1-2-1-CrossLink-NX-Family.ashx?document_id=52780

Older documents listed a wider frequency range but ±7% is the range for
production parts.