### PR TITLE
Vizier scripts for HPS platform

### DIFF
--- a/proj/hps_accel/vizier/__init__.py
+++ b/proj/hps_accel/vizier/__init__.py
@@ -1,0 +1,43 @@
+from abc import abstractclassmethod
+from concurrent.futures import ThreadPoolExecutor
+
+from  vizier.vapi import *
+from vizier.client import OptimizerClient
+
+class Optimizer:
+    def __init__(self, study: Study, concurrency: int):
+        self.study = study
+        self.concurrency = concurrency
+    
+    @abstractclassmethod
+    def run_blackbox(self, instance: int, **params) -> 'list[Measurement]':
+        pass
+
+    def optimize(self, client: OptimizerClient) -> Trial:
+        i_trial = 0
+        while i_trial < self.study.max_trials:
+            suggested_trials = client.get_suggestions(self.study, self.concurrency)
+
+            if len(suggested_trials) == 0:
+                break
+
+            trial_nos = [str(i) for i in range(i_trial, i_trial + len(suggested_trials))]
+            print(f'Running trials {", ".join(trial_nos)}...\n')
+
+            def suggested_params():
+                for trial in suggested_trials:
+                    yield dict((p.name, p.value) for p in trial.parameters)
+            def run_bb(instancee, params):
+                return self.run_blackbox(instancee, **params)
+            
+            with ThreadPoolExecutor(max_workers=len(suggested_trials)) as executor:
+                instances = range(0, len(suggested_trials))
+                threads = executor.map(run_bb, instances, suggested_params())
+                for ms, t in zip(threads, suggested_trials):
+                    t.measurements = [client.process_measurement(self.study, m) for m in ms]
+                    print(f'Completing trial {t.to_json_dict()}\n')
+                    client.complete_trial(self.study, t)
+            
+            i_trial += len(suggested_trials)
+
+        return client.get_best_trial(self.study)

--- a/proj/hps_accel/vizier/client.py
+++ b/proj/hps_accel/vizier/client.py
@@ -1,0 +1,31 @@
+from abc import abstractclassmethod;
+
+from vizier.vapi import *
+
+class OptimizerClient:
+    def __init__(self):
+        pass
+
+    @abstractclassmethod
+    def create_study(self, study: Study, concurrency: int):
+        pass
+    
+    @abstractclassmethod
+    def get_suggestions(self, study: Study, concurrency: int) -> 'list[Trial]':
+        pass
+    
+    @abstractclassmethod
+    def process_measurement(
+        self,
+        study: Study,
+        measurement: Measurement
+    ) -> Measurement:
+        pass
+
+    @abstractclassmethod
+    def complete_trial(self, study: Study, trial: Trial):
+        pass
+
+    @abstractclassmethod
+    def get_best_trial(self, study: Study) -> Trial:
+        pass

--- a/proj/hps_accel/vizier/client_vizier.py
+++ b/proj/hps_accel/vizier/client_vizier.py
@@ -1,0 +1,188 @@
+import math
+import random
+import time
+
+from google.cloud import storage
+from googleapiclient import discovery, errors
+from scipy.fftpack import idct
+
+from vizier.client import OptimizerClient
+from vizier.vapi import *
+
+_OPTIMIZER_API_DOCUMENT_BUCKET = 'caip-optimizer-public'
+_OPTIMIZER_API_DOCUMENT_FILE = 'api/ml_public_google_rest_v1.json'
+
+random.seed()
+
+def _read_api_document(project_id):
+    client = storage.Client(project_id)
+    bucket = client.get_bucket(_OPTIMIZER_API_DOCUMENT_BUCKET)
+    blob = bucket.get_blob(_OPTIMIZER_API_DOCUMENT_FILE)
+    return blob.download_as_string()
+
+def _trial_name(project_id, region, study_id, trial_id):
+  return f'projects/{project_id}/locations/{region}/studies/{study_id}/trials/{trial_id}'
+
+def trial_from_gtrial(study: Study, id, gtrial):    
+    trial = Trial(
+        client_id = id,
+        state = gtrial['state'],
+        parameters = [],
+        measurements = []
+    )
+
+    for param in gtrial['parameters']:
+        pname = param['parameter']
+        ptype = study.parameters[pname].type
+        pval = None
+        if ptype in ['DOUBLE', 'DISCRETE']:
+            pval = param['floatValue']
+        elif ptype == 'INTEGER':
+            pval = param['intValue']
+        elif ptype == 'CATEGORICAL':
+            pval = param['stringValue']
+        else:
+            raise Exception('Unknown parameter type')
+
+        p: Parameter = study.parameters[pname].trial(pname, pval)
+        trial.parameters += [p]
+    
+    return trial
+
+class VizierClient(OptimizerClient):
+    def __init__(self, account, project_id, region):
+        self.account = account
+        self.project_id = project_id
+        self.region = region
+        self.client_id = f'client{"".join([str(random.choice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) for i in range(0, 8)])}'
+        self.api = discovery.build_from_document(service=_read_api_document(self.project_id))
+    
+    def create_study(self, study: Study, concurrency: int):
+        # study_id = f'{self.account}_study_{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}'
+        req = self.api.projects().locations().studies().create(
+            parent=f'projects/{self.project_id}/locations/{self.region}',
+            studyId=study.name,
+            body={'study_config': study.to_json_dict()}
+        )
+        try:
+            print(req.execute())
+        except errors.HttpError as e:
+            if e.resp.status == 409:
+                print('Study already existed.')
+            else:
+                raise e
+    
+    def get_suggestions(self, study: Study, concurrency: int) -> 'list[Trial]':
+        resp = self.api.projects().locations().studies().trials().suggest(
+            parent = f'projects/{self.project_id}/locations/{self.region}/studies/{study.name}',
+            body = { 'client_id': self.client_id, 'suggestion_count': concurrency }
+        ).execute()
+        op_id = resp['name'].split('/')[-1]
+        get_op = self.api.projects().locations().operations().get(
+            name = f'projects/{self.project_id}/locations/{self.region}/operations/{op_id}'
+        )
+
+        # Wait for GCloud to be done
+        while True:
+            op = get_op.execute()
+            if 'done' in op and op['done']:
+                break
+            time.sleep(1)
+        
+        trials = []
+        for suggestion in get_op.execute()['response']['trials']:
+            id = int(suggestion['name'].split('/')[-1])
+            gtrial = self.api.projects().locations().studies().trials().get(
+                name=_trial_name(self.project_id, self.region, study.name, id)
+            ).execute()
+
+            if gtrial['state'] in ['COMPLETED', 'INFEASIBLE']:
+                continue
+
+            trial = trial_from_gtrial(study, id, gtrial)
+
+            trials += [trial]
+        
+        print(f'Suggestions: {[t.to_json_dict() for t in trials]}')
+
+        return trials
+            
+    def process_measurement(
+        self,
+        study: Study,
+        measurement: Measurement
+    ) -> Measurement:
+        # Google Cloud Measurements don't require extra processing
+        return measurement
+    
+    def complete_trial(self, study: Study, trial: Trial):
+        trial_name = _trial_name(self.project_id, self.region, study.name, trial.client_id)
+        for m in  [m.to_json_dict() for m in trial.measurements]:
+            self.api.projects().locations().studies().trials().addMeasurement(
+            name = trial_name,
+            body={'measurement': m}
+        ).execute()
+        self.api.projects().locations().studies().trials().complete(
+            name = trial_name
+        ).execute()
+
+    def get_best_trial(self, study: Study) -> Trial:
+        resp = self.api.projects().locations().studies().trials().list(
+            parent = f'projects/{self.project_id}/locations/{self.region}/studies/{study.name}'
+        ).execute()
+
+        trials: 'list[Trial]' = []
+        
+        for gtrial in resp['trials']:
+            if 'finalMeasurement' in gtrial:
+                id = int(gtrial['name'].split('/')[-1])
+                trial = trial_from_gtrial(study, id, gtrial)
+                trial.measurements += [Measurement()]
+                for metric in gtrial['finalMeasurement']['metrics']:
+                    # TODO: Cloud does not return the `value` field.
+                    # Investigate what's going on.
+                    trial.measurements[-1].metrics[metric['metric']] = metric['value']
+                
+                if trial is None:
+                    continue
+                trials += [trial]
+        
+        # Find minimums / maximums for each metric in order to construct
+        # a space for optimizing length of a vector
+        mins = {}
+        maxs = {}
+        for t in trials:
+            # Dunno what to do with extra measuremenrs
+            measurement = t.measurements[-1]
+            for m_name, m_value in measurement.metrics:
+                if mins.get(m_name) is None:
+                    mins[m_name] = m_value
+                elif mins[m_value] > m_value:
+                    mins[m_value] = m_value
+                if maxs.get(m_name) is None:
+                    maxs[m_name] = m_value
+                elif maxs[m_value] < m_value:
+                    maxs[m_value] = m_value
+
+        # Minimze length of a metrics vector
+        maxlen = 0
+        best_trial = None
+        for t in trials:
+            # Dunno what to do with extra measuremenrs
+            measurement = t.measurements[-1]
+
+            length = 0
+            for m_name, m_value in measurement.metrics.items():
+                v = 0 
+                if study.metrics[m_name] == 'MINIMIZE':
+                    v = maxs[m_name] - m_value
+                else:
+                    v = m_value - mins[m_name]
+
+                length += v * v
+            length = math.sqrt(length)
+            if length > maxlen:
+                maxlen = length
+                best_trial = t
+        
+        return best_trial

--- a/proj/hps_accel/vizier/vapi.py
+++ b/proj/hps_accel/vizier/vapi.py
@@ -1,0 +1,227 @@
+import json
+from abc import abstractclassmethod;
+
+
+class ToJsonDict:
+    @abstractclassmethod
+    def to_json_dict(self) -> dict:
+        pass
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_json_dict())
+
+class MetricSpec(ToJsonDict):
+    def __init__(self, goal: str, metric: str):
+        self.metric = metric
+        self.goal = goal
+    
+    def to_json_dict(self):
+        return {
+            'metric': self.metric,
+            'goal': self.goal,
+        }
+
+class NumericalValueSpec(ToJsonDict):
+    def __init__(self, min, max):
+        self.min_value = min
+        self.max_value = max
+    
+    def to_json_dict(self):
+        return {
+            'min_value': self.min_value,
+            'max_value': self.max_value,
+        }
+
+class DiscreteValueSpec(ToJsonDict):
+    def __init__(self, values: 'list[int] | list[str]'):
+        self.values: 'list[int] | list[str]' = values
+
+CategoricalValueSpec = DiscreteValueSpec
+
+class TrialParameter(ToJsonDict):
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+        self.ufield = 'value'
+    
+    def to_json_dict(self) -> dict:
+        return {
+            'parameter': self.name,
+            self.ufield: self.value
+        }
+
+class TrialParameterDouble(TrialParameter):
+    def __init__(self, name, value):
+        super().__init__(name, value)
+        self.ufield = 'float_value'
+
+TrialParameterDiscrete = TrialParameterDouble
+
+class TrialParameterInt(TrialParameter):
+    def __init__(self, name, value):
+        super().__init__(name, value)
+        self.ufield = 'int_value'
+
+class TrialParameterCategorical(TrialParameter):
+    def __init__(self, name, value):
+        super().__init__(name, value)
+        self.ufield = 'string_value'
+
+def _abstract_param_trial(name, value):
+    raise Exception('Abstract parameter')
+
+class Parameter:
+    def __init__(self):
+        self.type: str = 'PARAMETER_TYPE_UNSPECIFIED'
+        self.value_spec: 'DiscreteValueSpec | NumericalValueSpec' = None
+        self.scale = None
+        self.trial = _abstract_param_trial
+
+class ParameterInt(Parameter):
+    def __init__(self, min, max, scale='UNSPECIFIED'):
+        self.type = 'INTEGER'
+        self.value_spec = NumericalValueSpec(min, max)
+        self.scale = scale
+        self.trial = TrialParameterInt
+    
+    def trial(self, name: str, value) -> TrialParameter:
+        TrialParameterInt(name, value)
+
+class ParameterDouble(Parameter):
+    def __init__(self, min, max, scale='UNSPECIFIED'):
+        self.type = 'DOUBLE'
+        self.value_spec = NumericalValueSpec(min, max)
+        self.scale = scale
+        self.trial = TrialParameterDouble
+
+class ParameterCategorical(Parameter):
+    def __init__(self, *values):
+        self.type = 'CATEGORICAL'
+        self.value_spec = DiscreteValueSpec(*values)
+        self.trial = TrialParameterCategorical
+
+class ParameterDiscrete(Parameter):
+    def __init__(self, *values, scale='UNSPECIFIED'):
+        self.type = 'DISCRETE'
+        self.value_spec = DiscreteValueSpec(*values)
+        self.scale = scale
+        self.trial = self.trial = TrialParameterDiscrete
+
+class DecayCurveStoppingConfig(ToJsonDict):
+    def __init__(self, use_elapsed_time=False):
+        self.use_elapsed_time = use_elapsed_time
+
+    def to_json_dict(self) -> dict:
+        return { 
+            'DecayCurveAutomatedStoppingConfig': {
+                'useElapsedTime': self.use_elapsed_time
+            }
+        }
+
+class MedianAutomatedStoppingConfig(ToJsonDict):
+    def __init__(self, use_elapsed_time=False):
+        self.use_elapsed_time = use_elapsed_time
+
+    def to_json_dict(self) -> dict:
+        return { 
+            'MedianAutomatedStoppingConfig': {
+                'useElapsedTime': self.use_elapsed_time
+            }
+        }
+
+_vizier_scale_map = {
+    'UNSPECIFIED': 'SCALE_TYPE_UNSPECIFIED',
+    'LINEAR': 'UNIT_LINEAR_SCALE',
+    'LOG': 'UNIT_LOG_SCALE',
+    'REVERSE_LOG': 'UNIT_REVERSE_LOG_SCALE'
+}
+
+class Study(ToJsonDict):
+    def __init__(
+        self,
+        name: str,
+        max_trials: int,
+        metrics: 'list[MetricSpec]',
+        parameters: 'dict[str, Parameter]',
+        algorithm: str = 'ALGORITHM_UNSPECIFIED',
+        asconfig: 'MedianAutomatedStoppingConfig | None' = None
+    ):
+        self.name = name
+        self.algorithm: str = algorithm
+        self.metrics: 'dict[str, str]' = metrics
+        self.parameters: 'dict[str, Parameter]' = parameters
+        self.asconfig: 'MedianAutomatedStoppingConfig | None' = asconfig
+        self.max_trials = max_trials
+    
+    def to_json_dict(self):
+        parameters = []
+        for name, spec in self.parameters.items():
+            p = {
+                'parameter': name,
+                'type': spec.type,
+                f'{spec.type.lower()}_value_spec': spec.value_spec.to_json_dict()
+            }
+            if spec.scale:
+                p['scale_type'] = _vizier_scale_map[spec.scale]
+            parameters += [p]
+
+        d = {
+            'metrics': [MetricSpec(goal, name).to_json_dict() for name, goal in self.metrics.items()],
+            'parameters': parameters,
+            'algorithm': self.algorithm,
+        }
+        if self.asconfig is not None:
+            d['automatedStoppingConfig'] = self.asconfig.to_json_dict()
+        return d
+
+class Metric(ToJsonDict):
+    def __init__(self, metric, value):
+        self.metric = metric
+        self.value = value
+    
+    def to_json_dict(self) -> dict:
+        return {
+            'metric': self.metric,
+            'value': self.value
+        }
+        
+
+class Measurement(ToJsonDict):
+    def __init__(self,
+        step_count: int = 1,
+        metrics: 'dict[str, ]' = {}
+    ) -> None:
+        self.step_count = step_count
+        self.metrics = metrics
+    
+    def to_json_dict(self) -> dict:
+        return {
+            'step_count': self.step_count,
+            'metrics': [Metric(name, val).to_json_dict() for name, val in self.metrics.items()]
+        }
+
+class Trial(ToJsonDict):
+    def __init__(
+        self,
+        client_id = None,
+        state: str = 'STATE_UNSPECIFIED',
+        parameters: 'list[TrialParameter]' = [],
+        measurements: 'list[Measurement]' = [],
+        final_measurement: 'int | None' = None
+    ):
+        self.state = state
+        self.client_id = client_id
+        self.parameters: 'list[TrialParameter]' = parameters
+        self.measurements: 'list[Measurement]' = measurements
+        self.final_measurement: 'int | None' = final_measurement
+        
+        # See https://cloud.google.com/ai-platform/optimizer/docs/reference/rest/v1/projects.locations.studies.trials
+        # description of measurements[] field
+        self.measurements.sort(key=lambda m: (m.step_count, m.elapsed_time))
+    
+    def to_json_dict(self) -> dict:
+        return {
+            'state': self.state,
+            'parameters': [p.to_json_dict() for p in self.parameters],
+            'measurements': [m.to_json_dict() for m in self.measurements],
+        }

--- a/proj/hps_accel/vizier_autotune.ipynb
+++ b/proj/hps_accel/vizier_autotune.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vizier Auto-tuning\n",
+    "\n",
+    "Use this notebook to find optimal parameters for `nextpnr` using Google Vizier framework."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Install python dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! pip install -U google-api-python-client\n",
+    "! pip install -U google-cloud\n",
+    "! pip install -U google-cloud-storage\n",
+    "! pip install -U requests\n",
+    "! pip install -U matplotlib\n",
+    "! pip install -U scipy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Synthesize design\n",
+    "\n",
+    "Let's synthesize design beforehand. After all we want to test only nextpnr."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Specify a path for your riscv toolchain installation.\n",
+    "# Might be unncessary if you are running inside a conda environment\n",
+    "riscv_toolchain_path = '../../../riscv64-unknown-elf-gcc-10.1.0-2020.08.2-x86_64-linux-ubuntu14/'\n",
+    "riscv_toolchain_path = os.path.realpath(riscv_toolchain_path)\n",
+    "\n",
+    "rv_bin = os.path.join(riscv_toolchain_path, 'bin')\n",
+    "path = f'{rv_bin}:{os.environ[\"PATH\"]}'\n",
+    "\n",
+    "! source ../../env/conda/bin/activate cfu-common\n",
+    "%env PATH $path\n",
+    "! make synth"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure SaaS backend and authorization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Google Cloud Vizier config\n",
+    "gc_accnt = 'example@email.com'\n",
+    "gc_project_id = 'project_id'\n",
+    "gc_region= 'region'\n",
+    "%env GOOGLE_APPLICATION_CREDENTIALS credentials.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create study"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import datetime\n",
+    "from vizier.vapi import *\n",
+    "\n",
+    "random.seed()\n",
+    "\n",
+    "def make_study_name(identity):\n",
+    "    random_id = ''.join(str(random.choice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])) for i in range(0, 8))\n",
+    "    return f'hps-study{random_id}_{identity}_{datetime.datetime.now().strftime(\"%Y%m%d_%H%M%S\")}'\n",
+    "\n",
+    "study_id = make_study_name('hps')\n",
+    "\n",
+    "print(f'Study will be named \"{study_id}\"')\n",
+    "\n",
+    "study = Study(\n",
+    "    name = study_id,\n",
+    "    max_trials = 3,\n",
+    "    # Add metrics to optimize here\n",
+    "    metrics = {\n",
+    "        'fmax': 'MAXIMIZE',\n",
+    "        'runtime': 'MINIMIZE'\n",
+    "    },\n",
+    "    # Add parameters for the blackbox here.\n",
+    "    # Use 'UNSPECIFIED'/'LENEAR'/'LOG'/'REVERSE_LOG' to define parameter scaling (Vizier)\n",
+    "    parameters = {\n",
+    "        'estimate-delay-mult': ParameterInt(min=10, max=50, scale='LINEAR')\n",
+    "    },\n",
+    "    # Choose algorithm. Vizier accepts the following options:\n",
+    "    # 'ALGORITHM_UNSPECIFIED', 'GAUSSIAN_PROCESS_BANDIT', 'GRID_SEARCH' (discrete/categorical params only)\n",
+    "    # and 'RANDOM_SEARCH'\n",
+    "    algorithm = 'GAUSSIAN_PROCESS_BANDIT'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create a Vizier-compatible client\n",
+    "\n",
+    "This version of script is meant to be used with Vizier backend. Use `VizierClient`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vizier.client_vizier import VizierClient\n",
+    "\n",
+    "! gcloud config set project $gc_project_id\n",
+    "# ! gcloud auth application-default login\n",
+    "! gcloud auth login $gc_accnt\n",
+    "client = VizierClient(gc_accnt, gc_project_id, gc_region)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set-up an Optimizer for HPS flow\n",
+    "\n",
+    "This is where we define how to use out \"black-box\", ie. the Oxide flow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vizier import Optimizer\n",
+    "import subprocess\n",
+    "import os\n",
+    "import shutil\n",
+    "import json\n",
+    "import time\n",
+    "\n",
+    "# Path to nextpnr-nexus\n",
+    "nextpnr = '/mnt/more/Documents/symbiflow-enhancements-fpga-tool-perf/env/conda'\\\n",
+    "          '/envs/nextpnr-env/bin/nextpnr-nexus'\n",
+    "\n",
+    "def get_metrics_from_report(json_dict):\n",
+    "    return {\n",
+    "        'fmax': json_dict['fmax']['clkout$glb_clk']['achieved']\n",
+    "    }\n",
+    "\n",
+    "def params_to_npr_args(params):\n",
+    "    args = []\n",
+    "    for name, value in params.items():\n",
+    "        args += [f'--{name}', str(value)]\n",
+    "    return args\n",
+    "\n",
+    "def standard_npr_args(json, pdc, result_fasm, device):\n",
+    "    return [\n",
+    "        '--json', json,\n",
+    "        '--pdc', pdc,\n",
+    "        '--fasm', result_fasm,\n",
+    "        '--device', device,\n",
+    "        '--detailed-timing-report'\n",
+    "    ]\n",
+    "\n",
+    "next_dir = 'next'\n",
+    "os.makedirs(next_dir, exist_ok=True)\n",
+    "\n",
+    "gateware_dir = os.path.realpath('../../soc/build/hps.hps_accel/gateware')\n",
+    "\n",
+    "class HpsFlowOptimizer(Optimizer):\n",
+    "\n",
+    "    # Run the blackbox inside the `run_blackbox` method. The `instance` parameter is an instance\n",
+    "    # number of the blackbox if multiple blackboxes are being run in parallel. This can be used\n",
+    "    # avoid problems if the blackbox generates some artifacts in the filesystem.\n",
+    "    def run_blackbox(self, instance, **params) -> 'list[Measurement]':\n",
+    "        dir_path = os.path.join(next_dir, f'run_{instance}')\n",
+    "\n",
+    "        if os.path.exists(dir_path):\n",
+    "            shutil.rmtree(dir_path)\n",
+    "        os.makedirs(dir_path)\n",
+    "\n",
+    "        report_path = os.path.join(dir_path, f'next_report.json')\n",
+    "\n",
+    "        args = standard_npr_args(\n",
+    "            json = os.path.join(gateware_dir, 'hps_proto2_platform.json'),\n",
+    "            pdc = os.path.join(gateware_dir, 'hps_proto2_platform.pdc'),\n",
+    "            result_fasm = os.path.join(dir_path, 'hps_proto2_platform.fasm'),\n",
+    "            device = 'LIFCL-17-8UWG72C'\n",
+    "        ) + ['--report', report_path] + params_to_npr_args(params)\n",
+    "\n",
+    "        now = time.time()\n",
+    "        subprocess.run([nextpnr] + args)\n",
+    "        duration = time.time() - now\n",
+    "\n",
+    "        metrics: dict\n",
+    "        with open(report_path, 'r') as report:\n",
+    "            metrics = get_metrics_from_report(json.loads(report.read()))\n",
+    "        metrics['runtime'] = duration\n",
+    "        \n",
+    "        return [Measurement(metrics = metrics)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Auto-tune"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from vizier import Optimizer\n",
+    "\n",
+    "concurrency = 1\n",
+    "\n",
+    "client.create_study(study, concurrency)\n",
+    "\n",
+    "# Best trial is currently being calculated by finding the longest vector.\n",
+    "# In case of values that are expected to be minimized, they get substracted from maximum during\n",
+    "# computations. See `get_best_trial` in cielnt_vizier.py.\n",
+    "best_trial = HpsFlowOptimizer(study, concurrency).optimize(client)\n",
+    "\n",
+    "print(f'Parameters: {\", \".join([\"{}: {}\".format(p.name, p.value) for p in best_trial.parameters])}')\n",
+    "\n",
+    "i = 0\n",
+    "for measurement in best_trial.measurements:\n",
+    "    print(f'Measurements[{i}]: {\",\".join([\"{}: {}\".format(name, value) for name, value in measurement.metrics.items()])}')\n",
+    "    i += 0"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "b4b51eb36172fd8699849e82c9b2a9926c1fd27781b3e4794bcc81e1be220048"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.5 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -286,6 +286,9 @@ prog: $(CFU_VERILOG)
 bitstream: $(CFU_VERILOG)
 	$(SOC_MK) bitstream
 
+synth: $(CFU_VERILOG)
+	$(SOC_MK) synth
+
 ifeq '1' '$(words $(TTY))'
 run: $(SOFTWARE_BIN)
 	@echo Running automated pdti8 test on board

--- a/soc/hps.mk
+++ b/soc/hps.mk
@@ -63,10 +63,13 @@ HPS_RUN:=   MAKEFLAGS=-j8 $(PYRUN) ./hps_soc.py $(LITEX_ARGS)
 
 BIOS_BIN := $(OUT_DIR)/software/bios/bios.bin
 BITSTREAM:= $(OUT_DIR)/gateware/hps_proto2_platform.bit
+SYNTH:= $(OUT_DIR)/gateware/hps_proto2_platform.json
 
 .PHONY: bitstream litex-software prog clean
 
 bitstream: $(BITSTREAM)
+
+synth: $(SYNTH)
 
 litex-software: $(BIOS_BIN)
 
@@ -86,5 +89,9 @@ $(BIOS_BIN): $(CFU_V)
 	$(HPS_RUN)
 
 $(BITSTREAM): $(CFU_V)
-	@echo Building bitstream for Arty. CFU option: $(CFU_ARGS)
+	@echo Building bitstream for Nexus. CFU option: $(CFU_ARGS)
 	$(HPS_RUN) --build
+
+$(SYNTH): $(CFU_V)
+	@echo Synthesizing sources for Nexus. CFU option: $(CFU_ARGS)
+	$(HPS_RUN) --build --just-synth

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -292,6 +292,7 @@ def main():
                         help="Make the CPU execute from integrated ROM stored in LRAM instead of flash")
     parser.add_argument("--integrated-rom-init", metavar="FILE",
                         help="Use FILE as integrated ROM data instead of default BIOS")
+    parser.add_argument("--just-synth", action='store_true', help="Stop after synthesis")
 
     args = parser.parse_args()
 
@@ -310,7 +311,7 @@ def main():
     else:
         variant = "full+debug" if args.debug else "full"
     copy_cpu_variant_if_needed(variant)
-    soc = HpsSoC(Platform(args.toolchain, args.parallel_nextpnr, args.extra_nextpnr_params),
+    soc = HpsSoC(Platform(args.toolchain, args.parallel_nextpnr, args.extra_nextpnr_params, args.just_synth),
                     debug=args.debug,
                     variant=variant,
                     cpu_cfu=args.cpu_cfu,


### PR DESCRIPTION
Integration with Google Vizier platform for HPS gen2.

Simply fill the required fields in `proj/hps_accel/vizier_autotune.ipynb` and run the notebook.
You can change the parameters to be adjusted and metrics to be optimized by modyfying the study definition structure. Parameter names are indentical as names used by `nextpnr-nexus`. See the notebook for more details.

The most universal way of running this notebook (headless, requires no DE, except for Google authentication which is done through browser. To avoid that you need to provide cached credentials for `gcloud`):
```
cd proj/hps_accel
jupyter nbconvert --to notebook --execute vizier_autotune.ipynb --output=output.ipynb
```

Using jupyter-lab may cause severe performance issues when displaying synthesis output. Classic jupyter notebook and Jupter extension for VS Code handle the output fine.

You will be asked to authenticate using your Google account twice.
That's just how Google handles the authentication process.