### PR TITLE
Filter the sync workflows to only run on the main repo

### DIFF
--- a/.github/workflows/sync-renode.yml
+++ b/.github/workflows/sync-renode.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: |
-      github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+      github.repository_owner == 'google' && ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' )
 
     env:
       GH_SERVICE_ACCOUNT_NAME: "CFU-Playground-Bot"

--- a/.github/workflows/sync-tflm.yml
+++ b/.github/workflows/sync-tflm.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: |
-      github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+      github.repository_owner == 'google' && ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' )
 
     env:
       GH_SERVICE_ACCOUNT_NAME: "CFU-Playground-Bot"


### PR DESCRIPTION
It turned out that detecting if you are a fork in runtime is hell, but there's a convenient check we might have. It has a hardcoded "google" string, so please let me know if it's ok