### PR TITLE
Add SymbiFlow Yosys plugins even for non-Xilinx env.

### DIFF
--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - litex-hub::nextpnr-ice40
   - litex-hub::iceprog
   - litex-hub::yosys
+  - litex-hub::symbiflow-yosys-plugins
   - python=3.7
   - pip
   - pip:


### PR DESCRIPTION
(required for some upcoming Lattice Nexus optimizations)

Signed-off-by: Tim Callahan <tcal@google.com>