### PR TITLE
Make Arty default clk freq 75MHz when using SymbiFlow.

### DIFF
--- a/soc/board_specific_workflows/digilent_arty.py
+++ b/soc/board_specific_workflows/digilent_arty.py
@@ -43,6 +43,8 @@ class DigilentArtySoCWorkflow(general.GeneralSoCWorkflow):
                             help='Arty variant: a7-35 (default) or a7-100')
         arty_args = parser.parse_known_args()[0]
         args = argparse.Namespace(**vars(arty_args), **vars(args))
+        if args.toolchain == 'symbiflow' and not args.sys_clk_freq:
+            args.sys_clk_freq = 75000000
         super().__init__(args, soc_constructor, builder_constructor)
 
     def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:

--- a/soc/board_specific_workflows/digilent_arty.py
+++ b/soc/board_specific_workflows/digilent_arty.py
@@ -43,8 +43,20 @@ class DigilentArtySoCWorkflow(general.GeneralSoCWorkflow):
                             help='Arty variant: a7-35 (default) or a7-100')
         arty_args = parser.parse_known_args()[0]
         args = argparse.Namespace(**vars(arty_args), **vars(args))
+
+        #
+        # If using SymbiFlow, and the user hasn't specified the target freq,
+        # use 75MHz as default. Currently, using the litex-boards default 100MHz
+        # with SymbiFlow usually results in a bitstream that does not function
+        # on the board.
+        #
+        # This should be removed when SymbiFlow can reliably
+        # produce a working bitstream at 100MHz.
+        #
         if args.toolchain == 'symbiflow' and not args.sys_clk_freq:
             args.sys_clk_freq = 75000000
+            print("INFO:Workflow:Setting sys_clk_freq to 75MHz.");
+
         super().__init__(args, soc_constructor, builder_constructor)
 
     def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:


### PR DESCRIPTION
This PR changes the default target frequency for the Arty A7 board to 75MHz when SymbiFlow is used.   It can still be overridden by an explicit `--sys-clk-freq` LiteX option to be either higher or lower.

The default frequency for an Arty A7 board in litex-boards is 100MHz.  When the bitstream is built with this target frequency, vpr will not meet timing, but it will not give visible error, and a bitstream will be generated.   The bitstream will not work on the board; the LEDChaser works, but loading and running software over UART does not work (see #455).

There is an open issue for vpr to produce a hard error when it does not meet timing (https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1928).   However, here we would need to downgrade the error, since with even a simple CFU, the achieved maximum frequency (fmax) is 50MHz, but we can't drop the requested frequency that low, since at that frequency DDR memory does not function.

Experiments show that building for 75MHz and running on the board at that frequency usually works, even though vpr reports an fmax of about 50MHz.   Whether it actually works on a given board is dependent on the particular device though, so it is not guaranteed to work in all cases.

This current workaround would be better if there was a very visible message visible to the user along the lines of "75.0MHz requested but only xx.xMHz achieved.   A bitstream has been produced, but it is not guaranteed to work at 75.0MHz."

Followup questions:
* Is vpr being too conservative in its fmax calculation?   Running the fasm through fasm2bels --> Vivado timing analysis could give us some useful information.
* Is there a plan to improve fmax so that we can target 100MHz and meet timing with high confidence?   Is the issue that DSP blocks are not used?

Signed-off-by: Tim Callahan <tcal@google.com>