### PR TITLE
Expand space for .text section from 0x80000 to 0x81000 on HPS platform

### DIFF
--- a/common/_hps/hps/ld/linker.ld
+++ b/common/_hps/hps/ld/linker.ld
@@ -24,7 +24,7 @@ SECTIONS
 		/*
 		 * Align models and large chunks of data into a constant position
 		 */
-		. = _ftext + 0x80000;
+		. = _ftext + 0x81000;
 		_frodata = .;
 		src/models/*/*(SORT(.rodata.*))
 		src/conv2d_??.o(SORT(.rodata.*))  /* specific to hps_accel */

--- a/proj/example_cfu/Makefile
+++ b/proj/example_cfu/Makefile
@@ -19,8 +19,25 @@ export DEFINES := PLACEHOLDER
 # Uncomment this line to use software defined CFU
 # DEFINES += CFU_SOFTWARE_DEFINED
 
-# Uncomment to include pdti8 in built binary
+# Uncomment this line to skip debug code (large effect on performance)
+DEFINES += NDEBUG
+
+# Uncomment this line to skip individual profiling output (has minor effect on performance).
+#DEFINES += NPROFILE
+
+# Uncomment to include specified model in built binary
 DEFINES += INCLUDE_MODEL_PDTI8
+#DEFINES += INCLUDE_MODEL_MICRO_SPEECH
+#DEFINES += INCLUDE_MODEL_MAGIC_WAND
+#DEFINES += INCLUDE_MODEL_MNV2
+#DEFINES += INCLUDE_MODEL_HPS
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_ANOMD
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_IMGC
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_KWS
+#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_VWW
+
+# Uncomment to include all TFLM examples (pdti8, micro_speech, magic_wand)
+#DEFINES += INCLUDE_ALL_TFLM_EXAMPLES
 
 # Tests are in implementation files in this project
 PYTEST_PATTERN := '*.py'


### PR DESCRIPTION
HPS tests were failing with the latest tflite-micro bump (https://github.com/google/CFU-Playground/pull/500#issuecomment-1075741023).   With local testing, I observed the same thing also on `main` branch, which is a bit puzzling.   This is the error (the exact value can vary):
```
/home/runner/work/CFU-Playground/CFU-Playground/proj/example_cfu/build/ld/linker.ld:27
cannot move location counter backwards (from 00000000202803f0 to 0000000020280000)
```

To reproduce the previous behavior locally,
```
cd proj/example_cfu
make PLATFORM=hps BUILD_JOBS=8 software
```
Edit: Another mystery -- the symptom only occurs eith `example_cfu` -- not with `proj_accel_1`, `mnv2_first`, `hps_accel`, or the  template projects.    I haven't found what the difference is.

Edit#2: Solved!   All of the other projects use `DEFINES += NDEBUG` to remove debug code.   When I add that to `example_cfu`, it also passes.    @alanvgreen , would you prefer that we go ahead and expand the .text section anyway, or, just add NDEBUG to the failing test?    Edit: why not both?  I've pushed another commit.


Signed-off-by: Tim Callahan <tcal@google.com>