### PR TITLE
Initial code for building customized VexRiscv on-demand.

### DIFF
--- a/soc/board_specific_workflows/general.py
+++ b/soc/board_specific_workflows/general.py
@@ -21,6 +21,7 @@ from litex.soc.integration import soc_core
 from litex.soc.cores.cpu.vexriscv import core
 from typing import Callable
 from patch_cpu_variant import patch_cpu_variant, copy_cpu_variant_if_needed
+from patch_cpu_variant import build_cpu_variant_if_needed
 
 
 
@@ -77,6 +78,9 @@ class GeneralSoCWorkflow():
             base_soc_kwargs['toolchain'] = self.args.toolchain
         if self.args.sys_clk_freq:
             base_soc_kwargs['sys_clk_freq'] = self.args.sys_clk_freq
+
+        print("make_soc: cpu_variant is", self.args.cpu_variant)
+        build_cpu_variant_if_needed(self.args.cpu_variant)
 
         base_soc_kwargs.update(kwargs)
         return self.soc_constructor(**base_soc_kwargs)

--- a/soc/patch_cpu_variant.py
+++ b/soc/patch_cpu_variant.py
@@ -93,3 +93,53 @@ def copy_cpu_variant_if_needed(variant):
                 print(f"Couldn't find \"{custom_cpu}\".")
     else:
         print(f"Variant \"{variant}\" not known.")
+
+
+################################################################
+# This builds a CPU variant on demand 
+################################################################
+def build_cpu_variant_if_needed(variant):
+    if variant in core.CPU_VARIANTS:
+        print(f"Variant \"{variant}\" already known.")
+    else:
+        cpu_filename_base = "VexRiscv_GEN"
+        cpu_filename      = cpu_filename_base + ".v"
+        print(f"Generating variant \"{variant}\" in file \"{cpu_filename}\".")
+
+        cfu_root = os.environ.get('CFU_ROOT')
+        custom_dir = os.path.join(cfu_root, "soc", "vexriscv")
+        custom_cpu = os.path.join(custom_dir, cpu_filename)
+
+        vdir = get_data_mod("cpu", "vexriscv").data_location
+        fullpath = os.path.join(vdir, cpu_filename)
+
+        # set up config
+        dsz = 4096
+        isz = 4096
+        gen_args = []
+        if "cfu" in variant:
+            gen_args.append(f"--cfu=true")
+        gen_args.append(f"--dCacheSize={dsz}")
+        gen_args.append(f"--iCacheSize={isz}")
+        gen_args.append(f"--outputFile={cpu_filename_base}")
+
+        # build it!
+        cmd = 'cd {path} && sbt compile "runMain vexriscv.GenCoreDefault {args}"'.format(path=custom_dir, args=" ".join(gen_args))
+        if os.system(cmd) != 0:
+            raise OSError('Failed to run sbt')
+
+
+        # do some patching
+        arch  = "rv32im"
+        abi   = "ilp32"
+        gcc_flags = f"-march={arch} -mabi={abi}"
+
+        core.CPU_VARIANTS.update({
+            variant:             cpu_filename_base,
+        })
+        core.GCC_FLAGS.update({
+            variant:             gcc_flags,
+        })
+
+        # Copy file to where it goes
+        copyfile(custom_cpu, fullpath)


### PR DESCRIPTION
Prototype code for generating a VexRiscv variant on demand.   To trigger, just use any unrecognized variant, for example, add this to the project Makefile:

```
export EXTRA_LITEX_ARGS
EXTRA_LITEX_ARGS += --cpu-variant doesnotexist+cfu
```

The current code ignores the variant and just builds a vanilla VexRiscv.   More code needs to be added to parse the variant string to generate the config and the corresponding canonical Verilog file name.

