### PR TITLE
CFU clock gating

### DIFF
--- a/common/src/cfu_clk_menu.c
+++ b/common/src/cfu_clk_menu.c
@@ -23,12 +23,26 @@
 
 static void do_cfu_clk_enable () {
     puts("Enabling CFU clock\n");
-    cfu_ctl_csr_write(1);
+    uint32_t csr = cfu_ctl_csr_read();
+    cfu_ctl_csr_write(csr |  0x01);
 }
 
 static void do_cfu_clk_disable () {
     puts("Disabling CFU clock\n");
-    cfu_ctl_csr_write(0);
+    uint32_t csr = cfu_ctl_csr_read();
+    cfu_ctl_csr_write(csr & ~0x01);
+}
+
+static void do_cfu_rst_enable () {
+    puts("Asserting CFU reset\n");
+    uint32_t csr = cfu_ctl_csr_read();
+    cfu_ctl_csr_write(csr |  0x02);
+}
+
+static void do_cfu_rst_disable () {
+    puts("Releasing CFU reset\n");
+    uint32_t csr = cfu_ctl_csr_read();
+    cfu_ctl_csr_write(csr & ~0x02);
 }
 
 struct Menu MENU = {
@@ -36,7 +50,9 @@ struct Menu MENU = {
     "cfu_clock",
     {
         MENU_ITEM('1', "Enable CFU clock", do_cfu_clk_enable),
-        MENU_ITEM('0', "Disable CFU clock", do_cfu_clk_disable),
+        MENU_ITEM('2', "Disable CFU clock", do_cfu_clk_disable),
+        MENU_ITEM('3', "Hold CFU in reset", do_cfu_rst_enable),
+        MENU_ITEM('4', "Release CFU from reset", do_cfu_rst_disable),
         MENU_END,
     },
 };

--- a/common/src/cfu_clk_menu.c
+++ b/common/src/cfu_clk_menu.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The CFU-Playground Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cfu_clk_menu.h"
+#include "menu.h"
+
+#include <generated/csr.h>
+
+#include <stdio.h>
+
+static void do_cfu_clk_enable () {
+    puts("Enabling CFU clock\n");
+    cfu_ctl_csr_write(1);
+}
+
+static void do_cfu_clk_disable () {
+    puts("Disabling CFU clock\n");
+    cfu_ctl_csr_write(0);
+}
+
+struct Menu MENU = {
+    "CFU clock control menu",
+    "cfu_clock",
+    {
+        MENU_ITEM('1', "Enable CFU clock", do_cfu_clk_enable),
+        MENU_ITEM('0', "Disable CFU clock", do_cfu_clk_disable),
+        MENU_END,
+    },
+};
+
+void cfu_clk_menu() {
+    menu_run(&MENU);
+}

--- a/common/src/cfu_clk_menu.c
+++ b/common/src/cfu_clk_menu.c
@@ -45,6 +45,12 @@ static void do_cfu_rst_disable () {
     cfu_ctl_csr_write(csr & ~0x02);
 }
 
+static void do_cfu_suicide () {
+    puts("Turning of clock to myself. Bye bye!\n");
+    uint32_t csr = cfu_ctl_csr_read();
+    cfu_ctl_csr_write(csr & ~0x04);
+}
+
 struct Menu MENU = {
     "CFU clock control menu",
     "cfu_clock",
@@ -53,6 +59,7 @@ struct Menu MENU = {
         MENU_ITEM('2', "Disable CFU clock", do_cfu_clk_disable),
         MENU_ITEM('3', "Hold CFU in reset", do_cfu_rst_enable),
         MENU_ITEM('4', "Release CFU from reset", do_cfu_rst_disable),
+        MENU_ITEM('0', "Turn off self clock (suicide)", do_cfu_suicide),
         MENU_END,
     },
 };

--- a/common/src/cfu_clk_menu.h
+++ b/common/src/cfu_clk_menu.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 The CFU-Playground Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CFU_CLK_MENU_H
+#define CFU_CLK_MENU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// CFU clock control menu
+void cfu_clk_menu();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CFU_CLK_MENU_H

--- a/common/src/main.c
+++ b/common/src/main.c
@@ -32,6 +32,7 @@
 #include "proj_menu.h"
 #include "spiflash.h"
 #include "tflite_unit_tests.h"
+#include "cfu_clk_menu.h"
 
 #ifdef PLATFORM_sim
 static void trace_sim() {
@@ -48,6 +49,7 @@ static struct Menu MENU = {
     "CFU Playground",
     "main",
     {
+        MENU_ITEM('c', "CFU clock control menu", cfu_clk_menu),
         MENU_ITEM('1', "TfLM Models menu", models_menu),
         MENU_ITEM('2', "Functional CFU Tests", do_functional_cfu_tests),
         MENU_ITEM('3', "Project menu", do_proj_menu),

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -61,13 +61,15 @@ class CfuClockCtrl(Module, AutoCSR):
     """
 
     def __init__(self):
-        self.csr = CSRStorage(2, reset=1, description="CFU clock & reset control")
+        self.csr = CSRStorage(3, reset=5, description="CFU clock & reset control")
 
-        self.cen = Signal(reset=1) # Clock enable
-        self.rst = Signal(reset=0) # Clock reset
+        self.gcen = Signal(reset=1) # Global clock enable
+        self.cen  = Signal(reset=1) # Clock enable
+        self.rst  = Signal(reset=0) # Clock reset
 
         self.sync += If(self.csr.re, self.cen.eq(self.csr.storage[0]))
         self.sync += If(self.csr.re, self.rst.eq(self.csr.storage[1]))
+        self.sync += If(self.csr.re, self.gcen.eq(self.csr.storage[2]))
 
 
 class HpsSoC(LiteXSoC):
@@ -120,6 +122,8 @@ class HpsSoC(LiteXSoC):
 
         self.cpu.cfu_params.update(i_cfu_cen=self.cfu_ctl.cen)
         self.cpu.cfu_params.update(i_cfu_rst=self.cfu_ctl.rst)
+
+        self.comb += self.crg.sys_clk.enable.eq(self.cfu_ctl.gcen)
 
         # RAM
         if separate_arena:

--- a/soc/hps_soc.py
+++ b/soc/hps_soc.py
@@ -61,10 +61,10 @@ class CfuClockCtrl(Module, AutoCSR):
     """
 
     def __init__(self):
-        self.csr = CSRStorage(2, description="CFU clock & reset control")
+        self.csr = CSRStorage(2, reset=1, description="CFU clock & reset control")
 
-        self.cen = Signal() # Clock enable
-        self.rst = Signal() # Clock reset
+        self.cen = Signal(reset=1) # Clock enable
+        self.rst = Signal(reset=0) # Clock reset
 
         self.sync += If(self.csr.re, self.cen.eq(self.csr.storage[0]))
         self.sync += If(self.csr.re, self.rst.eq(self.csr.storage[1]))


### PR DESCRIPTION
This PR adds a clock gate for the HPS CFU controlled via a CSR accessible from the risc-v core. The CSR has two bits: bit0 for clock enable and bit1 for reset assertion. This allows to turn the clock on/off from the software level as well as resetting the CFU gateware. There is a menu added that allows manually controlling this two bits.

The clock gate is built using the CrossLink-NX `DCC` primitive hence it will only work on the `nexus` arch for now.

I took some current measurements on the `hps_proto2` board using built-in shunt resistors for cases when the CFU clock was enabled and disabled. Turning the clock off decreases power consumption by about **6 to 10 mW**

| Rail | Voltage [V] | Clock on [mV] | Clock off [mV] | Rsense [ohm] | Clock on [mA] | Clock off [mA] |
| --- | --- | --- | --- | --- | --- | --- |
|FPGA_VCC1/2/3 |1.0 |4.5 |3.9 |0.1 |45 |**39** |
|Whole board |3.3 |2.3 |2.0 |0.1 |23 |**20** |

This is meant to be a proof of concept, not a final solution.