### PR TITLE
conf: ignore files updated by Symbiflow install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ third_party/yosys
 
 # Environment
 env
+conf/environment.yml
+conf/requirements.txt


### PR DESCRIPTION
conf/requirements.txt and conf/environment.yml are updated by `make
sf-install`. `git status` then records them as modified, but the
developer mostly likely does not want to send these updates upstream.

This change adds these two files to .gitignore.

Signed-off-by: Alan Green <avg@google.com>