### PR TITLE
scripts/install_oxide: fixes

### DIFF
--- a/scripts/install_oxide
+++ b/scripts/install_oxide
@@ -72,13 +72,14 @@ DESTDIR=${CFU_ROOT}/third_party
 echo
 echo "BUILDING YOSYS"
 cd "${CFU_ROOT}/third_party/yosys"
-make -j$(nproc)
+make DESTDIR=${DESTDIR} -j$(nproc)
 make DESTDIR=${DESTDIR} install
+export PATH="${DESTDIR}/usr/local/bin:${PATH}"
 
 echo
 echo "BUILDING YOSYS PLUGINS"
 cd "${CFU_ROOT}/third_party/yosys-f4pga-plugins/dsp-ff-plugin"
-make -j$(nproc)
+YOSYS_PATH=${DESTDIR}/usr/local make -j$(nproc)
 # DESTDIR not respected in this repo, so we can't do `make install`
 # make DESTDIR=${DESTDIR} install
 mkdir -p "${DESTDIR}/usr/local/share/yosys/plugins"


### PR DESCRIPTION
Contains two fixes:

1. Passes full path to Yosys src the plugin make command, which enables
   it to find the yosys-config script.
2. Passes DESTDIR to the first yosys make invocation so that it can be
   used when constructing the yosys-config script.

Note that the install_oxide script will require a change to the yosys
makefile in order to construct the correct yosys-config script.

Signed-off-by: Alan Green <avg@google.com>