### PR TITLE
Make 'fomu' cpu variant available everywhere incl. sim.

### DIFF
--- a/soc/board_specific_workflows/ice40up5k.py
+++ b/soc/board_specific_workflows/ice40up5k.py
@@ -23,30 +23,6 @@ from litex.soc.integration import builder
 from typing import Callable
 
 
-def patch_cpu_fomu_variant():
-    """Monkey patches the fomu variant into LiteX."""
-    core.CPU_VARIANTS.update({
-        'fomu': 'VexRiscv_Fomu',
-        'fomu+cfu': 'VexRiscv_FomuCfu'
-    })
-    core.GCC_FLAGS.update({
-        'fomu': '    -march=rv32im -mabi=ilp32 -mno-div',
-        'fomu+cfu': '-march=rv32im -mabi=ilp32 -mno-div',
-    })
-
-    old_add_soc_components = core.VexRiscv.add_soc_components
-
-    def new_add_soc_components(self, soc, soc_region_cls):
-        old_add_soc_components(self, soc, soc_region_cls)
-        if 'fomu' in self.variant:
-            soc.add_config('CPU_DIV_UNIMPLEMENTED')
-
-            # Fomu variant has *no* Dcache.
-            # This is here to avoid the dcache flush instruction (system.h).
-            soc.constants.pop('CONFIG_CPU_HAS_DCACHE', None)
-
-    core.VexRiscv.add_soc_components = new_add_soc_components
-
 
 class Ice40UP5KWorkflow(general.GeneralSoCWorkflow):
     """Workflow for boards derived from the Ice40UP5K.
@@ -60,9 +36,6 @@ class Ice40UP5KWorkflow(general.GeneralSoCWorkflow):
                  soc_constructor: Callable[..., litex_soc.LiteXSoC],
                  builder_constructor: Callable[..., builder.Builder] = None,
                  warn: bool = True) -> None:
-
-        # Remove if/when the new CPU variant is upstreamed.
-        patch_cpu_fomu_variant()
 
         if warn and args.cpu_variant != 'fomu+cfu':
             warnings.warn('Only fomu+cfu variant of Vexriscv supported for ' +

--- a/soc/patch_cpu_variant.py
+++ b/soc/patch_cpu_variant.py
@@ -27,6 +27,8 @@ import os
 def patch_cpu_variant():
     """Monkey patches custom variants into LiteX."""
     core.CPU_VARIANTS.update({
+        'fomu':                 'VexRiscv_Fomu',
+        'fomu+cfu':             'VexRiscv_FomuCfu',
         'custom':               'VexRiscv_Custom',
         'custom+cfu':           'VexRiscv_CustomCfu',
         'hps+cfu':              'VexRiscv_HpsCfu',
@@ -42,6 +44,8 @@ def patch_cpu_variant():
         'slimperf+cfu+debug':   'VexRiscv_SlimPerfCfuDebug',
     })
     core.GCC_FLAGS.update({
+        'fomu':                 '-march=rv32im -mabi=ilp32 -mno-div',
+        'fomu+cfu':             '-march=rv32im -mabi=ilp32 -mno-div',
         'custom':               '-march=rv32im -mabi=ilp32',
         'custom+cfu':           '-march=rv32im -mabi=ilp32',
         'hps+cfu':              '-march=rv32im -mabi=ilp32',
@@ -62,8 +66,16 @@ def patch_cpu_variant():
 
     def new_add_soc_components(self, soc, soc_region_cls):
         old_add_soc_components(self, soc, soc_region_cls)
+
         if 'perf' in self.variant:
             soc.add_config('CPU_PERF_CSRS', 8)
+
+        if 'fomu' in self.variant:
+            soc.add_config('CPU_DIV_UNIMPLEMENTED')
+
+            # Fomu variant has *no* Dcache.
+            # This is here to avoid the dcache flush instruction (system.h).
+            soc.constants.pop('CONFIG_CPU_HAS_DCACHE', None)
 
     core.VexRiscv.add_soc_components = new_add_soc_components
 


### PR DESCRIPTION
Before, the patching for the fomu cpu variant was only done
when you were targeting the fomu board.  This change
makes it so the patching is always done, so that the fomu
variant is always available, including in Verilator sim.

This fixes #543.

Signed-off-by: Tim Callahan <tcal@google.com>