### PR TITLE
Some cleanup:

### DIFF
--- a/common/src/menu.cc
+++ b/common/src/menu.cc
@@ -40,7 +40,10 @@ void menu_print(struct Menu* menu) {
 
 // Get the menu selection
 struct MenuItem* menu_get_selection(struct Menu* menu) {
-  char c = readchar();
+  char c = '\0';
+  do {
+    c = readchar();
+  } while (c == '\n' || c == '\r');
   putchar(c);
   for (struct MenuItem* p = menu->items; p->selection; p++) {
     if (c == p->selection) {

--- a/proj/skip_tflm/Makefile
+++ b/proj/skip_tflm/Makefile
@@ -28,18 +28,5 @@ export SKIP_TFLM=1
 # Uncomment this line to skip individual profiling output (has minor effect on performance).
 #DEFINES += NPROFILE
 
-# Uncomment to include specified model in built binary
-#DEFINES += INCLUDE_MODEL_PDTI8
-#DEFINES += INCLUDE_MODEL_MICRO_SPEECH
-#DEFINES += INCLUDE_MODEL_MAGIC_WAND
-#DEFINES += INCLUDE_MODEL_MNV2
-#DEFINES += INCLUDE_MODEL_HPS
-#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_ANOMD
-#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_IMGC
-DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_KWS
-#DEFINES += INLCUDE_MODEL_MLCOMMONS_TINY_V01_VWW
-
-# Uncomment to include all TFLM examples (pdti8, micro_speech, magic_wand)
-#DEFINES += INCLUDE_ALL_TFLM_EXAMPLES
 
 include ../proj.mk


### PR DESCRIPTION
* Remove model include lines from "skip_tflm" proj Makefile
* Ignore CR/LF in menu input (these are necessarily added
    when running Renode in the Colab; this tidies things up,
    preventing spurious *unknown* messages).

Signed-off-by: Tim Callahan <tcal@google.com>