### PR TITLE
Fix install_oxide script w.r.t. dsp-ff plugin

### DIFF
--- a/scripts/install_oxide
+++ b/scripts/install_oxide
@@ -79,7 +79,7 @@ export PATH="${INSTALL_ROOT}/usr/local/bin:${PATH}"
 echo
 echo "BUILDING YOSYS PLUGINS"
 cd "${CFU_ROOT}/third_party/yosys-f4pga-plugins/dsp-ff-plugin"
-YOSYS_PATH=${INSTALL_ROOT}/usr/local make -j$(nproc)
+YOSYS_PATH=${INSTALL_ROOT}/usr/local make -j$(nproc) all
 # INSTALL_ROOT not respected in this repo, so we can't do `make install`
 # make INSTALL_ROOT=${INSTALL_ROOT} install
 mkdir -p "${INSTALL_ROOT}/usr/local/share/yosys/plugins"


### PR DESCRIPTION
The dsp-ff plugin Makefile now has building a directory
as the default action, which isn't enough, so we must
now explicitly "make all" instead of just "make".

It is currently broken either in CI or if you're running 
`./scripts/install_oxide` locally.

Signed-off-by: Tim Callahan <tcal@google.com>