### PR TITLE
Ice40 placement

### DIFF
--- a/scripts/critpath.py
+++ b/scripts/critpath.py
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Copyright 2022 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Display color-coded floowplan and critical path,
+#  using data files written by nextpnr.
+# Currently the critical path display is disabled
+#  since it hasn't been tested with ice40.
+#
+
+
+
+import json
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import random
+
+fig, ax = plt.subplots(dpi=200)
+
+# read placement file
+with open('placement_data.txt', 'r') as pfile:
+    placement_data=pfile.readlines()
+
+if False:
+    # read critical path file
+    with open('hps_proto2_platform-report.json', 'r') as myfile:
+        data=myfile.read()
+
+    # parse file
+    obj = json.loads(data)
+
+    # assume first CP is the one we're interested in (maybe print out from/to clk domains)
+    cp = obj['critical_paths'][0]['path']
+    #print(cp)
+
+    accum = {}
+    accum['logic'] = 0.0
+    accum['routing'] = 0.0
+    accum['clk-to-q'] = 0.0
+    accum['setup'] = 0.0
+
+# plot placement data first
+for line in placement_data:
+  if 'KEY' in line:
+    continue
+  [type,x,y,color]=line.rstrip().split(' ')
+  x = int(x)
+  y = int(y)
+  if type == 'small':
+    rx = random.uniform(0,0.7)
+    ry = random.uniform(0,0.7)
+    ax.add_patch(mpatches.Rectangle(
+                [x+rx, y+ry], 0.1, 0.1,
+                color=color, fill=True))
+  if type == 'med':
+    ax.add_patch(mpatches.Rectangle(
+                [x, y-0.2], 1.6, 1.6,
+                color=color, ec='white', fill=True))
+  if type == 'circle':
+    ax.add_patch(mpatches.Circle(
+                [x, y+0.5], 0.7,
+                color=color, ec='white', fill=True))
+
+ax.set_aspect('equal')
+ax.autoscale_view()
+
+
+if 'cp' in locals():
+    xs = []
+    ys = []
+    for hop in cp:
+        dtype = hop['type']
+        accum[dtype] += hop['delay']
+        fromcell = hop['from']['cell']
+        tocell = hop['to']['cell']
+        delay = "%.3f" % hop['delay']
+        fromloc = hop['from']['loc']
+        toloc = hop['to']['loc']
+        floc = str(fromloc[0]) + ":" + str(fromloc[1])
+        tloc = str(toloc[0]) + ":" + str(toloc[1])
+        if toloc != fromloc:
+            xs.append(fromloc[0])
+            ys.append(fromloc[1])
+            xs.append(toloc[0])
+            ys.append(toloc[1])
+        if 'clk' in dtype:
+            print(f"from {tloc} {tocell}  {dtype} --> {delay} ->")
+        else:
+            print(f"from {floc} {fromcell}  {dtype} --> {delay} ->")
+
+    plt.plot(xs, ys, marker='x', linewidth=3, color='black', label=delay)
+
+    for k,v in accum.items():
+        delay = "%.2f" % v
+        print(f"total {k}: {delay}")
+
+for line in placement_data:
+  if 'KEY' in line:
+    print(line.rstrip())
+print("KEY Multiplier Circle")
+print("KEY Memory Square")
+
+plt.xlim([0, 27])
+plt.ylim([0, 32])
+plt.show()
+plt.savefig("critpath.png", format="png", dpi=300)
+print("Done writing critical path image.\n")

--- a/scripts/critpath.py
+++ b/scripts/critpath.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # Copyright 2022 The CFU-Playground Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,9 +33,9 @@ fig, ax = plt.subplots(dpi=200)
 with open('placement_data.txt', 'r') as pfile:
     placement_data=pfile.readlines()
 
-if False:
+if True:
     # read critical path file
-    with open('hps_proto2_platform-report.json', 'r') as myfile:
+    with open('kosagi_fomu_pvt-report.json', 'r') as myfile:
         data=myfile.read()
 
     # parse file
@@ -102,10 +102,12 @@ if 'cp' in locals():
 
     plt.plot(xs, ys, marker='x', linewidth=3, color='black', label=delay)
 
+    print("");
     for k,v in accum.items():
         delay = "%.2f" % v
         print(f"total {k}: {delay}")
 
+print("");
 for line in placement_data:
   if 'KEY' in line:
     print(line.rstrip())
@@ -114,6 +116,6 @@ print("KEY Memory Square")
 
 plt.xlim([0, 27])
 plt.ylim([0, 32])
-plt.show()
+# plt.show()
 plt.savefig("critpath.png", format="png", dpi=300)
 print("Done writing critical path image.\n")

--- a/scripts/save-placement.py
+++ b/scripts/save-placement.py
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Copyright 2022 The CFU-Playground Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# When executed by nextpnr-ice40 using the "--pre-route" option,
+#  this saves placement data in a file "placement_data.txt".
+
+
+import sys
+
+print("\nSaving placement data...\n")
+
+COLOR_TABLE = [
+  ('Vex', 'gray'),
+  ('Cfu', 'seagreen'),
+  ('litespi', 'blue'),
+  ('cdcusbphy', 'red'),
+  ('_usb_', 'red'),
+]
+
+with open('placement_data.txt', 'w') as f:
+  for cell, cellinfo in ctx.cells:
+    if cellinfo.bel:
+        bel = cellinfo.bel
+        #print(cell, file=f)
+        #print(bel, file=f)
+        loc = ctx.getBelLocation(bel)
+        x = int(loc.x)
+        y = int(loc.y)
+
+        color = 'black'
+        for match, c in COLOR_TABLE:
+          if match in cell:
+            color = c
+
+        mul = "DSP" in cell
+        ebr = "/ram" in bel
+
+        # Set color for LRAMs
+        lram = "spram_" in bel
+        color= 'tan' if lram else color
+
+        if mul:
+            print(f"circle {x} {y} {color}", file=f)
+        elif ebr or lram:
+            print(f"med {x} {y} {color}", file=f)
+        else:
+            print(f"small {x} {y} {color}", file=f)
+
+  for i, (match, c) in enumerate(COLOR_TABLE):
+    print(f"KEY {match} {c}", file=f)
+  print("KEY LiteX black", file=f)
+
+print("\nDone\n")
+
+sys.exit()

--- a/scripts/save-placement.py
+++ b/scripts/save-placement.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # Copyright 2022 The CFU-Playground Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,4 +64,4 @@ with open('placement_data.txt', 'w') as f:
 
 print("\nDone\n")
 
-sys.exit()
+# sys.exit()

--- a/soc/board_specific_workflows/ice40up5k.py
+++ b/soc/board_specific_workflows/ice40up5k.py
@@ -23,6 +23,16 @@ from litex.soc.integration import builder
 from typing import Callable
 
 
+_ice40_placement_build_template = [
+    "yosys -l {build_name}.rpt {build_name}.ys",
+    "nextpnr-ice40 --json {build_name}.json --pcf {build_name}.pcf --asc {build_name}.txt \
+     --pre-route ../../../../scripts/save-placement.py \
+     --report={build_name}-report.json \
+     --pre-pack {build_name}_pre_pack.py --{architecture} --package {package} {timefailarg} {ignoreloops} --seed {seed}",
+    "icepack -s {build_name}.txt {build_name}.bin",
+    "critpath.py > critpath.log"
+]
+
 
 class Ice40UP5KWorkflow(general.GeneralSoCWorkflow):
     """Workflow for boards derived from the Ice40UP5K.
@@ -64,6 +74,10 @@ class Ice40UP5KWorkflow(general.GeneralSoCWorkflow):
         soc.bus.regions["sram"].size = 128 * 1024;
         soc.bus.regions["main_ram"].origin = 128 * 1024;
         soc.bus.regions["main_ram"].size = 0;
+
+        # add scripts for plotting placement
+        soc.platform.toolchain.build_template = _ice40_placement_build_template
+
         return soc
 
     def software_load(


### PR DESCRIPTION
Generate files `critpath.png` and `critpath.log` in the build `gateware/` directory.   The PNG file contains a color-coded plot of placement color coded by LiteX, CPU, and CFU; the plot is overlayed with the critical path.   The LOG file contains the text list of cells on the critical path, and also the color key for the placement.

To do: generalize to make it easy to adapt for ECP5, Nexus, or any other part that uses Nextpnr. 



