### PR TITLE
hps: drive sys reset signal from osc reset signal

### DIFF
--- a/soc/hps_proto2_platform.py
+++ b/soc/hps_proto2_platform.py
@@ -79,6 +79,7 @@ class _CRG(Module):
             o_CLKO=ClockSignal("sys"),
             i_CE=self.sys_clk_enable,
         )
+        self.comb += self.cd_sys.rst.eq(self.cd_osc.rst)
         # We make the period constraint 7% tighter than our actual system
         # clock frequency, because the CrossLink-NX internal oscillator runs
         # at ±7% of nominal frequency.


### PR DESCRIPTION
When I was porting the dynamic clock control change (PR #597) to ChromeOS:
https://chromium-review.googlesource.com/c/chromiumos/platform/hps-firmware/+/3783309
I found that I needed to connect the sys clock domain's reset signal to the osc clock domain's reset signal. Otherwise it doesn't seem to come out of reset properly.

I'm not sure why we got away without this in CFU-Playground, but let's add it here for consistency too.