### PR TITLE
Fix compilation if no TFLM models included in Makefile

### DIFF
--- a/common/src/models/models.h
+++ b/common/src/models/models.h
@@ -23,6 +23,7 @@ extern "C" {
 
 // For integration into menu system
 void models_menu();
+void no_menu();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR fixes a bug in some legacy code to make sure compilation succeeds. If no TFLM models are included in the project makefile by commenting out this [line](https://github.com/google/CFU-Playground/blob/fc6f7991f9618c4b694b3ef2b4716f31e3c19469/proj/proj_template/Makefile#L29), the following [code](https://github.com/google/CFU-Playground/blob/fc6f7991f9618c4b694b3ef2b4716f31e3c19469/common/src/models/models.c#L74-L76) will be included in compilation. However, the build fails if you comment out the PDIT8 model with the following error:
```
…
LD       software.elf
/home/shvetank/Repos/CFU-Playground/env/conda/envs/cfu-symbiflow/bin/../lib/gcc/riscv32-elf/10.1.0/../../../../riscv32-elf/bin/ld: src/models/models.o: in function `.LANCHOR0':
models.c:(.sdata.MENU+0x10): undefined reference to `no_menu'
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:164: software.elf] Error 1
make[3]: Leaving directory '/home/shvetank/Repos/CFU-Playground/proj/proj_template/build'
make[2]: *** [../proj.mk:232: /home/shvetank/Repos//CFU-Playground/proj/proj_template/build/software.bin] Error 2
make[2]: Leaving directory '/home/shvetank/Repos/CFU-Playground/proj/proj_template'
```

To fix this we just need to add the `no_menu()` prototype to the header file and then the build succeeds and the output is as we would expect then:

```
CFU Playground
==============
 1: TfLM Mode menu
 2: Functional CFU Tests
 3: Project menu
 4: Performance Counter Tests
 5: TFLite Unit Tests
 6: Benchmarks
 7: Ul Tests
 8: SPI Flash Debugging
 I: Illegal Instruction Tests (these *WILL* hang on Fomu!)
main> 1

Running TfLM Models menu

TfLM Models
===========
 !:No models selected! Check defines in Makefile!
 x: eXit to previous menu
models>
```