### PR TITLE
Revert "Fix compilation if no TFLM models included in Makefile"

### DIFF
--- a/common/src/models/models.h
+++ b/common/src/models/models.h
@@ -23,7 +23,6 @@ extern "C" {
 
 // For integration into menu system
 void models_menu();
-void no_menu();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This change causes problems; I think it makes the model version of `no_menu` more visible so that it clashes with the embench version of `no_menu`.

If you do this:
```
% cd proj/proj_template_v
% make software
```

you will get:
```
  ...
  CXX tflite_unit_tests.cc      tflite_unit_tests.o
  AS  crt0-vexriscv.S   crt0-vexriscv.o
  LD       software.elf
/media/tim/GIT/tcal-x/CFU-Playground/env/conda/envs/cfu-common/bin/../lib/gcc/riscv32-elf/10.1.0/../../../../riscv32-elf/bin/ld: src/third_party/embench_iot_v1/embench.o: in function `no_menu':
/media/tim/GIT/tcal-x/CFU-Playground/proj/proj_template_v/build/src/third_party/embench_iot_v1/embench.c:23: multiple definition of `no_menu'; src/models/models.o:/media/tim/GIT/tcal-x/CFU-Playground/proj/proj_template_v/build/src/models/models.c:32: first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:164: software.elf] Error 1
make[2]: Leaving directory '/media/tim/GIT/tcal-x/CFU-Playground/proj/proj_template_v/build'
make[1]: *** [../proj.mk:232: /media/tim/GIT/tcal-x/CFU-Playground/proj/proj_template_v/build/software.bin] Error 2
make[1]: Leaving directory '/media/tim/GIT/tcal-x/CFU-Playground/proj/proj_template_v'

```
