### PR TITLE
Add json-c and libevent to conda env.

### DIFF
--- a/conf/environment-symbiflow.yml
+++ b/conf/environment-symbiflow.yml
@@ -21,6 +21,8 @@ dependencies:
   - lxml
   - simplejson
   - intervaltree
+  - json-c
+  - libevent
   - python=3.7
   - pip
   - pip:

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -14,6 +14,8 @@ dependencies:
   - litex-hub::iceprog
   - litex-hub::yosys
   - litex-hub::symbiflow-yosys-plugins
+  - libevent
+  - json-c
   - python=3.7
   - pip
   - pip:


### PR DESCRIPTION
I think they used to be implicitly loaded as dependencies of the Verilator package, but now they need to be explicitly specified.

Signed-off-by: Tim Callahan <tcal@google.com>