### PR TITLE
Conda: constrain sysroot_linux-64>=2.17.

### DIFF
--- a/conf/environment-symbiflow.yml
+++ b/conf/environment-symbiflow.yml
@@ -23,6 +23,7 @@ dependencies:
   - intervaltree
   - json-c
   - libevent
+  - sysroot_linux-64>=2.17
   - python=3.7
   - pip
   - pip:

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - litex-hub::symbiflow-yosys-plugins
   - libevent
   - json-c
+  - sysroot_linux-64>=2.17
   - python=3.7
   - pip
   - pip:


### PR DESCRIPTION
Tested with Ubuntu 20.04 and 18.04.

Fixes #568 and fixes #629.

Edit: For background, see my comment here: https://github.com/google/CFU-Playground/issues/568#issuecomment-1199591603 

Signed-off-by: Tim Callahan <tcal@google.com>