### PR TITLE
Update VexRiscv: no rw check on blockmem; work around #596 (CFU CSR collision)

### DIFF
--- a/soc/vexriscv/Makefile
+++ b/soc/vexriscv/Makefile
@@ -1,6 +1,6 @@
 SRC := ${shell find . -type f -name \*.scala}
 
-VERILOGS := VexRiscv_Custom.v VexRiscv_CustomCfu.v VexRiscv_PerfCfu.v VexRiscv_PerfCfuDebug.v VexRiscv_SlimCfu.v VexRiscv_SlimCfuDebug.v VexRiscv_SlimPerfCfu.v VexRiscv_SlimPerfCfuDebug.v VexRiscv_Fomu.v VexRiscv_FomuCfu.v VexRiscv_SlimoptCfu.v
+VERILOGS := VexRiscv_Custom.v VexRiscv_CustomCfu.v VexRiscv_PerfCfu.v VexRiscv_PerfCfuDebug.v VexRiscv_SlimCfu.v VexRiscv_SlimCfuDebug.v VexRiscv_SlimPerfCfu.v VexRiscv_SlimPerfCfuDebug.v VexRiscv_Fomu.v VexRiscv_FomuCfu.v VexRiscv_SlimoptCfu.v VexRiscv_HpsCfu.v VexRiscv_HpsdeltaCfu.v VexRiscv_Fpu.v VexRiscv_FpuCfu.v VexRiscv_MinCfu.v VexRiscv_dbpl8Cfu.v
 YAMLS    := $(VERILOGS:.v=.yaml)
 
 

--- a/soc/vexriscv/VexRiscv_Custom.v
+++ b/soc/vexriscv/VexRiscv_Custom.v
@@ -1,48 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -74,6 +34,33 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -102,6 +89,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -184,6 +173,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
@@ -194,77 +185,77 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_1;
   wire                _zz__zz_decode_IS_RS2_SIGNED_2;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_3;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_4;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_5;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_6;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_7;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_4;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_5;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_6;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_7;
   wire                _zz__zz_decode_IS_RS2_SIGNED_8;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_9;
-  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_10;
+  wire       [24:0]   _zz__zz_decode_IS_RS2_SIGNED_9;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_10;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_11;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_12;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_13;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_14;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_15;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_16;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_13;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_15;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_16;
   wire                _zz__zz_decode_IS_RS2_SIGNED_17;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_18;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_19;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_20;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_18;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_19;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_20;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_21;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_23;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_24;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
-  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_29;
+  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_26;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_27;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_29;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_30;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_32;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_36;
-  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_38;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_31;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_32;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_33;
+  wire       [17:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_36;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_37;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_38;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_39;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_40;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_41;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_42;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_43;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_44;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_40;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_41;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_42;
+  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_43;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_44;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_45;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_47;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_50;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_51;
-  wire       [14:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_53;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_54;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_55;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_56;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_57;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_58;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_46;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_50;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_53;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_54;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_55;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_56;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_57;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_58;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_59;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_60;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_60;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_61;
   wire                _zz__zz_decode_IS_RS2_SIGNED_62;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_63;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_64;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_64;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_65;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_66;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_67;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_66;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_67;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_68;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_69;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_70;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_71;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_73;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_74;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_72;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_73;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_76;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_77;
@@ -273,87 +264,67 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_80;
   wire                _zz__zz_decode_IS_RS2_SIGNED_81;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_82;
-  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
+  wire       [10:0]   _zz__zz_decode_IS_RS2_SIGNED_83;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_84;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_85;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_86;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_87;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_88;
   wire                _zz__zz_decode_IS_RS2_SIGNED_89;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_90;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_91;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_92;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_93;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_95;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_96;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_97;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_98;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_94;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_95;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_96;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_97;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_98;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_99;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_100;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_101;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_102;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_104;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_100;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_101;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_102;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_103;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_104;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_105;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
+  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_106;
   wire                _zz__zz_decode_IS_RS2_SIGNED_107;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_108;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_109;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_110;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_111;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_112;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_108;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_109;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_110;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_111;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_112;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_113;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_114;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_118;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_119;
-  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_121;
+  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_114;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_115;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_119;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_121;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_122;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_123;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_124;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_125;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_126;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_128;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_129;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_123;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_124;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_126;
+  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_127;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire                _zz__zz_decode_IS_RS2_SIGNED_129;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_130;
-  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_131;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_132;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_133;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_132;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_133;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_134;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_137;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_140;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_137;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
+  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_139;
+  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_140;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_141;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_142;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_142;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_143;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_144;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_145;
-  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_146;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_147;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_148;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_149;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_150;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_151;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_152;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_153;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_154;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_155;
-  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_156;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_157;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_158;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_159;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_161;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_162;
-  wire                _zz__zz_decode_IS_RS2_SIGNED_163;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -426,27 +397,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -454,18 +425,18 @@ module VexRiscv (
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -485,20 +456,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -512,41 +482,41 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -555,6 +525,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -567,8 +538,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -580,7 +551,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -624,6 +595,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -692,6 +664,7 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -734,14 +707,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -783,18 +756,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -813,7 +786,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -860,43 +832,43 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [31:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
   wire                _zz_decode_IS_RS2_SIGNED_3;
   wire                _zz_decode_IS_RS2_SIGNED_4;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
+  wire                _zz_decode_IS_RS2_SIGNED_5;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -950,7 +922,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -988,11 +960,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1007,59 +979,59 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1128,7 +1100,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1138,9 +1110,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1164,21 +1136,21 @@ module VexRiscv (
   wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_37;
@@ -1237,59 +1209,60 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1308,8 +1281,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1403,7 +1376,7 @@ module VexRiscv (
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
@@ -1417,7 +1390,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1429,6 +1402,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1502,166 +1477,146 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_4 = 1'b0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_5 = (((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_6) == 32'h00000050) != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ({_zz__zz_decode_IS_RS2_SIGNED_8,_zz__zz_decode_IS_RS2_SIGNED_9} != 2'b00);
-  assign _zz__zz_decode_IS_RS2_SIGNED_10 = {({_zz__zz_decode_IS_RS2_SIGNED_11,_zz__zz_decode_IS_RS2_SIGNED_12} != 2'b00),{(_zz__zz_decode_IS_RS2_SIGNED_14 != _zz__zz_decode_IS_RS2_SIGNED_16),{_zz__zz_decode_IS_RS2_SIGNED_17,{_zz__zz_decode_IS_RS2_SIGNED_20,_zz__zz_decode_IS_RS2_SIGNED_28}}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_6 = 32'h00403050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_9 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_11 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_12 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_13) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_14 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_15) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_16 = 1'b0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ({_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_19} != 2'b00);
-  assign _zz__zz_decode_IS_RS2_SIGNED_20 = ({_zz__zz_decode_IS_RS2_SIGNED_21,_zz__zz_decode_IS_RS2_SIGNED_23} != 3'b000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_28 = {(_zz__zz_decode_IS_RS2_SIGNED_29 != _zz__zz_decode_IS_RS2_SIGNED_31),{_zz__zz_decode_IS_RS2_SIGNED_32,{_zz__zz_decode_IS_RS2_SIGNED_35,_zz__zz_decode_IS_RS2_SIGNED_37}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_13 = 32'h0000001c;
-  assign _zz__zz_decode_IS_RS2_SIGNED_15 = 32'h00000058;
-  assign _zz__zz_decode_IS_RS2_SIGNED_18 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_21 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_22) == 32'h40001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_23 = {(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25),(_zz__zz_decode_IS_RS2_SIGNED_26 == _zz__zz_decode_IS_RS2_SIGNED_27)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_29 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_30) == 32'h00000024);
-  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 1'b0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_32 = ((_zz__zz_decode_IS_RS2_SIGNED_33 == _zz__zz_decode_IS_RS2_SIGNED_34) != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_35 = (_zz__zz_decode_IS_RS2_SIGNED_36 != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_37 = {(_zz__zz_decode_IS_RS2_SIGNED_38 != _zz__zz_decode_IS_RS2_SIGNED_43),{_zz__zz_decode_IS_RS2_SIGNED_44,{_zz__zz_decode_IS_RS2_SIGNED_47,_zz__zz_decode_IS_RS2_SIGNED_52}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_22 = 32'h40003054;
-  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_4 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_5) == 32'h00000050));
+  assign _zz__zz_decode_IS_RS2_SIGNED_6 = (|{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_8});
+  assign _zz__zz_decode_IS_RS2_SIGNED_9 = {(|{_zz__zz_decode_IS_RS2_SIGNED_10,_zz__zz_decode_IS_RS2_SIGNED_11}),{(|_zz__zz_decode_IS_RS2_SIGNED_13),{_zz__zz_decode_IS_RS2_SIGNED_15,{_zz__zz_decode_IS_RS2_SIGNED_18,_zz__zz_decode_IS_RS2_SIGNED_26}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_5 = 32'h00403050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_10 = _zz_decode_IS_RS2_SIGNED_4;
+  assign _zz__zz_decode_IS_RS2_SIGNED_11 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_12) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_14) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_15 = (|{_zz__zz_decode_IS_RS2_SIGNED_16,_zz__zz_decode_IS_RS2_SIGNED_17});
+  assign _zz__zz_decode_IS_RS2_SIGNED_18 = (|{_zz__zz_decode_IS_RS2_SIGNED_19,_zz__zz_decode_IS_RS2_SIGNED_21});
+  assign _zz__zz_decode_IS_RS2_SIGNED_26 = {(|_zz__zz_decode_IS_RS2_SIGNED_27),{_zz__zz_decode_IS_RS2_SIGNED_29,{_zz__zz_decode_IS_RS2_SIGNED_32,_zz__zz_decode_IS_RS2_SIGNED_34}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_12 = 32'h0000001c;
+  assign _zz__zz_decode_IS_RS2_SIGNED_14 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_16 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_17 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_19 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_20) == 32'h40001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_21 = {(_zz__zz_decode_IS_RS2_SIGNED_22 == _zz__zz_decode_IS_RS2_SIGNED_23),(_zz__zz_decode_IS_RS2_SIGNED_24 == _zz__zz_decode_IS_RS2_SIGNED_25)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_27 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_28) == 32'h00000024);
+  assign _zz__zz_decode_IS_RS2_SIGNED_29 = (|(_zz__zz_decode_IS_RS2_SIGNED_30 == _zz__zz_decode_IS_RS2_SIGNED_31));
+  assign _zz__zz_decode_IS_RS2_SIGNED_32 = (|_zz__zz_decode_IS_RS2_SIGNED_33);
+  assign _zz__zz_decode_IS_RS2_SIGNED_34 = {(|_zz__zz_decode_IS_RS2_SIGNED_35),{_zz__zz_decode_IS_RS2_SIGNED_38,{_zz__zz_decode_IS_RS2_SIGNED_40,_zz__zz_decode_IS_RS2_SIGNED_43}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_20 = 32'h40003054;
+  assign _zz__zz_decode_IS_RS2_SIGNED_22 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_RS2_SIGNED_23 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_24 = (decode_INSTRUCTION & 32'h02007054);
   assign _zz__zz_decode_IS_RS2_SIGNED_25 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_26 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_IS_RS2_SIGNED_27 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_30 = 32'h00000064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_33 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_34 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_36 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_38 = {(_zz__zz_decode_IS_RS2_SIGNED_39 == _zz__zz_decode_IS_RS2_SIGNED_40),(_zz__zz_decode_IS_RS2_SIGNED_41 == _zz__zz_decode_IS_RS2_SIGNED_42)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_43 = 2'b00;
-  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((_zz__zz_decode_IS_RS2_SIGNED_45 == _zz__zz_decode_IS_RS2_SIGNED_46) != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_47 = ({_zz__zz_decode_IS_RS2_SIGNED_48,_zz__zz_decode_IS_RS2_SIGNED_50} != 2'b00);
-  assign _zz__zz_decode_IS_RS2_SIGNED_52 = {(_zz__zz_decode_IS_RS2_SIGNED_53 != _zz__zz_decode_IS_RS2_SIGNED_66),{_zz__zz_decode_IS_RS2_SIGNED_67,{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_83}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_39 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_40 = 32'h00002000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_41 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_IS_RS2_SIGNED_42 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_45 = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz__zz_decode_IS_RS2_SIGNED_46 = 32'h00004008;
-  assign _zz__zz_decode_IS_RS2_SIGNED_48 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_49) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_50 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_51) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_53 = {(_zz__zz_decode_IS_RS2_SIGNED_54 == _zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_56,{_zz__zz_decode_IS_RS2_SIGNED_58,_zz__zz_decode_IS_RS2_SIGNED_61}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 5'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_67 = ((_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69) != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_70 = ({_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_74} != 5'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {(_zz__zz_decode_IS_RS2_SIGNED_84 != _zz__zz_decode_IS_RS2_SIGNED_97),{_zz__zz_decode_IS_RS2_SIGNED_98,{_zz__zz_decode_IS_RS2_SIGNED_115,_zz__zz_decode_IS_RS2_SIGNED_120}}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_49 = 32'h00000034;
-  assign _zz__zz_decode_IS_RS2_SIGNED_51 = 32'h00000064;
-  assign _zz__zz_decode_IS_RS2_SIGNED_54 = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_55 = 32'h00002040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_56 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_57) == 32'h00001040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_58 = (_zz__zz_decode_IS_RS2_SIGNED_59 == _zz__zz_decode_IS_RS2_SIGNED_60);
-  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {_zz__zz_decode_IS_RS2_SIGNED_62,_zz__zz_decode_IS_RS2_SIGNED_64};
-  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_71 = (_zz__zz_decode_IS_RS2_SIGNED_72 == _zz__zz_decode_IS_RS2_SIGNED_73);
-  assign _zz__zz_decode_IS_RS2_SIGNED_74 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_97 = 5'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_98 = ({_zz__zz_decode_IS_RS2_SIGNED_99,_zz__zz_decode_IS_RS2_SIGNED_100} != 6'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (_zz__zz_decode_IS_RS2_SIGNED_116 != _zz__zz_decode_IS_RS2_SIGNED_119);
-  assign _zz__zz_decode_IS_RS2_SIGNED_120 = {_zz__zz_decode_IS_RS2_SIGNED_121,{_zz__zz_decode_IS_RS2_SIGNED_126,_zz__zz_decode_IS_RS2_SIGNED_131}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_57 = 32'h00001040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_59 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_RS2_SIGNED_60 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_63) == 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_64 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_65) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_72 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_IS_RS2_SIGNED_73 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_28 = 32'h00000064;
+  assign _zz__zz_decode_IS_RS2_SIGNED_30 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_31 = 32'h00001000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_33 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_35 = {((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_36) == 32'h00002000),((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_37) == 32'h00001000)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_38 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_39) == 32'h00004008));
+  assign _zz__zz_decode_IS_RS2_SIGNED_40 = (|{_zz__zz_decode_IS_RS2_SIGNED_41,_zz__zz_decode_IS_RS2_SIGNED_42});
+  assign _zz__zz_decode_IS_RS2_SIGNED_43 = {(|{_zz__zz_decode_IS_RS2_SIGNED_44,_zz__zz_decode_IS_RS2_SIGNED_46}),{(|_zz__zz_decode_IS_RS2_SIGNED_55),{_zz__zz_decode_IS_RS2_SIGNED_57,{_zz__zz_decode_IS_RS2_SIGNED_70,_zz__zz_decode_IS_RS2_SIGNED_83}}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_36 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_37 = 32'h00005000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_39 = 32'h00004048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_41 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_42 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_44 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_45) == 32'h00002040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_46 = {(_zz__zz_decode_IS_RS2_SIGNED_47 == _zz__zz_decode_IS_RS2_SIGNED_48),{_zz__zz_decode_IS_RS2_SIGNED_49,{_zz__zz_decode_IS_RS2_SIGNED_51,_zz__zz_decode_IS_RS2_SIGNED_54}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_55 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_56) == 32'h00000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_57 = (|{_zz__zz_decode_IS_RS2_SIGNED_58,{_zz__zz_decode_IS_RS2_SIGNED_60,_zz__zz_decode_IS_RS2_SIGNED_61}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_70 = (|{_zz__zz_decode_IS_RS2_SIGNED_71,_zz__zz_decode_IS_RS2_SIGNED_72});
+  assign _zz__zz_decode_IS_RS2_SIGNED_83 = {(|_zz__zz_decode_IS_RS2_SIGNED_84),{_zz__zz_decode_IS_RS2_SIGNED_97,{_zz__zz_decode_IS_RS2_SIGNED_102,_zz__zz_decode_IS_RS2_SIGNED_106}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_45 = 32'h00002040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_47 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_48 = 32'h00001040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_50) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_51 = (_zz__zz_decode_IS_RS2_SIGNED_52 == _zz__zz_decode_IS_RS2_SIGNED_53);
+  assign _zz__zz_decode_IS_RS2_SIGNED_54 = _zz_decode_IS_RS2_SIGNED_2;
+  assign _zz__zz_decode_IS_RS2_SIGNED_56 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_59) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_60 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_61 = {_zz__zz_decode_IS_RS2_SIGNED_62,{_zz__zz_decode_IS_RS2_SIGNED_64,_zz__zz_decode_IS_RS2_SIGNED_67}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_71 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_72 = {_zz__zz_decode_IS_RS2_SIGNED_73,{_zz__zz_decode_IS_RS2_SIGNED_75,_zz__zz_decode_IS_RS2_SIGNED_78}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_84 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_85,_zz__zz_decode_IS_RS2_SIGNED_88}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_97 = (|{_zz__zz_decode_IS_RS2_SIGNED_98,_zz__zz_decode_IS_RS2_SIGNED_99});
+  assign _zz__zz_decode_IS_RS2_SIGNED_102 = (|_zz__zz_decode_IS_RS2_SIGNED_103);
+  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_110,_zz__zz_decode_IS_RS2_SIGNED_114}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_50 = 32'h00000050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_52 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_53 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_59 = 32'h00000040;
+  assign _zz__zz_decode_IS_RS2_SIGNED_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_63) == 32'h00004020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_64 = (_zz__zz_decode_IS_RS2_SIGNED_65 == _zz__zz_decode_IS_RS2_SIGNED_66);
+  assign _zz__zz_decode_IS_RS2_SIGNED_67 = (_zz__zz_decode_IS_RS2_SIGNED_68 == _zz__zz_decode_IS_RS2_SIGNED_69);
+  assign _zz__zz_decode_IS_RS2_SIGNED_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_74) == 32'h00002010);
   assign _zz__zz_decode_IS_RS2_SIGNED_75 = (_zz__zz_decode_IS_RS2_SIGNED_76 == _zz__zz_decode_IS_RS2_SIGNED_77);
   assign _zz__zz_decode_IS_RS2_SIGNED_78 = {_zz__zz_decode_IS_RS2_SIGNED_79,_zz__zz_decode_IS_RS2_SIGNED_81};
   assign _zz__zz_decode_IS_RS2_SIGNED_85 = (_zz__zz_decode_IS_RS2_SIGNED_86 == _zz__zz_decode_IS_RS2_SIGNED_87);
   assign _zz__zz_decode_IS_RS2_SIGNED_88 = {_zz__zz_decode_IS_RS2_SIGNED_89,{_zz__zz_decode_IS_RS2_SIGNED_91,_zz__zz_decode_IS_RS2_SIGNED_94}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_99 = _zz_decode_IS_RS2_SIGNED_3;
-  assign _zz__zz_decode_IS_RS2_SIGNED_100 = {_zz__zz_decode_IS_RS2_SIGNED_101,{_zz__zz_decode_IS_RS2_SIGNED_103,_zz__zz_decode_IS_RS2_SIGNED_106}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = {_zz_decode_IS_RS2_SIGNED_2,_zz__zz_decode_IS_RS2_SIGNED_117};
-  assign _zz__zz_decode_IS_RS2_SIGNED_119 = 2'b00;
-  assign _zz__zz_decode_IS_RS2_SIGNED_121 = ({_zz__zz_decode_IS_RS2_SIGNED_122,_zz__zz_decode_IS_RS2_SIGNED_123} != 2'b00);
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = (_zz__zz_decode_IS_RS2_SIGNED_127 != _zz__zz_decode_IS_RS2_SIGNED_130);
-  assign _zz__zz_decode_IS_RS2_SIGNED_131 = {_zz__zz_decode_IS_RS2_SIGNED_132,{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_146}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00400040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_65 = 32'h00000038;
-  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00004020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_98 = _zz_decode_IS_RS2_SIGNED_3;
+  assign _zz__zz_decode_IS_RS2_SIGNED_99 = (_zz__zz_decode_IS_RS2_SIGNED_100 == _zz__zz_decode_IS_RS2_SIGNED_101);
+  assign _zz__zz_decode_IS_RS2_SIGNED_103 = {_zz_decode_IS_RS2_SIGNED_3,_zz__zz_decode_IS_RS2_SIGNED_104};
+  assign _zz__zz_decode_IS_RS2_SIGNED_107 = (|_zz__zz_decode_IS_RS2_SIGNED_108);
+  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (|_zz__zz_decode_IS_RS2_SIGNED_111);
+  assign _zz__zz_decode_IS_RS2_SIGNED_114 = {_zz__zz_decode_IS_RS2_SIGNED_115,{_zz__zz_decode_IS_RS2_SIGNED_124,_zz__zz_decode_IS_RS2_SIGNED_127}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_63 = 32'h00004020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_65 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_66 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_68 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_IS_RS2_SIGNED_69 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_74 = 32'h00002030;
+  assign _zz__zz_decode_IS_RS2_SIGNED_76 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_77 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_79 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_80) == 32'h00002020);
   assign _zz__zz_decode_IS_RS2_SIGNED_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_82) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_90) == 32'h00000010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_86 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_87 = 32'h00001010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_90) == 32'h00002010);
   assign _zz__zz_decode_IS_RS2_SIGNED_91 = (_zz__zz_decode_IS_RS2_SIGNED_92 == _zz__zz_decode_IS_RS2_SIGNED_93);
-  assign _zz__zz_decode_IS_RS2_SIGNED_94 = (_zz__zz_decode_IS_RS2_SIGNED_95 == _zz__zz_decode_IS_RS2_SIGNED_96);
-  assign _zz__zz_decode_IS_RS2_SIGNED_101 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_102) == 32'h00001010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_103 = (_zz__zz_decode_IS_RS2_SIGNED_104 == _zz__zz_decode_IS_RS2_SIGNED_105);
-  assign _zz__zz_decode_IS_RS2_SIGNED_106 = {_zz__zz_decode_IS_RS2_SIGNED_107,{_zz__zz_decode_IS_RS2_SIGNED_109,_zz__zz_decode_IS_RS2_SIGNED_112}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_117 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_118) == 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_122 = _zz_decode_IS_RS2_SIGNED_2;
-  assign _zz__zz_decode_IS_RS2_SIGNED_123 = (_zz__zz_decode_IS_RS2_SIGNED_124 == _zz__zz_decode_IS_RS2_SIGNED_125);
-  assign _zz__zz_decode_IS_RS2_SIGNED_127 = (_zz__zz_decode_IS_RS2_SIGNED_128 == _zz__zz_decode_IS_RS2_SIGNED_129);
-  assign _zz__zz_decode_IS_RS2_SIGNED_130 = 1'b0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_132 = (_zz__zz_decode_IS_RS2_SIGNED_133 != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_135 = (_zz__zz_decode_IS_RS2_SIGNED_136 != _zz__zz_decode_IS_RS2_SIGNED_145);
-  assign _zz__zz_decode_IS_RS2_SIGNED_146 = {_zz__zz_decode_IS_RS2_SIGNED_147,{_zz__zz_decode_IS_RS2_SIGNED_149,_zz__zz_decode_IS_RS2_SIGNED_156}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h00000030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h02000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00001030;
-  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz__zz_decode_IS_RS2_SIGNED_93 = 32'h00002020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_95 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_96 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_102 = 32'h00001010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_104 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_107 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_108) == 32'h00000010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_109 = (_zz__zz_decode_IS_RS2_SIGNED_110 == _zz__zz_decode_IS_RS2_SIGNED_111);
-  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (_zz__zz_decode_IS_RS2_SIGNED_113 == _zz__zz_decode_IS_RS2_SIGNED_114);
-  assign _zz__zz_decode_IS_RS2_SIGNED_118 = 32'h00000070;
-  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_RS2_SIGNED_125 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_IS_RS2_SIGNED_129 = 32'h00004010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_133 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_134) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_136 = {_zz__zz_decode_IS_RS2_SIGNED_137,{_zz__zz_decode_IS_RS2_SIGNED_138,_zz__zz_decode_IS_RS2_SIGNED_140}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_145 = 4'b0000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_147 = (_zz__zz_decode_IS_RS2_SIGNED_148 != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_149 = (_zz__zz_decode_IS_RS2_SIGNED_150 != _zz__zz_decode_IS_RS2_SIGNED_155);
-  assign _zz__zz_decode_IS_RS2_SIGNED_156 = {_zz__zz_decode_IS_RS2_SIGNED_157,{_zz__zz_decode_IS_RS2_SIGNED_159,_zz__zz_decode_IS_RS2_SIGNED_162}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_108 = 32'h00000050;
-  assign _zz__zz_decode_IS_RS2_SIGNED_110 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz__zz_decode_IS_RS2_SIGNED_111 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_113 = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz__zz_decode_IS_RS2_SIGNED_114 = 32'h0;
-  assign _zz__zz_decode_IS_RS2_SIGNED_134 = 32'h00006014;
-  assign _zz__zz_decode_IS_RS2_SIGNED_137 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_140 = {(_zz__zz_decode_IS_RS2_SIGNED_141 == _zz__zz_decode_IS_RS2_SIGNED_142),(_zz__zz_decode_IS_RS2_SIGNED_143 == _zz__zz_decode_IS_RS2_SIGNED_144)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_148 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_150 = {(_zz__zz_decode_IS_RS2_SIGNED_151 == _zz__zz_decode_IS_RS2_SIGNED_152),{_zz__zz_decode_IS_RS2_SIGNED_153,_zz__zz_decode_IS_RS2_SIGNED_154}};
-  assign _zz__zz_decode_IS_RS2_SIGNED_155 = 3'b000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_157 = ({_zz__zz_decode_IS_RS2_SIGNED_158,_zz_decode_IS_RS2_SIGNED_1} != 2'b00);
-  assign _zz__zz_decode_IS_RS2_SIGNED_159 = ({_zz__zz_decode_IS_RS2_SIGNED_160,_zz__zz_decode_IS_RS2_SIGNED_161} != 2'b00);
-  assign _zz__zz_decode_IS_RS2_SIGNED_162 = (_zz__zz_decode_IS_RS2_SIGNED_163 != 1'b0);
-  assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00000018;
-  assign _zz__zz_decode_IS_RS2_SIGNED_141 = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_142 = 32'h00002000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_143 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_144 = 32'h00001000;
-  assign _zz__zz_decode_IS_RS2_SIGNED_151 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_RS2_SIGNED_152 = 32'h00000040;
-  assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz__zz_decode_IS_RS2_SIGNED_158 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_160 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz__zz_decode_IS_RS2_SIGNED_161 = _zz_decode_IS_RS2_SIGNED_1;
-  assign _zz__zz_decode_IS_RS2_SIGNED_163 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_94 = {_zz__zz_decode_IS_RS2_SIGNED_95,_zz__zz_decode_IS_RS2_SIGNED_96};
+  assign _zz__zz_decode_IS_RS2_SIGNED_100 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_RS2_SIGNED_101 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_104 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_105) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_108 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_109) == 32'h00004010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_111 = (_zz__zz_decode_IS_RS2_SIGNED_112 == _zz__zz_decode_IS_RS2_SIGNED_113);
+  assign _zz__zz_decode_IS_RS2_SIGNED_115 = (|{_zz__zz_decode_IS_RS2_SIGNED_116,_zz__zz_decode_IS_RS2_SIGNED_118});
+  assign _zz__zz_decode_IS_RS2_SIGNED_124 = (|_zz__zz_decode_IS_RS2_SIGNED_125);
+  assign _zz__zz_decode_IS_RS2_SIGNED_127 = {_zz__zz_decode_IS_RS2_SIGNED_128,{_zz__zz_decode_IS_RS2_SIGNED_134,_zz__zz_decode_IS_RS2_SIGNED_138}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_80 = 32'h02002060;
+  assign _zz__zz_decode_IS_RS2_SIGNED_82 = 32'h02003020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_90 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_92 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_RS2_SIGNED_93 = 32'h00000010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_95 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_96 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_105 = 32'h00000020;
+  assign _zz__zz_decode_IS_RS2_SIGNED_109 = 32'h00004014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_112 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_IS_RS2_SIGNED_113 = 32'h00002010;
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_118 = {_zz_decode_IS_RS2_SIGNED_2,{_zz__zz_decode_IS_RS2_SIGNED_119,{_zz__zz_decode_IS_RS2_SIGNED_120,_zz__zz_decode_IS_RS2_SIGNED_122}}};
+  assign _zz__zz_decode_IS_RS2_SIGNED_125 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_126) == 32'h0);
+  assign _zz__zz_decode_IS_RS2_SIGNED_128 = (|{_zz__zz_decode_IS_RS2_SIGNED_129,{_zz__zz_decode_IS_RS2_SIGNED_130,_zz__zz_decode_IS_RS2_SIGNED_132}});
+  assign _zz__zz_decode_IS_RS2_SIGNED_134 = (|{_zz__zz_decode_IS_RS2_SIGNED_135,_zz__zz_decode_IS_RS2_SIGNED_137});
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = {(|_zz__zz_decode_IS_RS2_SIGNED_139),(|_zz__zz_decode_IS_RS2_SIGNED_142)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000044;
+  assign _zz__zz_decode_IS_RS2_SIGNED_119 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_120 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_121) == 32'h00001000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_122 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_123) == 32'h00004000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = 32'h00000058;
+  assign _zz__zz_decode_IS_RS2_SIGNED_129 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_IS_RS2_SIGNED_130 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_131) == 32'h00002010);
+  assign _zz__zz_decode_IS_RS2_SIGNED_132 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_133) == 32'h40000030);
+  assign _zz__zz_decode_IS_RS2_SIGNED_135 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_136) == 32'h00000004);
+  assign _zz__zz_decode_IS_RS2_SIGNED_137 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_139 = {(_zz__zz_decode_IS_RS2_SIGNED_140 == _zz__zz_decode_IS_RS2_SIGNED_141),_zz_decode_IS_RS2_SIGNED_1};
+  assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_121 = 32'h00005004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h00004050;
+  assign _zz__zz_decode_IS_RS2_SIGNED_131 = 32'h00002014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_133 = 32'h40000034;
+  assign _zz__zz_decode_IS_RS2_SIGNED_136 = 32'h00000014;
+  assign _zz__zz_decode_IS_RS2_SIGNED_140 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_RS2_SIGNED_141 = 32'h00000004;
+  assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00005048;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1685,836 +1640,819 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
@@ -2592,14 +2530,13 @@ module VexRiscv (
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[15];
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2675,10 +2612,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2723,10 +2660,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00001073),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2748,6 +2685,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -2805,7 +2743,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2818,7 +2756,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2846,15 +2784,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2863,7 +2801,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2919,7 +2857,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -2950,10 +2888,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2964,29 +2902,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -2994,21 +2934,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3049,9 +2989,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3074,7 +3014,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3136,24 +3076,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3178,7 +3124,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3224,7 +3170,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3272,7 +3218,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3353,12 +3299,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3376,7 +3322,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3395,9 +3341,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3407,12 +3355,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3425,7 +3373,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3435,7 +3383,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3454,7 +3402,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3467,8 +3415,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3481,7 +3429,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3533,7 +3481,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3546,7 +3494,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3566,10 +3514,11 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_IS_RS2_SIGNED = {(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{(_zz_decode_IS_RS2_SIGNED_4 != 1'b0),{((_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1) != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_2 != 1'b0),{(_zz__zz_decode_IS_RS2_SIGNED_3 != _zz__zz_decode_IS_RS2_SIGNED_4),{_zz__zz_decode_IS_RS2_SIGNED_5,{_zz__zz_decode_IS_RS2_SIGNED_7,_zz__zz_decode_IS_RS2_SIGNED_10}}}}}}};
+  assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_5),{(|_zz_decode_IS_RS2_SIGNED_5),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_6,_zz__zz_decode_IS_RS2_SIGNED_9}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
@@ -3615,10 +3564,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3629,10 +3578,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3643,13 +3592,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3708,13 +3657,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3767,7 +3716,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -3884,9 +3833,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -3904,13 +3853,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -3983,10 +3932,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -3998,7 +3947,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4033,11 +3982,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4097,9 +4046,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4144,28 +4093,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4173,7 +4122,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4211,14 +4160,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4316,18 +4265,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4335,20 +4284,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4361,20 +4310,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4383,9 +4332,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4396,8 +4345,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4490,7 +4439,7 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4606,30 +4555,30 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4667,12 +4616,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -4802,8 +4752,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4859,11 +4809,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -4875,6 +4823,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4903,16 +4853,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -4930,13 +4880,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4945,7 +4895,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4954,7 +4904,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4963,7 +4913,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4986,51 +4936,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5039,7 +4993,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5050,8 +5004,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5061,7 +5015,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
@@ -5089,9 +5043,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5099,6 +5059,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5155,10 +5135,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5175,21 +5151,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5411,76 +5387,76 @@ module VexRiscv (
     if(when_Pipeline_l124_61) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5515,26 +5491,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -5565,6 +5521,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -5588,6 +5545,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5604,6 +5563,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -5645,40 +5605,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5688,33 +5648,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5722,18 +5682,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5745,17 +5705,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -5809,14 +5769,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -5830,42 +5790,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5875,7 +5835,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -5885,7 +5845,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -5895,7 +5855,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5920,14 +5880,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -5937,7 +5897,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -5947,7 +5907,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -5957,7 +5917,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -5970,15 +5930,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -5986,7 +5946,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6008,42 +5968,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6051,7 +6011,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6061,27 +6021,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6092,8 +6052,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6101,26 +6061,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6141,22 +6101,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6165,8 +6125,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6179,8 +6139,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6195,8 +6155,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6206,12 +6166,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6220,11 +6180,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6240,12 +6200,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6253,26 +6213,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6283,27 +6243,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6324,28 +6284,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6356,7 +6322,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6364,7 +6330,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6415,6 +6381,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -6432,7 +6399,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6478,8 +6445,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -6549,10 +6516,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6580,7 +6547,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_CustomCfu.v
+++ b/soc/vexriscv/VexRiscv_CustomCfu.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -86,6 +42,35 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -114,6 +99,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -196,179 +183,169 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -439,10 +416,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -450,46 +427,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -499,9 +478,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -515,20 +496,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -542,42 +522,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -586,6 +566,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -598,8 +579,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -611,7 +592,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -655,6 +636,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -723,6 +705,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -765,14 +748,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -814,18 +797,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -844,7 +827,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -891,45 +873,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -983,7 +965,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1003,7 +985,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1022,11 +1004,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1043,59 +1025,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1143,22 +1125,25 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1180,7 +1165,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1190,9 +1175,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1212,80 +1197,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1293,59 +1284,60 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1364,8 +1356,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1454,7 +1446,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1468,7 +1460,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1483,7 +1475,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1495,6 +1487,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1568,172 +1562,160 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h00203050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00403050);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1757,899 +1739,882 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2693,6 +2658,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2727,6 +2694,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2747,14 +2716,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2830,10 +2798,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2844,7 +2812,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2881,10 +2849,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2906,6 +2874,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -2963,7 +2932,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2976,7 +2945,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3004,27 +2973,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3058,7 +3030,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3076,7 +3048,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3107,10 +3079,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3121,29 +3093,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3151,21 +3125,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3206,9 +3180,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3231,7 +3205,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3293,24 +3267,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3335,7 +3315,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3381,7 +3361,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3429,7 +3409,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3510,12 +3490,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3533,7 +3513,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3552,9 +3532,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3564,12 +3546,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3582,7 +3564,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3592,7 +3574,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3611,7 +3593,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3624,8 +3606,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3638,7 +3620,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3690,7 +3672,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3703,7 +3685,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3723,11 +3705,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3742,8 +3725,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3775,10 +3758,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3789,10 +3772,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3803,13 +3786,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3868,13 +3851,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3927,7 +3910,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4044,9 +4027,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4064,13 +4047,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4143,10 +4126,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4158,7 +4141,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4193,11 +4176,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4248,14 +4231,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4264,9 +4247,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4310,28 +4293,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4339,7 +4322,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4377,14 +4360,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4482,18 +4465,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4501,20 +4484,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4527,20 +4510,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4549,9 +4532,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4562,8 +4545,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4656,12 +4639,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4695,7 +4681,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4706,16 +4692,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4752,64 +4738,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4836,30 +4825,30 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4897,12 +4886,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5032,8 +5022,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5089,11 +5079,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5105,6 +5093,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5137,16 +5127,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5164,13 +5154,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5179,7 +5169,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5188,7 +5178,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5197,7 +5187,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5220,51 +5210,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5273,7 +5267,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5284,8 +5278,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5295,7 +5289,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5306,16 +5300,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5344,9 +5338,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5354,6 +5354,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5410,10 +5430,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5426,21 +5442,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5558,186 +5574,195 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5772,26 +5797,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -5822,6 +5827,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -5845,6 +5851,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5861,6 +5869,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -5902,40 +5911,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5945,33 +5954,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5979,18 +5988,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6002,17 +6011,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6066,14 +6075,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6087,42 +6096,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6132,7 +6141,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6142,7 +6151,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6152,7 +6161,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6177,14 +6186,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6194,7 +6203,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6204,7 +6213,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6214,7 +6223,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6227,15 +6236,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6243,7 +6252,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6265,42 +6274,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6308,7 +6317,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6318,27 +6327,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6349,8 +6358,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6358,26 +6367,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6398,22 +6407,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6422,8 +6431,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6436,8 +6445,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6452,8 +6461,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6463,12 +6472,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6477,11 +6486,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6497,12 +6506,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6510,26 +6519,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6540,27 +6549,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6581,28 +6590,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6613,7 +6628,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6621,7 +6636,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6672,6 +6687,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -6689,7 +6705,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6735,8 +6751,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -6806,10 +6822,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6837,7 +6853,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_Fomu.v
+++ b/soc/vexriscv/VexRiscv_Fomu.v
@@ -1,47 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : b974c176159a3b4d56d11c22552ed780bbeedcbc
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b10
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -73,6 +34,32 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_ECALL = 2'd2;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -112,138 +99,117 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_MUL;
   wire       [31:0]   _zz__zz_decode_IS_MUL_1;
   wire       [31:0]   _zz__zz_decode_IS_MUL_2;
-  wire                _zz__zz_decode_IS_MUL_3;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_4;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_5;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_3;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_4;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_5;
   wire       [31:0]   _zz__zz_decode_IS_MUL_6;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_7;
+  wire                _zz__zz_decode_IS_MUL_7;
   wire       [31:0]   _zz__zz_decode_IS_MUL_8;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_9;
-  wire                _zz__zz_decode_IS_MUL_10;
-  wire                _zz__zz_decode_IS_MUL_11;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_12;
-  wire                _zz__zz_decode_IS_MUL_13;
-  wire       [21:0]   _zz__zz_decode_IS_MUL_14;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_9;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_10;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_11;
+  wire       [20:0]   _zz__zz_decode_IS_MUL_12;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_13;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_14;
   wire       [1:0]    _zz__zz_decode_IS_MUL_15;
   wire       [31:0]   _zz__zz_decode_IS_MUL_16;
   wire       [31:0]   _zz__zz_decode_IS_MUL_17;
   wire       [31:0]   _zz__zz_decode_IS_MUL_18;
   wire       [31:0]   _zz__zz_decode_IS_MUL_19;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_20;
-  wire                _zz__zz_decode_IS_MUL_21;
+  wire       [2:0]    _zz__zz_decode_IS_MUL_20;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_21;
   wire       [31:0]   _zz__zz_decode_IS_MUL_22;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_23;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_24;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_25;
+  wire                _zz__zz_decode_IS_MUL_23;
+  wire                _zz__zz_decode_IS_MUL_24;
+  wire                _zz__zz_decode_IS_MUL_25;
   wire       [31:0]   _zz__zz_decode_IS_MUL_26;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_27;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_28;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_29;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_30;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_31;
-  wire       [18:0]   _zz__zz_decode_IS_MUL_32;
-  wire       [2:0]    _zz__zz_decode_IS_MUL_33;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_27;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_28;
+  wire                _zz__zz_decode_IS_MUL_29;
+  wire       [16:0]   _zz__zz_decode_IS_MUL_30;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_31;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_32;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_33;
   wire       [31:0]   _zz__zz_decode_IS_MUL_34;
   wire       [31:0]   _zz__zz_decode_IS_MUL_35;
   wire                _zz__zz_decode_IS_MUL_36;
   wire                _zz__zz_decode_IS_MUL_37;
-  wire       [2:0]    _zz__zz_decode_IS_MUL_38;
-  wire                _zz__zz_decode_IS_MUL_39;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_40;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_41;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_42;
-  wire                _zz__zz_decode_IS_MUL_43;
-  wire       [15:0]   _zz__zz_decode_IS_MUL_44;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_45;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_46;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_47;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_48;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_49;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_50;
-  wire                _zz__zz_decode_IS_MUL_51;
+  wire                _zz__zz_decode_IS_MUL_38;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_39;
+  wire       [13:0]   _zz__zz_decode_IS_MUL_40;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_41;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_42;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_43;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_44;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_45;
+  wire                _zz__zz_decode_IS_MUL_46;
+  wire                _zz__zz_decode_IS_MUL_47;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_48;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_49;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_50;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_51;
   wire                _zz__zz_decode_IS_MUL_52;
-  wire                _zz__zz_decode_IS_MUL_53;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_54;
-  wire       [12:0]   _zz__zz_decode_IS_MUL_55;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_56;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_57;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_58;
+  wire       [10:0]   _zz__zz_decode_IS_MUL_53;
+  wire       [3:0]    _zz__zz_decode_IS_MUL_54;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_55;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_56;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_57;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_58;
   wire       [31:0]   _zz__zz_decode_IS_MUL_59;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_60;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_61;
-  wire                _zz__zz_decode_IS_MUL_62;
+  wire                _zz__zz_decode_IS_MUL_60;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_61;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_62;
   wire       [31:0]   _zz__zz_decode_IS_MUL_63;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_64;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_64;
   wire       [0:0]    _zz__zz_decode_IS_MUL_65;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_66;
+  wire       [4:0]    _zz__zz_decode_IS_MUL_66;
   wire       [31:0]   _zz__zz_decode_IS_MUL_67;
-  wire       [2:0]    _zz__zz_decode_IS_MUL_68;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_68;
   wire                _zz__zz_decode_IS_MUL_69;
   wire       [31:0]   _zz__zz_decode_IS_MUL_70;
-  wire       [9:0]    _zz__zz_decode_IS_MUL_71;
-  wire       [2:0]    _zz__zz_decode_IS_MUL_72;
-  wire                _zz__zz_decode_IS_MUL_73;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_74;
-  wire       [2:0]    _zz__zz_decode_IS_MUL_75;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_71;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_72;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_73;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_74;
+  wire                _zz__zz_decode_IS_MUL_75;
   wire                _zz__zz_decode_IS_MUL_76;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_77;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_78;
+  wire       [7:0]    _zz__zz_decode_IS_MUL_77;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_78;
   wire       [31:0]   _zz__zz_decode_IS_MUL_79;
-  wire       [3:0]    _zz__zz_decode_IS_MUL_80;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_80;
   wire                _zz__zz_decode_IS_MUL_81;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_82;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_83;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_84;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_85;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_86;
-  wire                _zz__zz_decode_IS_MUL_87;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_88;
-  wire                _zz__zz_decode_IS_MUL_89;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_90;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_91;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_92;
+  wire                _zz__zz_decode_IS_MUL_82;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_83;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_84;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_85;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_86;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_87;
+  wire       [2:0]    _zz__zz_decode_IS_MUL_88;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_89;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_90;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_91;
+  wire       [4:0]    _zz__zz_decode_IS_MUL_92;
   wire       [0:0]    _zz__zz_decode_IS_MUL_93;
   wire       [31:0]   _zz__zz_decode_IS_MUL_94;
   wire       [31:0]   _zz__zz_decode_IS_MUL_95;
-  wire       [6:0]    _zz__zz_decode_IS_MUL_96;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_97;
-  wire                _zz__zz_decode_IS_MUL_98;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_99;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_100;
-  wire                _zz__zz_decode_IS_MUL_101;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_102;
+  wire                _zz__zz_decode_IS_MUL_96;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_97;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_98;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_99;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_100;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_101;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_102;
   wire       [31:0]   _zz__zz_decode_IS_MUL_103;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_104;
-  wire       [2:0]    _zz__zz_decode_IS_MUL_105;
-  wire                _zz__zz_decode_IS_MUL_106;
+  wire       [0:0]    _zz__zz_decode_IS_MUL_104;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_105;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_106;
   wire       [31:0]   _zz__zz_decode_IS_MUL_107;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_108;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_109;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_110;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_111;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_112;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_113;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_114;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_115;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_116;
-  wire       [3:0]    _zz__zz_decode_IS_MUL_117;
-  wire                _zz__zz_decode_IS_MUL_118;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_119;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_120;
-  wire       [31:0]   _zz__zz_decode_IS_MUL_121;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_122;
-  wire                _zz__zz_decode_IS_MUL_123;
-  wire                _zz__zz_decode_IS_MUL_124;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_125;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_126;
-  wire                _zz__zz_decode_IS_MUL_127;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_128;
-  wire       [1:0]    _zz__zz_decode_IS_MUL_129;
-  wire                _zz__zz_decode_IS_MUL_130;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_131;
-  wire       [0:0]    _zz__zz_decode_IS_MUL_132;
-  wire                _zz__zz_decode_IS_MUL_133;
-  wire                _zz__zz_decode_IS_MUL_134;
+  wire       [1:0]    _zz__zz_decode_IS_MUL_108;
+  wire                _zz__zz_decode_IS_MUL_109;
+  wire                _zz__zz_decode_IS_MUL_110;
+  wire                _zz__zz_decode_IS_MUL_111;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_112;
+  wire       [31:0]   _zz__zz_decode_IS_MUL_113;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -289,45 +255,45 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
   wire                decode_MEMORY_ENABLE;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
@@ -342,18 +308,18 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -364,39 +330,38 @@ module VexRiscv (
   wire                writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
-  wire                writeBack_MEMORY_STORE;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_lastStageRegFileWrite_payload_data;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
@@ -422,7 +387,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   wire                decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -466,6 +431,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_pcValids_0;
   wire                IBusCachedPlugin_pcValids_1;
@@ -488,6 +454,7 @@ module VexRiscv (
   wire                IBusCachedPlugin_mmuBus_busy;
   wire                BranchPlugin_jumpInterface_valid;
   wire       [31:0]   BranchPlugin_jumpInterface_payload;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -526,14 +493,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -575,18 +542,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -594,7 +561,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -617,12 +583,12 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l426;
+  wire                when_DBusSimplePlugin_l428;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l479;
+  wire                when_DBusSimplePlugin_l482;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
@@ -635,13 +601,14 @@ module VexRiscv (
   wire                _zz_decode_IS_MUL_3;
   wire                _zz_decode_IS_MUL_4;
   wire                _zz_decode_IS_MUL_5;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
+  wire                _zz_decode_IS_MUL_6;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -697,7 +664,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_DO;
   reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
@@ -727,11 +694,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   wire                CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -744,55 +711,55 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -830,7 +797,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
   wire                when_Pipeline_l124_9;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_11;
@@ -840,7 +807,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_13;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_15;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_16;
@@ -858,66 +825,64 @@ module VexRiscv (
   wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_MEMORY_STORE;
   wire                when_Pipeline_l124_23;
-  reg                 memory_to_writeBack_MEMORY_STORE;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_24;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
-  wire                when_Pipeline_l124_25;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  wire                when_Pipeline_l124_25;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_26;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_27;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_28;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
-  wire                when_Pipeline_l124_29;
   reg                 decode_to_execute_IS_CSR;
+  wire                when_Pipeline_l124_29;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_30;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_31;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_32;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
-  wire                when_Pipeline_l124_33;
   reg                 decode_to_execute_IS_MUL;
-  wire                when_Pipeline_l124_34;
+  wire                when_Pipeline_l124_33;
   reg                 execute_to_memory_IS_MUL;
-  wire                when_Pipeline_l124_35;
+  wire                when_Pipeline_l124_34;
   reg                 memory_to_writeBack_IS_MUL;
-  wire                when_Pipeline_l124_36;
+  wire                when_Pipeline_l124_35;
   reg        [31:0]   decode_to_execute_RS1;
-  wire                when_Pipeline_l124_37;
+  wire                when_Pipeline_l124_36;
   reg        [31:0]   decode_to_execute_RS2;
-  wire                when_Pipeline_l124_38;
+  wire                when_Pipeline_l124_37;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  wire                when_Pipeline_l124_39;
+  wire                when_Pipeline_l124_38;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  wire                when_Pipeline_l124_40;
+  wire                when_Pipeline_l124_39;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  wire                when_Pipeline_l124_41;
+  wire                when_Pipeline_l124_40;
   reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  wire                when_Pipeline_l124_42;
+  wire                when_Pipeline_l124_41;
   reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  wire                when_Pipeline_l124_43;
+  wire                when_Pipeline_l124_42;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  wire                when_Pipeline_l124_44;
+  wire                when_Pipeline_l124_43;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  wire                when_Pipeline_l124_45;
+  wire                when_Pipeline_l124_44;
   reg                 execute_to_memory_BRANCH_DO;
-  wire                when_Pipeline_l124_46;
+  wire                when_Pipeline_l124_45;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  wire                when_Pipeline_l124_47;
+  wire                when_Pipeline_l124_46;
   reg        [31:0]   execute_to_memory_MUL_LL;
-  wire                when_Pipeline_l124_48;
+  wire                when_Pipeline_l124_47;
   reg        [33:0]   execute_to_memory_MUL_LH;
-  wire                when_Pipeline_l124_49;
+  wire                when_Pipeline_l124_48;
   reg        [33:0]   execute_to_memory_MUL_HL;
-  wire                when_Pipeline_l124_50;
+  wire                when_Pipeline_l124_49;
   reg        [33:0]   execute_to_memory_MUL_HH;
-  wire                when_Pipeline_l124_51;
+  wire                when_Pipeline_l124_50;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
-  wire                when_Pipeline_l124_52;
+  wire                when_Pipeline_l124_51;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
-  wire                when_Pipeline_l124_53;
+  wire                when_Pipeline_l124_52;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -925,28 +890,29 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_4032;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -957,8 +923,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1053,7 +1019,7 @@ module VexRiscv (
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
   assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
@@ -1080,7 +1046,7 @@ module VexRiscv (
   assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
   assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
   assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
-  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
@@ -1090,141 +1056,120 @@ module VexRiscv (
   assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
-  assign _zz__zz_decode_IS_MUL = 32'h02000074;
-  assign _zz__zz_decode_IS_MUL_1 = (decode_INSTRUCTION & 32'h10003050);
-  assign _zz__zz_decode_IS_MUL_2 = 32'h00000050;
-  assign _zz__zz_decode_IS_MUL_3 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz__zz_decode_IS_MUL_4 = {(_zz__zz_decode_IS_MUL_5 == _zz__zz_decode_IS_MUL_6),(_zz__zz_decode_IS_MUL_7 == _zz__zz_decode_IS_MUL_8)};
-  assign _zz__zz_decode_IS_MUL_9 = 2'b00;
-  assign _zz__zz_decode_IS_MUL_10 = ({_zz_decode_IS_MUL_4,_zz__zz_decode_IS_MUL_11} != 2'b00);
-  assign _zz__zz_decode_IS_MUL_12 = (_zz__zz_decode_IS_MUL_13 != 1'b0);
-  assign _zz__zz_decode_IS_MUL_14 = {(_zz__zz_decode_IS_MUL_15 != _zz__zz_decode_IS_MUL_20),{_zz__zz_decode_IS_MUL_21,{_zz__zz_decode_IS_MUL_24,_zz__zz_decode_IS_MUL_32}}};
-  assign _zz__zz_decode_IS_MUL_5 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_IS_MUL_6 = 32'h00001050;
-  assign _zz__zz_decode_IS_MUL_7 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_IS_MUL_8 = 32'h00002050;
-  assign _zz__zz_decode_IS_MUL_11 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_IS_MUL_13 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz__zz_decode_IS_MUL = 32'h10003050;
+  assign _zz__zz_decode_IS_MUL_1 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_IS_MUL_2 = 32'h10000050;
+  assign _zz__zz_decode_IS_MUL_3 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_IS_MUL_4 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_IS_MUL_5 = {_zz_decode_IS_MUL_5,((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_6) == 32'h00000004)};
+  assign _zz__zz_decode_IS_MUL_7 = (|((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_8) == 32'h00000040));
+  assign _zz__zz_decode_IS_MUL_9 = (|(_zz__zz_decode_IS_MUL_10 == _zz__zz_decode_IS_MUL_11));
+  assign _zz__zz_decode_IS_MUL_12 = {(|{_zz__zz_decode_IS_MUL_13,_zz__zz_decode_IS_MUL_15}),{(|_zz__zz_decode_IS_MUL_20),{_zz__zz_decode_IS_MUL_25,{_zz__zz_decode_IS_MUL_28,_zz__zz_decode_IS_MUL_30}}}};
+  assign _zz__zz_decode_IS_MUL_6 = 32'h0000001c;
+  assign _zz__zz_decode_IS_MUL_8 = 32'h00000058;
+  assign _zz__zz_decode_IS_MUL_10 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz__zz_decode_IS_MUL_11 = 32'h00005010;
+  assign _zz__zz_decode_IS_MUL_13 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_14) == 32'h40001010);
   assign _zz__zz_decode_IS_MUL_15 = {(_zz__zz_decode_IS_MUL_16 == _zz__zz_decode_IS_MUL_17),(_zz__zz_decode_IS_MUL_18 == _zz__zz_decode_IS_MUL_19)};
-  assign _zz__zz_decode_IS_MUL_20 = 2'b00;
-  assign _zz__zz_decode_IS_MUL_21 = ((_zz__zz_decode_IS_MUL_22 == _zz__zz_decode_IS_MUL_23) != 1'b0);
-  assign _zz__zz_decode_IS_MUL_24 = ({_zz__zz_decode_IS_MUL_25,_zz__zz_decode_IS_MUL_27} != 3'b000);
-  assign _zz__zz_decode_IS_MUL_32 = {(_zz__zz_decode_IS_MUL_33 != _zz__zz_decode_IS_MUL_38),{_zz__zz_decode_IS_MUL_39,{_zz__zz_decode_IS_MUL_42,_zz__zz_decode_IS_MUL_44}}};
-  assign _zz__zz_decode_IS_MUL_16 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_MUL_17 = 32'h00000040;
-  assign _zz__zz_decode_IS_MUL_18 = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz__zz_decode_IS_MUL_19 = 32'h00000040;
-  assign _zz__zz_decode_IS_MUL_22 = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz__zz_decode_IS_MUL_23 = 32'h00005010;
-  assign _zz__zz_decode_IS_MUL_25 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_26) == 32'h40001010);
-  assign _zz__zz_decode_IS_MUL_27 = {(_zz__zz_decode_IS_MUL_28 == _zz__zz_decode_IS_MUL_29),(_zz__zz_decode_IS_MUL_30 == _zz__zz_decode_IS_MUL_31)};
-  assign _zz__zz_decode_IS_MUL_33 = {(_zz__zz_decode_IS_MUL_34 == _zz__zz_decode_IS_MUL_35),{_zz__zz_decode_IS_MUL_36,_zz__zz_decode_IS_MUL_37}};
-  assign _zz__zz_decode_IS_MUL_38 = 3'b000;
-  assign _zz__zz_decode_IS_MUL_39 = ((_zz__zz_decode_IS_MUL_40 == _zz__zz_decode_IS_MUL_41) != 1'b0);
-  assign _zz__zz_decode_IS_MUL_42 = (_zz__zz_decode_IS_MUL_43 != 1'b0);
-  assign _zz__zz_decode_IS_MUL_44 = {(_zz__zz_decode_IS_MUL_45 != _zz__zz_decode_IS_MUL_50),{_zz__zz_decode_IS_MUL_51,{_zz__zz_decode_IS_MUL_54,_zz__zz_decode_IS_MUL_55}}};
-  assign _zz__zz_decode_IS_MUL_26 = 32'h40003054;
-  assign _zz__zz_decode_IS_MUL_28 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_IS_MUL_29 = 32'h00001010;
-  assign _zz__zz_decode_IS_MUL_30 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_IS_MUL_31 = 32'h00001010;
-  assign _zz__zz_decode_IS_MUL_34 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_MUL_35 = 32'h00000024;
-  assign _zz__zz_decode_IS_MUL_36 = ((decode_INSTRUCTION & 32'h00003034) == 32'h00001010);
-  assign _zz__zz_decode_IS_MUL_37 = ((decode_INSTRUCTION & 32'h02003054) == 32'h00001010);
-  assign _zz__zz_decode_IS_MUL_40 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_IS_MUL_41 = 32'h00001000;
-  assign _zz__zz_decode_IS_MUL_43 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_IS_MUL_45 = {(_zz__zz_decode_IS_MUL_46 == _zz__zz_decode_IS_MUL_47),(_zz__zz_decode_IS_MUL_48 == _zz__zz_decode_IS_MUL_49)};
-  assign _zz__zz_decode_IS_MUL_50 = 2'b00;
-  assign _zz__zz_decode_IS_MUL_51 = ({_zz__zz_decode_IS_MUL_52,_zz__zz_decode_IS_MUL_53} != 2'b00);
-  assign _zz__zz_decode_IS_MUL_54 = (_zz_decode_IS_MUL_2 != 1'b0);
-  assign _zz__zz_decode_IS_MUL_55 = {(_zz__zz_decode_IS_MUL_56 != _zz__zz_decode_IS_MUL_61),{_zz__zz_decode_IS_MUL_62,{_zz__zz_decode_IS_MUL_65,_zz__zz_decode_IS_MUL_71}}};
-  assign _zz__zz_decode_IS_MUL_46 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_IS_MUL_47 = 32'h00002000;
-  assign _zz__zz_decode_IS_MUL_48 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_IS_MUL_49 = 32'h00001000;
-  assign _zz__zz_decode_IS_MUL_52 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00006000);
-  assign _zz__zz_decode_IS_MUL_53 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00004000);
-  assign _zz__zz_decode_IS_MUL_56 = {(_zz__zz_decode_IS_MUL_57 == _zz__zz_decode_IS_MUL_58),(_zz__zz_decode_IS_MUL_59 == _zz__zz_decode_IS_MUL_60)};
-  assign _zz__zz_decode_IS_MUL_61 = 2'b00;
-  assign _zz__zz_decode_IS_MUL_62 = ((_zz__zz_decode_IS_MUL_63 == _zz__zz_decode_IS_MUL_64) != 1'b0);
-  assign _zz__zz_decode_IS_MUL_65 = ({_zz__zz_decode_IS_MUL_66,_zz__zz_decode_IS_MUL_68} != 4'b0000);
-  assign _zz__zz_decode_IS_MUL_71 = {(_zz__zz_decode_IS_MUL_72 != _zz__zz_decode_IS_MUL_75),{_zz__zz_decode_IS_MUL_76,{_zz__zz_decode_IS_MUL_91,_zz__zz_decode_IS_MUL_96}}};
-  assign _zz__zz_decode_IS_MUL_57 = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz__zz_decode_IS_MUL_58 = 32'h00000020;
-  assign _zz__zz_decode_IS_MUL_59 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_IS_MUL_60 = 32'h00000020;
-  assign _zz__zz_decode_IS_MUL_63 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_IS_MUL_64 = 32'h00000020;
-  assign _zz__zz_decode_IS_MUL_66 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_67) == 32'h00000040);
-  assign _zz__zz_decode_IS_MUL_68 = {_zz_decode_IS_MUL_3,{_zz_decode_IS_MUL_5,_zz__zz_decode_IS_MUL_69}};
-  assign _zz__zz_decode_IS_MUL_72 = {_zz_decode_IS_MUL_3,{_zz_decode_IS_MUL_5,_zz__zz_decode_IS_MUL_73}};
-  assign _zz__zz_decode_IS_MUL_75 = 3'b000;
-  assign _zz__zz_decode_IS_MUL_76 = ({_zz_decode_IS_MUL_4,{_zz__zz_decode_IS_MUL_77,_zz__zz_decode_IS_MUL_80}} != 6'h0);
-  assign _zz__zz_decode_IS_MUL_91 = ({_zz__zz_decode_IS_MUL_92,_zz__zz_decode_IS_MUL_93} != 2'b00);
-  assign _zz__zz_decode_IS_MUL_96 = {(_zz__zz_decode_IS_MUL_97 != _zz__zz_decode_IS_MUL_100),{_zz__zz_decode_IS_MUL_101,{_zz__zz_decode_IS_MUL_112,_zz__zz_decode_IS_MUL_117}}};
-  assign _zz__zz_decode_IS_MUL_67 = 32'h00000040;
-  assign _zz__zz_decode_IS_MUL_69 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_70) == 32'h00000020);
-  assign _zz__zz_decode_IS_MUL_73 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_74) == 32'h00000020);
-  assign _zz__zz_decode_IS_MUL_77 = (_zz__zz_decode_IS_MUL_78 == _zz__zz_decode_IS_MUL_79);
-  assign _zz__zz_decode_IS_MUL_80 = {_zz__zz_decode_IS_MUL_81,{_zz__zz_decode_IS_MUL_83,_zz__zz_decode_IS_MUL_86}};
-  assign _zz__zz_decode_IS_MUL_92 = _zz_decode_IS_MUL_3;
+  assign _zz__zz_decode_IS_MUL_20 = {(_zz__zz_decode_IS_MUL_21 == _zz__zz_decode_IS_MUL_22),{_zz__zz_decode_IS_MUL_23,_zz__zz_decode_IS_MUL_24}};
+  assign _zz__zz_decode_IS_MUL_25 = (|(_zz__zz_decode_IS_MUL_26 == _zz__zz_decode_IS_MUL_27));
+  assign _zz__zz_decode_IS_MUL_28 = (|_zz__zz_decode_IS_MUL_29);
+  assign _zz__zz_decode_IS_MUL_30 = {(|_zz__zz_decode_IS_MUL_31),{_zz__zz_decode_IS_MUL_36,{_zz__zz_decode_IS_MUL_39,_zz__zz_decode_IS_MUL_40}}};
+  assign _zz__zz_decode_IS_MUL_14 = 32'h40003054;
+  assign _zz__zz_decode_IS_MUL_16 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz__zz_decode_IS_MUL_17 = 32'h00001010;
+  assign _zz__zz_decode_IS_MUL_18 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_IS_MUL_19 = 32'h00001010;
+  assign _zz__zz_decode_IS_MUL_21 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_MUL_22 = 32'h00000024;
+  assign _zz__zz_decode_IS_MUL_23 = ((decode_INSTRUCTION & 32'h00003034) == 32'h00001010);
+  assign _zz__zz_decode_IS_MUL_24 = ((decode_INSTRUCTION & 32'h02003054) == 32'h00001010);
+  assign _zz__zz_decode_IS_MUL_26 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_IS_MUL_27 = 32'h00001000;
+  assign _zz__zz_decode_IS_MUL_29 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_IS_MUL_31 = {(_zz__zz_decode_IS_MUL_32 == _zz__zz_decode_IS_MUL_33),(_zz__zz_decode_IS_MUL_34 == _zz__zz_decode_IS_MUL_35)};
+  assign _zz__zz_decode_IS_MUL_36 = (|{_zz__zz_decode_IS_MUL_37,_zz__zz_decode_IS_MUL_38});
+  assign _zz__zz_decode_IS_MUL_39 = (|_zz_decode_IS_MUL_2);
+  assign _zz__zz_decode_IS_MUL_40 = {(|_zz__zz_decode_IS_MUL_41),{_zz__zz_decode_IS_MUL_46,{_zz__zz_decode_IS_MUL_51,_zz__zz_decode_IS_MUL_53}}};
+  assign _zz__zz_decode_IS_MUL_32 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_IS_MUL_33 = 32'h00002000;
+  assign _zz__zz_decode_IS_MUL_34 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_IS_MUL_35 = 32'h00001000;
+  assign _zz__zz_decode_IS_MUL_37 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00006000);
+  assign _zz__zz_decode_IS_MUL_38 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00004000);
+  assign _zz__zz_decode_IS_MUL_41 = {(_zz__zz_decode_IS_MUL_42 == _zz__zz_decode_IS_MUL_43),(_zz__zz_decode_IS_MUL_44 == _zz__zz_decode_IS_MUL_45)};
+  assign _zz__zz_decode_IS_MUL_46 = (|{_zz__zz_decode_IS_MUL_47,{_zz__zz_decode_IS_MUL_48,_zz__zz_decode_IS_MUL_49}});
+  assign _zz__zz_decode_IS_MUL_51 = (|_zz__zz_decode_IS_MUL_52);
+  assign _zz__zz_decode_IS_MUL_53 = {(|_zz__zz_decode_IS_MUL_54),{_zz__zz_decode_IS_MUL_60,{_zz__zz_decode_IS_MUL_64,_zz__zz_decode_IS_MUL_77}}};
+  assign _zz__zz_decode_IS_MUL_42 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_IS_MUL_43 = 32'h00000020;
+  assign _zz__zz_decode_IS_MUL_44 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_IS_MUL_45 = 32'h00000020;
+  assign _zz__zz_decode_IS_MUL_47 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_IS_MUL_48 = _zz_decode_IS_MUL_3;
+  assign _zz__zz_decode_IS_MUL_49 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_50) == 32'h00000040);
+  assign _zz__zz_decode_IS_MUL_52 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_IS_MUL_54 = {(_zz__zz_decode_IS_MUL_55 == _zz__zz_decode_IS_MUL_56),{_zz_decode_IS_MUL_4,{_zz__zz_decode_IS_MUL_57,_zz__zz_decode_IS_MUL_58}}};
+  assign _zz__zz_decode_IS_MUL_60 = (|{_zz_decode_IS_MUL_4,{_zz__zz_decode_IS_MUL_61,_zz__zz_decode_IS_MUL_62}});
+  assign _zz__zz_decode_IS_MUL_64 = (|{_zz__zz_decode_IS_MUL_65,_zz__zz_decode_IS_MUL_66});
+  assign _zz__zz_decode_IS_MUL_77 = {(|_zz__zz_decode_IS_MUL_78),{_zz__zz_decode_IS_MUL_81,{_zz__zz_decode_IS_MUL_84,_zz__zz_decode_IS_MUL_92}}};
+  assign _zz__zz_decode_IS_MUL_50 = 32'h00403040;
+  assign _zz__zz_decode_IS_MUL_55 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_IS_MUL_56 = 32'h00000040;
+  assign _zz__zz_decode_IS_MUL_57 = _zz_decode_IS_MUL_6;
+  assign _zz__zz_decode_IS_MUL_58 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_59) == 32'h00000020);
+  assign _zz__zz_decode_IS_MUL_61 = _zz_decode_IS_MUL_6;
+  assign _zz__zz_decode_IS_MUL_62 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_63) == 32'h00000020);
+  assign _zz__zz_decode_IS_MUL_65 = _zz_decode_IS_MUL_5;
+  assign _zz__zz_decode_IS_MUL_66 = {(_zz__zz_decode_IS_MUL_67 == _zz__zz_decode_IS_MUL_68),{_zz__zz_decode_IS_MUL_69,{_zz__zz_decode_IS_MUL_71,_zz__zz_decode_IS_MUL_74}}};
+  assign _zz__zz_decode_IS_MUL_78 = {_zz_decode_IS_MUL_4,(_zz__zz_decode_IS_MUL_79 == _zz__zz_decode_IS_MUL_80)};
+  assign _zz__zz_decode_IS_MUL_81 = (|{_zz_decode_IS_MUL_4,_zz__zz_decode_IS_MUL_82});
+  assign _zz__zz_decode_IS_MUL_84 = (|{_zz__zz_decode_IS_MUL_85,_zz__zz_decode_IS_MUL_88});
+  assign _zz__zz_decode_IS_MUL_92 = {(|_zz__zz_decode_IS_MUL_93),{_zz__zz_decode_IS_MUL_96,{_zz__zz_decode_IS_MUL_104,_zz__zz_decode_IS_MUL_108}}};
+  assign _zz__zz_decode_IS_MUL_59 = 32'h02000020;
+  assign _zz__zz_decode_IS_MUL_63 = 32'h02000060;
+  assign _zz__zz_decode_IS_MUL_67 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_IS_MUL_68 = 32'h00001010;
+  assign _zz__zz_decode_IS_MUL_69 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_70) == 32'h00002010);
+  assign _zz__zz_decode_IS_MUL_71 = (_zz__zz_decode_IS_MUL_72 == _zz__zz_decode_IS_MUL_73);
+  assign _zz__zz_decode_IS_MUL_74 = {_zz__zz_decode_IS_MUL_75,_zz__zz_decode_IS_MUL_76};
+  assign _zz__zz_decode_IS_MUL_79 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_IS_MUL_80 = 32'h00000020;
+  assign _zz__zz_decode_IS_MUL_82 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_83) == 32'h0);
+  assign _zz__zz_decode_IS_MUL_85 = (_zz__zz_decode_IS_MUL_86 == _zz__zz_decode_IS_MUL_87);
+  assign _zz__zz_decode_IS_MUL_88 = {_zz_decode_IS_MUL_3,{_zz__zz_decode_IS_MUL_89,_zz__zz_decode_IS_MUL_90}};
   assign _zz__zz_decode_IS_MUL_93 = (_zz__zz_decode_IS_MUL_94 == _zz__zz_decode_IS_MUL_95);
-  assign _zz__zz_decode_IS_MUL_97 = {_zz_decode_IS_MUL_3,_zz__zz_decode_IS_MUL_98};
-  assign _zz__zz_decode_IS_MUL_100 = 2'b00;
-  assign _zz__zz_decode_IS_MUL_101 = ({_zz__zz_decode_IS_MUL_102,_zz__zz_decode_IS_MUL_105} != 4'b0000);
-  assign _zz__zz_decode_IS_MUL_112 = (_zz__zz_decode_IS_MUL_113 != _zz__zz_decode_IS_MUL_116);
-  assign _zz__zz_decode_IS_MUL_117 = {_zz__zz_decode_IS_MUL_118,{_zz__zz_decode_IS_MUL_125,_zz__zz_decode_IS_MUL_129}};
-  assign _zz__zz_decode_IS_MUL_70 = 32'h02000020;
-  assign _zz__zz_decode_IS_MUL_74 = 32'h02000060;
-  assign _zz__zz_decode_IS_MUL_78 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_IS_MUL_79 = 32'h00001010;
-  assign _zz__zz_decode_IS_MUL_81 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_82) == 32'h00002010);
-  assign _zz__zz_decode_IS_MUL_83 = (_zz__zz_decode_IS_MUL_84 == _zz__zz_decode_IS_MUL_85);
-  assign _zz__zz_decode_IS_MUL_86 = {_zz__zz_decode_IS_MUL_87,_zz__zz_decode_IS_MUL_89};
-  assign _zz__zz_decode_IS_MUL_94 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_IS_MUL_95 = 32'h00000020;
-  assign _zz__zz_decode_IS_MUL_98 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_99) == 32'h0);
-  assign _zz__zz_decode_IS_MUL_102 = (_zz__zz_decode_IS_MUL_103 == _zz__zz_decode_IS_MUL_104);
-  assign _zz__zz_decode_IS_MUL_105 = {_zz__zz_decode_IS_MUL_106,{_zz__zz_decode_IS_MUL_108,_zz__zz_decode_IS_MUL_109}};
-  assign _zz__zz_decode_IS_MUL_113 = (_zz__zz_decode_IS_MUL_114 == _zz__zz_decode_IS_MUL_115);
-  assign _zz__zz_decode_IS_MUL_116 = 1'b0;
-  assign _zz__zz_decode_IS_MUL_118 = ({_zz__zz_decode_IS_MUL_119,_zz__zz_decode_IS_MUL_122} != 3'b000);
-  assign _zz__zz_decode_IS_MUL_125 = (_zz__zz_decode_IS_MUL_126 != _zz__zz_decode_IS_MUL_128);
-  assign _zz__zz_decode_IS_MUL_129 = {_zz__zz_decode_IS_MUL_130,_zz__zz_decode_IS_MUL_133};
-  assign _zz__zz_decode_IS_MUL_82 = 32'h00002010;
-  assign _zz__zz_decode_IS_MUL_84 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_IS_MUL_85 = 32'h00000010;
-  assign _zz__zz_decode_IS_MUL_87 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_88) == 32'h00000004);
-  assign _zz__zz_decode_IS_MUL_89 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_90) == 32'h0);
-  assign _zz__zz_decode_IS_MUL_99 = 32'h00000020;
-  assign _zz__zz_decode_IS_MUL_103 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_MUL_104 = 32'h0;
-  assign _zz__zz_decode_IS_MUL_106 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_107) == 32'h0);
-  assign _zz__zz_decode_IS_MUL_108 = _zz_decode_IS_MUL_2;
-  assign _zz__zz_decode_IS_MUL_109 = (_zz__zz_decode_IS_MUL_110 == _zz__zz_decode_IS_MUL_111);
-  assign _zz__zz_decode_IS_MUL_114 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_MUL_115 = 32'h0;
-  assign _zz__zz_decode_IS_MUL_119 = (_zz__zz_decode_IS_MUL_120 == _zz__zz_decode_IS_MUL_121);
-  assign _zz__zz_decode_IS_MUL_122 = {_zz__zz_decode_IS_MUL_123,_zz__zz_decode_IS_MUL_124};
-  assign _zz__zz_decode_IS_MUL_126 = {_zz__zz_decode_IS_MUL_127,_zz_decode_IS_MUL_1};
-  assign _zz__zz_decode_IS_MUL_128 = 2'b00;
-  assign _zz__zz_decode_IS_MUL_130 = ({_zz__zz_decode_IS_MUL_131,_zz__zz_decode_IS_MUL_132} != 2'b00);
-  assign _zz__zz_decode_IS_MUL_133 = (_zz__zz_decode_IS_MUL_134 != 1'b0);
-  assign _zz__zz_decode_IS_MUL_88 = 32'h0000000c;
-  assign _zz__zz_decode_IS_MUL_90 = 32'h00000028;
-  assign _zz__zz_decode_IS_MUL_107 = 32'h00000018;
-  assign _zz__zz_decode_IS_MUL_110 = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz__zz_decode_IS_MUL_111 = 32'h00001000;
-  assign _zz__zz_decode_IS_MUL_120 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_IS_MUL_121 = 32'h00000040;
-  assign _zz__zz_decode_IS_MUL_123 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_IS_MUL_124 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz__zz_decode_IS_MUL_127 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz__zz_decode_IS_MUL_131 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz__zz_decode_IS_MUL_132 = _zz_decode_IS_MUL_1;
-  assign _zz__zz_decode_IS_MUL_134 = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
+  assign _zz__zz_decode_IS_MUL_96 = (|{_zz__zz_decode_IS_MUL_97,_zz__zz_decode_IS_MUL_99});
+  assign _zz__zz_decode_IS_MUL_104 = (|_zz__zz_decode_IS_MUL_105);
+  assign _zz__zz_decode_IS_MUL_108 = {_zz__zz_decode_IS_MUL_109,_zz__zz_decode_IS_MUL_111};
+  assign _zz__zz_decode_IS_MUL_70 = 32'h00002010;
+  assign _zz__zz_decode_IS_MUL_72 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_IS_MUL_73 = 32'h00000010;
+  assign _zz__zz_decode_IS_MUL_75 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_IS_MUL_76 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz__zz_decode_IS_MUL_83 = 32'h00000020;
+  assign _zz__zz_decode_IS_MUL_86 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_IS_MUL_87 = 32'h0;
+  assign _zz__zz_decode_IS_MUL_89 = _zz_decode_IS_MUL_2;
+  assign _zz__zz_decode_IS_MUL_90 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_91) == 32'h00001000);
+  assign _zz__zz_decode_IS_MUL_94 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_IS_MUL_95 = 32'h0;
+  assign _zz__zz_decode_IS_MUL_97 = ((decode_INSTRUCTION & _zz__zz_decode_IS_MUL_98) == 32'h00000040);
+  assign _zz__zz_decode_IS_MUL_99 = {(_zz__zz_decode_IS_MUL_100 == _zz__zz_decode_IS_MUL_101),(_zz__zz_decode_IS_MUL_102 == _zz__zz_decode_IS_MUL_103)};
+  assign _zz__zz_decode_IS_MUL_105 = {(_zz__zz_decode_IS_MUL_106 == _zz__zz_decode_IS_MUL_107),_zz_decode_IS_MUL_1};
+  assign _zz__zz_decode_IS_MUL_109 = (|{_zz__zz_decode_IS_MUL_110,_zz_decode_IS_MUL_1});
+  assign _zz__zz_decode_IS_MUL_111 = (|(_zz__zz_decode_IS_MUL_112 == _zz__zz_decode_IS_MUL_113));
+  assign _zz__zz_decode_IS_MUL_91 = 32'h00005004;
+  assign _zz__zz_decode_IS_MUL_98 = 32'h00000044;
+  assign _zz__zz_decode_IS_MUL_100 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_IS_MUL_101 = 32'h00002010;
+  assign _zz__zz_decode_IS_MUL_102 = (decode_INSTRUCTION & 32'h40004034);
+  assign _zz__zz_decode_IS_MUL_103 = 32'h40000030;
+  assign _zz__zz_decode_IS_MUL_106 = (decode_INSTRUCTION & 32'h00000014);
+  assign _zz__zz_decode_IS_MUL_107 = 32'h00000004;
+  assign _zz__zz_decode_IS_MUL_110 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_IS_MUL_112 = (decode_INSTRUCTION & 32'h00001048);
+  assign _zz__zz_decode_IS_MUL_113 = 32'h00001008;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1244,665 +1189,665 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   `ifndef SYNTHESIS
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
@@ -1940,7 +1885,7 @@ module VexRiscv (
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_MUL[15];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_MUL[16];
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
   assign decode_MEMORY_STORE = _zz_decode_IS_MUL[11];
@@ -1974,7 +1919,7 @@ module VexRiscv (
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_IS_MUL[12];
+  assign decode_RS2_USE = _zz_decode_IS_MUL[13];
   assign decode_RS1_USE = _zz_decode_IS_MUL[5];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
@@ -1987,7 +1932,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2001,7 +1946,7 @@ module VexRiscv (
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_MUL[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_IS_MUL[18];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_MUL[19];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
@@ -2025,7 +1970,6 @@ module VexRiscv (
     end
   end
 
-  assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @(*) begin
     _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
     if(when_DBusSimplePlugin_l558) begin
@@ -2089,7 +2033,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2105,7 +2049,7 @@ module VexRiscv (
   assign decode_arbitration_flushNext = 1'b0;
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l426) begin
+    if(when_DBusSimplePlugin_l428) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2113,7 +2057,7 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2141,7 +2085,7 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l479) begin
+    if(when_DBusSimplePlugin_l482) begin
       memory_arbitration_haltItself = 1'b1;
     end
   end
@@ -2174,10 +2118,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2188,45 +2132,47 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2263,9 +2209,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -2288,7 +2234,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -2350,24 +2296,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -2440,7 +2392,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l426 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -2457,7 +2409,7 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l479 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2475,7 +2427,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -2527,7 +2479,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -2552,19 +2504,20 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_IS_MUL_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
   assign _zz_decode_IS_MUL_2 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_decode_IS_MUL_3 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_IS_MUL_4 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_IS_MUL_5 = ((decode_INSTRUCTION & 32'h00000030) == 32'h00000010);
-  assign _zz_decode_IS_MUL = {(((decode_INSTRUCTION & _zz__zz_decode_IS_MUL) == 32'h02000030) != 1'b0),{((_zz__zz_decode_IS_MUL_1 == _zz__zz_decode_IS_MUL_2) != 1'b0),{(_zz__zz_decode_IS_MUL_3 != 1'b0),{(_zz__zz_decode_IS_MUL_4 != _zz__zz_decode_IS_MUL_9),{_zz__zz_decode_IS_MUL_10,{_zz__zz_decode_IS_MUL_12,_zz__zz_decode_IS_MUL_14}}}}}};
+  assign _zz_decode_IS_MUL_3 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_IS_MUL_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_IS_MUL_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_IS_MUL_6 = ((decode_INSTRUCTION & 32'h00000030) == 32'h00000010);
+  assign _zz_decode_IS_MUL = {(|((decode_INSTRUCTION & 32'h02000074) == 32'h02000030)),{(|((decode_INSTRUCTION & _zz__zz_decode_IS_MUL) == 32'h00000050)),{(|(_zz__zz_decode_IS_MUL_1 == _zz__zz_decode_IS_MUL_2)),{(|{_zz__zz_decode_IS_MUL_3,_zz__zz_decode_IS_MUL_4}),{(|_zz__zz_decode_IS_MUL_5),{_zz__zz_decode_IS_MUL_7,{_zz__zz_decode_IS_MUL_9,_zz__zz_decode_IS_MUL_12}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_MUL[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_MUL[7 : 6];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_MUL[14 : 13];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_MUL[15 : 14];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_MUL[17 : 16];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_MUL[18 : 17];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_MUL[20 : 19];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_MUL[21 : 20];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
   assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_MUL[23 : 22];
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
@@ -2598,10 +2551,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -2612,10 +2565,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -2626,13 +2579,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -2691,13 +2644,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -2714,14 +2667,14 @@ module VexRiscv (
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_binary_sequential_DISABLE_1);
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != ShiftCtrlEnum_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+      ShiftCtrlEnum_SLL_1 : begin
         _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
@@ -2819,9 +2772,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
@@ -2839,13 +2792,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_DO_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_DO_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_DO_1 = 1'b1;
       end
       default : begin
@@ -2854,7 +2807,7 @@ module VexRiscv (
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JALR) ? execute_RS1 : execute_PC);
+  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JALR) ? execute_RS1 : execute_PC);
   assign _zz_execute_BranchPlugin_branch_src2 = _zz__zz_execute_BranchPlugin_branch_src2[19];
   always @(*) begin
     _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
@@ -2919,10 +2872,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_branch_src2_6 = {_zz_execute_BranchPlugin_branch_src2_3,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
@@ -2944,9 +2897,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode = 1'b0;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
@@ -2975,28 +2928,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -3004,7 +2957,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3042,12 +2995,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768) begin
@@ -3098,18 +3051,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3117,14 +3070,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3137,19 +3090,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3158,9 +3111,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3171,8 +3124,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -3215,7 +3168,7 @@ module VexRiscv (
   assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
   assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -3245,56 +3198,55 @@ module VexRiscv (
   assign when_Pipeline_l124_20 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_23 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
   assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
-  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
-  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
   assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
   assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! writeBack_arbitration_isStuck);
   assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_42 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
-  assign when_Pipeline_l124_44 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_43 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_45 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_47 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_48 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_50 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_50 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_51 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3321,23 +3273,24 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -3410,8 +3363,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -3490,7 +3443,6 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       _zz_2 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
@@ -3501,6 +3453,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
@@ -3525,16 +3479,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -3552,13 +3506,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3567,7 +3521,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3576,7 +3530,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3585,7 +3539,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3594,26 +3548,6 @@ module VexRiscv (
       if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      `ifndef SYNTHESIS
-        `ifdef FORMAL
-          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
-        `else
-          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
-            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
-            $finish;
-          end
-        `endif
-      `endif
-      `ifndef SYNTHESIS
-        `ifdef FORMAL
-          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
-        `else
-          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
-            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
-            $finish;
-          end
-        `endif
-      `endif
       _zz_2 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
@@ -3627,45 +3561,49 @@ module VexRiscv (
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -3674,7 +3612,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3685,8 +3623,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3696,7 +3634,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(when_Pipeline_l151) begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -3717,9 +3655,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -3769,29 +3713,25 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -3876,129 +3816,126 @@ module VexRiscv (
       execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
     end
     if(when_Pipeline_l124_23) begin
-      memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
-    end
-    if(when_Pipeline_l124_24) begin
       decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
-    if(when_Pipeline_l124_25) begin
+    if(when_Pipeline_l124_24) begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
-    if(when_Pipeline_l124_26) begin
+    if(when_Pipeline_l124_25) begin
       decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
-    if(when_Pipeline_l124_27) begin
+    if(when_Pipeline_l124_26) begin
       decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
-    if(when_Pipeline_l124_28) begin
+    if(when_Pipeline_l124_27) begin
       decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
-    if(when_Pipeline_l124_29) begin
+    if(when_Pipeline_l124_28) begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
-    if(when_Pipeline_l124_30) begin
+    if(when_Pipeline_l124_29) begin
       decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
-    if(when_Pipeline_l124_31) begin
+    if(when_Pipeline_l124_30) begin
       execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
-    if(when_Pipeline_l124_32) begin
+    if(when_Pipeline_l124_31) begin
       memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
-    if(when_Pipeline_l124_33) begin
+    if(when_Pipeline_l124_32) begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
-    if(when_Pipeline_l124_34) begin
+    if(when_Pipeline_l124_33) begin
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
-    if(when_Pipeline_l124_35) begin
+    if(when_Pipeline_l124_34) begin
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
-    if(when_Pipeline_l124_36) begin
+    if(when_Pipeline_l124_35) begin
       decode_to_execute_RS1 <= decode_RS1;
     end
-    if(when_Pipeline_l124_37) begin
+    if(when_Pipeline_l124_36) begin
       decode_to_execute_RS2 <= decode_RS2;
     end
-    if(when_Pipeline_l124_38) begin
+    if(when_Pipeline_l124_37) begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if(when_Pipeline_l124_39) begin
+    if(when_Pipeline_l124_38) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
-    if(when_Pipeline_l124_40) begin
+    if(when_Pipeline_l124_39) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if(when_Pipeline_l124_41) begin
+    if(when_Pipeline_l124_40) begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
-    if(when_Pipeline_l124_42) begin
+    if(when_Pipeline_l124_41) begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if(when_Pipeline_l124_43) begin
+    if(when_Pipeline_l124_42) begin
       execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
     end
-    if(when_Pipeline_l124_44) begin
+    if(when_Pipeline_l124_43) begin
       memory_to_writeBack_REGFILE_WRITE_DATA <= memory_REGFILE_WRITE_DATA;
     end
-    if(when_Pipeline_l124_45) begin
+    if(when_Pipeline_l124_44) begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if(when_Pipeline_l124_46) begin
+    if(when_Pipeline_l124_45) begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if(when_Pipeline_l124_47) begin
+    if(when_Pipeline_l124_46) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if(when_Pipeline_l124_48) begin
+    if(when_Pipeline_l124_47) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if(when_Pipeline_l124_49) begin
+    if(when_Pipeline_l124_48) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if(when_Pipeline_l124_50) begin
+    if(when_Pipeline_l124_49) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if(when_Pipeline_l124_51) begin
+    if(when_Pipeline_l124_50) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if(when_Pipeline_l124_52) begin
+    if(when_Pipeline_l124_51) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_Pipeline_l124_53) begin
+    if(when_Pipeline_l124_52) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -4071,6 +4008,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -4088,7 +4026,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -4134,8 +4072,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -4205,10 +4143,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -4236,7 +4174,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_FomuCfu.v
+++ b/soc/vexriscv/VexRiscv_FomuCfu.v
@@ -1,51 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : b974c176159a3b4d56d11c22552ed780bbeedcbc
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b10
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -85,6 +42,34 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_ECALL = 2'd2;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -123,150 +108,126 @@ module VexRiscv (
   wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
-  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire       [17:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
   wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [14:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
   wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
   wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [6:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [6:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -310,53 +271,55 @@ module VexRiscv (
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
   wire                decode_MEMORY_ENABLE;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
@@ -366,9 +329,11 @@ module VexRiscv (
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   reg        [31:0]   _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                writeBack_IS_MUL;
   wire       [33:0]   writeBack_MUL_HH;
   wire       [51:0]   writeBack_MUL_LOW;
@@ -378,18 +343,18 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -400,40 +365,39 @@ module VexRiscv (
   wire                writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
-  wire                writeBack_MEMORY_STORE;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_lastStageRegFileWrite_payload_data;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
@@ -459,7 +423,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   wire                decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -503,6 +467,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_pcValids_0;
   wire                IBusCachedPlugin_pcValids_1;
@@ -525,6 +490,7 @@ module VexRiscv (
   wire                IBusCachedPlugin_mmuBus_busy;
   wire                BranchPlugin_jumpInterface_valid;
   wire       [31:0]   BranchPlugin_jumpInterface_payload;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -563,14 +529,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -612,18 +578,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -631,7 +597,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -654,12 +619,12 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l426;
+  wire                when_DBusSimplePlugin_l428;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l479;
+  wire                when_DBusSimplePlugin_l482;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
@@ -673,14 +638,15 @@ module VexRiscv (
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -736,7 +702,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_DO;
   reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
@@ -766,11 +732,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   wire                CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -783,55 +749,55 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -850,22 +816,25 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -885,7 +854,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
   wire                when_Pipeline_l124_9;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_11;
@@ -895,7 +864,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_13;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_15;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_16;
@@ -913,70 +882,74 @@ module VexRiscv (
   wire                when_Pipeline_l124_22;
   reg                 execute_to_memory_MEMORY_STORE;
   wire                when_Pipeline_l124_23;
-  reg                 memory_to_writeBack_MEMORY_STORE;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_24;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_25;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_26;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_27;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_28;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_29;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_30;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_31;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_32;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_33;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_34;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_35;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_37;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_38;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_39;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_40;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_43;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_44;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
   wire                when_Pipeline_l124_47;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_48;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_49;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_50;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_51;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_52;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_53;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                when_Pipeline_l124_55;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_56;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  wire                when_Pipeline_l124_57;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -984,28 +957,29 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_4032;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -1016,8 +990,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1108,7 +1082,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
@@ -1121,7 +1095,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
   assign _zz_memory_MUL_LOW_1 = ($signed(_zz_memory_MUL_LOW_2) + $signed(_zz_memory_MUL_LOW_3));
@@ -1148,7 +1122,7 @@ module VexRiscv (
   assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
   assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
   assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
-  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
@@ -1159,152 +1133,128 @@ module VexRiscv (
   assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = (decode_INSTRUCTION & 32'h02000074);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 32'h02000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = 32'h02000074;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = (decode_INSTRUCTION & 32'h10003050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = 32'h00000050;
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = ({(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9)} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 3'b000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 32'h40003054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = {((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5) == 32'h00001050),((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) == 32'h00002050)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = (|{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9)});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24) == 32'h00000024);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = 32'h02007054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = (decode_INSTRUCTION & 32'h00003034);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (decode_INSTRUCTION & 32'h02003054);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = 32'h00000024;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & 32'h00003034) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = ((decode_INSTRUCTION & 32'h02003054) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = 32'h00001000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 32'h00002000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42) == 32'h00001000);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = (_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00006000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00004000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 3'b000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = 3'b000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (decode_INSTRUCTION & 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = (|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = 32'h00005000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = 32'h00006000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61),{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71),{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = (|{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = (decode_INSTRUCTION & 32'h02000060);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 4'b0000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = ((decode_INSTRUCTION & 32'h02000060) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}}};
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h00000070;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 3'b000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = (decode_INSTRUCTION & 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = 32'h40004034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h00001054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000070;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = (decode_INSTRUCTION & 32'h00000024);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = {((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119) == 32'h00000004),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = ((decode_INSTRUCTION & 32'h00001054) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 32'h00000044;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1324,728 +1274,728 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2086,9 +2036,11 @@ module VexRiscv (
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
   assign _zz_decode_to_execute_ALU_CTRL = _zz_decode_to_execute_ALU_CTRL_1;
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[12];
   assign decode_MEMORY_STORE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[11];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[10];
@@ -2120,13 +2072,15 @@ module VexRiscv (
   always @(*) begin
     _zz_memory_to_writeBack_REGFILE_WRITE_DATA = memory_REGFILE_WRITE_DATA;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_memory_to_writeBack_REGFILE_WRITE_DATA = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_memory_to_writeBack_REGFILE_WRITE_DATA = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign writeBack_IS_MUL = memory_to_writeBack_IS_MUL;
   assign writeBack_MUL_HH = memory_to_writeBack_MUL_HH;
   assign writeBack_MUL_LOW = memory_to_writeBack_MUL_LOW;
@@ -2144,7 +2098,7 @@ module VexRiscv (
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[12];
+  assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
@@ -2157,7 +2111,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2171,7 +2125,7 @@ module VexRiscv (
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
   assign decode_SRC_USE_SUB_LESS = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[18];
+  assign decode_SRC_ADD_ZERO = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[19];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
@@ -2195,7 +2149,6 @@ module VexRiscv (
     end
   end
 
-  assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @(*) begin
     _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
     if(when_DBusSimplePlugin_l558) begin
@@ -2259,7 +2212,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2275,7 +2228,7 @@ module VexRiscv (
   assign decode_arbitration_flushNext = 1'b0;
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l426) begin
+    if(when_DBusSimplePlugin_l428) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2283,12 +2236,15 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
@@ -2317,11 +2273,11 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l479) begin
+    if(when_DBusSimplePlugin_l482) begin
       memory_arbitration_haltItself = 1'b1;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -2349,10 +2305,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2363,45 +2319,47 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2438,9 +2396,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -2463,7 +2421,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -2525,24 +2483,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -2615,7 +2579,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l426 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -2632,7 +2596,7 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l479 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2650,7 +2614,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -2702,7 +2666,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -2727,27 +2691,28 @@ module VexRiscv (
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00000030) == 32'h00000010);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 != 1'b0),{((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1) != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00000030) == 32'h00000010);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9),{(|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2) == 32'h02000030)),{(|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2)),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_SRC2_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14 : 13];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15 : 14];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17 : 16];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[18 : 17];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[20 : 19];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[21 : 20];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
   assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[23 : 22];
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[26 : 25];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[29 : 29];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[29 : 29];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_10;
   assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
@@ -2776,10 +2741,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -2790,10 +2755,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -2804,13 +2769,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -2869,13 +2834,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -2892,14 +2857,14 @@ module VexRiscv (
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_binary_sequential_DISABLE_1);
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != ShiftCtrlEnum_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+      ShiftCtrlEnum_SLL_1 : begin
         _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
@@ -2997,9 +2962,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
@@ -3017,13 +2982,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_DO_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_DO_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_DO_1 = 1'b1;
       end
       default : begin
@@ -3032,7 +2997,7 @@ module VexRiscv (
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JALR) ? execute_RS1 : execute_PC);
+  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JALR) ? execute_RS1 : execute_PC);
   assign _zz_execute_BranchPlugin_branch_src2 = _zz__zz_execute_BranchPlugin_branch_src2[19];
   always @(*) begin
     _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
@@ -3097,10 +3062,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_branch_src2_6 = {_zz_execute_BranchPlugin_branch_src2_3,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
@@ -3122,9 +3087,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode = 1'b0;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
@@ -3153,28 +3118,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -3182,7 +3147,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3220,12 +3185,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768) begin
@@ -3276,18 +3241,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3295,14 +3260,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3315,19 +3280,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3336,9 +3301,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3349,8 +3314,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -3393,12 +3358,15 @@ module VexRiscv (
   assign when_MulPlugin_l147 = (writeBack_arbitration_isValid && writeBack_IS_MUL);
   assign switch_MulPlugin_l148 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -3432,7 +3400,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -3443,16 +3411,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -3482,61 +3450,63 @@ module VexRiscv (
   assign when_Pipeline_l124_20 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_21 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_22 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_23 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_23 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_CTRL_1 = decode_ALU_CTRL;
   assign _zz_decode_ALU_CTRL = _zz_decode_ALU_CTRL_1;
-  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_CTRL = decode_to_execute_ALU_CTRL;
-  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! writeBack_arbitration_isStuck);
   assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_36 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_37 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_44 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_45 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_47 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_48 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_48 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3563,23 +3533,24 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -3652,8 +3623,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -3732,7 +3703,6 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       _zz_2 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
@@ -3743,6 +3713,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
@@ -3771,16 +3743,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -3798,13 +3770,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3813,7 +3785,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3822,7 +3794,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3831,7 +3803,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -3840,26 +3812,6 @@ module VexRiscv (
       if(iBus_rsp_valid) begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      `ifndef SYNTHESIS
-        `ifdef FORMAL
-          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
-        `else
-          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
-            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
-            $finish;
-          end
-        `endif
-      `endif
-      `ifndef SYNTHESIS
-        `ifdef FORMAL
-          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
-        `else
-          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
-            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
-            $finish;
-          end
-        `endif
-      `endif
       _zz_2 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
@@ -3873,45 +3825,49 @@ module VexRiscv (
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -3920,7 +3876,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3931,8 +3887,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3942,7 +3898,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
       end
@@ -3952,16 +3908,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_52) begin
+      if(when_Pipeline_l124_54) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -3984,9 +3940,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -4036,29 +3998,25 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -4146,132 +4104,138 @@ module VexRiscv (
       execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
     end
     if(when_Pipeline_l124_23) begin
-      memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_24) begin
-      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_25) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      decode_to_execute_ALU_CTRL <= _zz_decode_to_execute_ALU_CTRL;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_30) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_31) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_32) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_37) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_38) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_40) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_43) begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_44) begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_45) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
     if(when_Pipeline_l124_46) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
     if(when_Pipeline_l124_47) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
     end
     if(when_Pipeline_l124_48) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
     end
     if(when_Pipeline_l124_49) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_50) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
     if(when_Pipeline_l124_51) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if(when_Pipeline_l124_52) begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_53) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
-    end
-    if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
     if(when_Pipeline_l124_55) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_56) begin
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
+    end
+    if(when_Pipeline_l124_57) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -4344,6 +4308,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -4361,7 +4326,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -4407,8 +4372,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -4478,10 +4443,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -4509,7 +4474,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_Fpu.v
+++ b/soc/vexriscv/VexRiscv_Fpu.v
@@ -1,77 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 2b111d2930973ec0f45f96859642e3fd5e8ad723
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define FpuOpcode_binary_sequential_type [3:0]
-`define FpuOpcode_binary_sequential_LOAD 4'b0000
-`define FpuOpcode_binary_sequential_STORE 4'b0001
-`define FpuOpcode_binary_sequential_MUL 4'b0010
-`define FpuOpcode_binary_sequential_ADD 4'b0011
-`define FpuOpcode_binary_sequential_FMA 4'b0100
-`define FpuOpcode_binary_sequential_I2F 4'b0101
-`define FpuOpcode_binary_sequential_F2I 4'b0110
-`define FpuOpcode_binary_sequential_CMP 4'b0111
-`define FpuOpcode_binary_sequential_DIV 4'b1000
-`define FpuOpcode_binary_sequential_SQRT 4'b1001
-`define FpuOpcode_binary_sequential_MIN_MAX 4'b1010
-`define FpuOpcode_binary_sequential_SGNJ 4'b1011
-`define FpuOpcode_binary_sequential_FMV_X_W 4'b1100
-`define FpuOpcode_binary_sequential_FMV_W_X 4'b1101
-`define FpuOpcode_binary_sequential_FCLASS 4'b1110
-`define FpuOpcode_binary_sequential_FCVT_X_X 4'b1111
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
-`define FpuFormat_binary_sequential_type [0:0]
-`define FpuFormat_binary_sequential_FLOAT 1'b0
-`define FpuFormat_binary_sequential_DOUBLE 1'b1
-
-`define FpuRoundMode_opt_type [2:0]
-`define FpuRoundMode_opt_RNE 3'b000
-`define FpuRoundMode_opt_RTZ 3'b001
-`define FpuRoundMode_opt_RDN 3'b010
-`define FpuRoundMode_opt_RUP 3'b011
-`define FpuRoundMode_opt_RMM 3'b100
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -103,6 +34,56 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+  localparam FpuFormat_FLOAT = 1'd0;
+  localparam FpuFormat_DOUBLE = 1'd1;
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -131,6 +112,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -237,6 +220,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
@@ -259,138 +244,138 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_FPU_RSP_13;
   wire                _zz__zz_decode_FPU_RSP_14;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_15;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_16;
+  wire                _zz__zz_decode_FPU_RSP_16;
   wire                _zz__zz_decode_FPU_RSP_17;
-  wire                _zz__zz_decode_FPU_RSP_18;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_19;
-  wire                _zz__zz_decode_FPU_RSP_20;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_21;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_18;
+  wire                _zz__zz_decode_FPU_RSP_19;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_20;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_21;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_22;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_23;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_23;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_24;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_25;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_26;
-  wire                _zz__zz_decode_FPU_RSP_27;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_28;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_29;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_25;
+  wire                _zz__zz_decode_FPU_RSP_26;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_27;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_28;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_29;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_30;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_31;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_32;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_31;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_32;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_33;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_34;
-  wire       [35:0]   _zz__zz_decode_FPU_RSP_35;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_36;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_37;
+  wire       [35:0]   _zz__zz_decode_FPU_RSP_34;
+  wire       [4:0]    _zz__zz_decode_FPU_RSP_35;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_36;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_37;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_38;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_39;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_40;
-  wire                _zz__zz_decode_FPU_RSP_41;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_42;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_43;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_39;
+  wire                _zz__zz_decode_FPU_RSP_40;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_41;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_42;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_43;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_44;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_45;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_46;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_45;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_46;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_47;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_48;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_49;
-  wire                _zz__zz_decode_FPU_RSP_50;
+  wire                _zz__zz_decode_FPU_RSP_48;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_49;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_50;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_51;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_52;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_53;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_54;
-  wire                _zz__zz_decode_FPU_RSP_55;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_52;
+  wire                _zz__zz_decode_FPU_RSP_53;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_54;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_55;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_56;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_57;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_58;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_57;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_58;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_59;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_60;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_61;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_62;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_63;
-  wire       [32:0]   _zz__zz_decode_FPU_RSP_64;
-  wire                _zz__zz_decode_FPU_RSP_65;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_60;
+  wire       [32:0]   _zz__zz_decode_FPU_RSP_61;
+  wire                _zz__zz_decode_FPU_RSP_62;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_63;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_64;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_65;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_66;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_67;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_68;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_69;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_70;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_71;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_72;
-  wire       [30:0]   _zz__zz_decode_FPU_RSP_73;
-  wire                _zz__zz_decode_FPU_RSP_74;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_75;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_76;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_77;
-  wire       [28:0]   _zz__zz_decode_FPU_RSP_78;
+  wire       [30:0]   _zz__zz_decode_FPU_RSP_71;
+  wire                _zz__zz_decode_FPU_RSP_72;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_73;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_74;
+  wire       [28:0]   _zz__zz_decode_FPU_RSP_75;
+  wire                _zz__zz_decode_FPU_RSP_76;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_77;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_78;
   wire                _zz__zz_decode_FPU_RSP_79;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_80;
+  wire       [26:0]   _zz__zz_decode_FPU_RSP_80;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_81;
-  wire                _zz__zz_decode_FPU_RSP_82;
-  wire       [26:0]   _zz__zz_decode_FPU_RSP_83;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_84;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_85;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_82;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_83;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_84;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_85;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_86;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_87;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_87;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_88;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_89;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_90;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_91;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_92;
-  wire                _zz__zz_decode_FPU_RSP_93;
-  wire                _zz__zz_decode_FPU_RSP_94;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_95;
-  wire                _zz__zz_decode_FPU_RSP_96;
-  wire       [22:0]   _zz__zz_decode_FPU_RSP_97;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_98;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_99;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_100;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_101;
+  wire                _zz__zz_decode_FPU_RSP_89;
+  wire                _zz__zz_decode_FPU_RSP_90;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_91;
+  wire                _zz__zz_decode_FPU_RSP_92;
+  wire       [22:0]   _zz__zz_decode_FPU_RSP_93;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_94;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_95;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_96;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_97;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_98;
+  wire                _zz__zz_decode_FPU_RSP_99;
+  wire                _zz__zz_decode_FPU_RSP_100;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_101;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_102;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_103;
-  wire                _zz__zz_decode_FPU_RSP_104;
-  wire                _zz__zz_decode_FPU_RSP_105;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_106;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_107;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_103;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_104;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_105;
+  wire                _zz__zz_decode_FPU_RSP_106;
+  wire       [19:0]   _zz__zz_decode_FPU_RSP_107;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_108;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_109;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_110;
-  wire                _zz__zz_decode_FPU_RSP_111;
-  wire       [19:0]   _zz__zz_decode_FPU_RSP_112;
+  wire                _zz__zz_decode_FPU_RSP_110;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_111;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_112;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_113;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_114;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_114;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_115;
-  wire                _zz__zz_decode_FPU_RSP_116;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_117;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_118;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_119;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_120;
+  wire       [16:0]   _zz__zz_decode_FPU_RSP_116;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_117;
+  wire                _zz__zz_decode_FPU_RSP_118;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_119;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_120;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_121;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_122;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_123;
-  wire       [16:0]   _zz__zz_decode_FPU_RSP_124;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_122;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_123;
+  wire                _zz__zz_decode_FPU_RSP_124;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_125;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_126;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_127;
-  wire                _zz__zz_decode_FPU_RSP_128;
-  wire                _zz__zz_decode_FPU_RSP_129;
+  wire       [3:0]    _zz__zz_decode_FPU_RSP_127;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_128;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_129;
   wire                _zz__zz_decode_FPU_RSP_130;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_131;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_131;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_132;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_133;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_134;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_133;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_134;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_135;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_136;
-  wire                _zz__zz_decode_FPU_RSP_137;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_138;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_139;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_140;
+  wire       [13:0]   _zz__zz_decode_FPU_RSP_136;
+  wire       [4:0]    _zz__zz_decode_FPU_RSP_137;
+  wire                _zz__zz_decode_FPU_RSP_138;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_139;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_140;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_141;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_142;
-  wire                _zz__zz_decode_FPU_RSP_143;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_144;
-  wire       [13:0]   _zz__zz_decode_FPU_RSP_145;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_146;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_147;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_142;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_143;
+  wire                _zz__zz_decode_FPU_RSP_144;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_145;
+  wire                _zz__zz_decode_FPU_RSP_146;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_147;
   wire                _zz__zz_decode_FPU_RSP_148;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_149;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_150;
@@ -406,92 +391,67 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_FPU_RSP_160;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_161;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_162;
-  wire       [3:0]    _zz__zz_decode_FPU_RSP_163;
+  wire       [5:0]    _zz__zz_decode_FPU_RSP_163;
   wire                _zz__zz_decode_FPU_RSP_164;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_165;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_166;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_167;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_168;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_169;
+  wire       [3:0]    _zz__zz_decode_FPU_RSP_169;
   wire                _zz__zz_decode_FPU_RSP_170;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_171;
-  wire                _zz__zz_decode_FPU_RSP_172;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_173;
-  wire       [10:0]   _zz__zz_decode_FPU_RSP_174;
-  wire       [6:0]    _zz__zz_decode_FPU_RSP_175;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_176;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_177;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_178;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_179;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_172;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_173;
+  wire                _zz__zz_decode_FPU_RSP_174;
+  wire                _zz__zz_decode_FPU_RSP_175;
+  wire       [9:0]    _zz__zz_decode_FPU_RSP_176;
+  wire       [3:0]    _zz__zz_decode_FPU_RSP_177;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_178;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_179;
   wire                _zz__zz_decode_FPU_RSP_180;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_181;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_182;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_183;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_184;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_185;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_186;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_187;
+  wire                _zz__zz_decode_FPU_RSP_182;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_183;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_184;
+  wire                _zz__zz_decode_FPU_RSP_185;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_186;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_187;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_188;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_189;
-  wire       [6:0]    _zz__zz_decode_FPU_RSP_190;
-  wire                _zz__zz_decode_FPU_RSP_191;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_192;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_193;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_194;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_190;
+  wire       [6:0]    _zz__zz_decode_FPU_RSP_191;
+  wire                _zz__zz_decode_FPU_RSP_192;
+  wire                _zz__zz_decode_FPU_RSP_193;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_194;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_195;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_196;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_197;
+  wire       [6:0]    _zz__zz_decode_FPU_RSP_196;
+  wire                _zz__zz_decode_FPU_RSP_197;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_198;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_199;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_200;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_199;
+  wire       [4:0]    _zz__zz_decode_FPU_RSP_200;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_201;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_202;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_203;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_204;
-  wire       [7:0]    _zz__zz_decode_FPU_RSP_205;
-  wire                _zz__zz_decode_FPU_RSP_206;
-  wire                _zz__zz_decode_FPU_RSP_207;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_208;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_204;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_205;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_206;
+  wire       [4:0]    _zz__zz_decode_FPU_RSP_207;
+  wire                _zz__zz_decode_FPU_RSP_208;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_209;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_210;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_210;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_211;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_212;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_213;
-  wire       [5:0]    _zz__zz_decode_FPU_RSP_214;
-  wire                _zz__zz_decode_FPU_RSP_215;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_216;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_217;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_218;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_219;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_220;
+  wire                _zz__zz_decode_FPU_RSP_213;
+  wire                _zz__zz_decode_FPU_RSP_214;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_215;
+  wire                _zz__zz_decode_FPU_RSP_216;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_217;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_218;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_219;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_220;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_221;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_222;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_223;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_224;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_225;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_226;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_227;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_228;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_229;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_230;
-  wire       [3:0]    _zz__zz_decode_FPU_RSP_231;
-  wire                _zz__zz_decode_FPU_RSP_232;
-  wire                _zz__zz_decode_FPU_RSP_233;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_234;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_235;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_236;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_237;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_238;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_239;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_240;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_241;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_242;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_243;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_244;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_245;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_246;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_247;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_248;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_222;
+  wire                _zz__zz_decode_FPU_RSP_223;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -574,16 +534,16 @@ module VexRiscv (
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   memory_RS1;
-  wire       `FpuOpcode_binary_sequential_type memory_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_memory_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_memory_to_writeBack_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_memory_to_writeBack_FPU_OPCODE_1;
-  wire       `FpuOpcode_binary_sequential_type execute_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_execute_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_execute_to_memory_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_execute_to_memory_FPU_OPCODE_1;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_to_execute_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_to_execute_FPU_OPCODE_1;
+  wire       [3:0]    memory_FPU_OPCODE;
+  wire       [3:0]    _zz_memory_FPU_OPCODE;
+  wire       [3:0]    _zz_memory_to_writeBack_FPU_OPCODE;
+  wire       [3:0]    _zz_memory_to_writeBack_FPU_OPCODE_1;
+  wire       [3:0]    execute_FPU_OPCODE;
+  wire       [3:0]    _zz_execute_FPU_OPCODE;
+  wire       [3:0]    _zz_execute_to_memory_FPU_OPCODE;
+  wire       [3:0]    _zz_execute_to_memory_FPU_OPCODE_1;
+  wire       [3:0]    _zz_decode_to_execute_FPU_OPCODE;
+  wire       [3:0]    _zz_decode_to_execute_FPU_OPCODE_1;
   wire                memory_FPU_RSP;
   wire                execute_FPU_RSP;
   wire                decode_FPU_RSP;
@@ -598,27 +558,27 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -626,18 +586,18 @@ module VexRiscv (
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -654,11 +614,11 @@ module VexRiscv (
   wire                writeBack_FPU_RSP;
   wire                writeBack_FPU_FORKED;
   wire       [1:0]    decode_FPU_ARG;
-  wire       `FpuOpcode_binary_sequential_type decode_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_FPU_OPCODE;
+  wire       [3:0]    decode_FPU_OPCODE;
+  wire       [3:0]    _zz_decode_FPU_OPCODE;
   wire                decode_FPU_ENABLE;
-  wire       `FpuOpcode_binary_sequential_type writeBack_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_writeBack_FPU_OPCODE;
+  wire       [3:0]    writeBack_FPU_OPCODE;
+  wire       [3:0]    _zz_writeBack_FPU_OPCODE;
   wire                writeBack_FPU_ENABLE;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
@@ -673,20 +633,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -700,43 +659,43 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [31:0]   _zz_execute_SRC1;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_FPU_OPCODE_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [3:0]    _zz_decode_FPU_OPCODE_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -745,6 +704,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -757,8 +717,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -770,7 +730,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -814,6 +774,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -882,6 +843,7 @@ module VexRiscv (
   wire                BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -907,17 +869,17 @@ module VexRiscv (
   wire                CsrPlugin_allowEbreakException;
   wire                FpuPlugin_port_cmd_valid /* verilator public */ ;
   wire                FpuPlugin_port_cmd_ready /* verilator public */ ;
-  wire       `FpuOpcode_binary_sequential_type FpuPlugin_port_cmd_payload_opcode /* verilator public */ ;
+  wire       [3:0]    FpuPlugin_port_cmd_payload_opcode /* verilator public */ ;
   wire       [1:0]    FpuPlugin_port_cmd_payload_arg /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rs1 /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rs2 /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rs3 /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rd /* verilator public */ ;
-  wire       `FpuFormat_binary_sequential_type FpuPlugin_port_cmd_payload_format /* verilator public */ ;
-  wire       `FpuRoundMode_opt_type FpuPlugin_port_cmd_payload_roundMode /* verilator public */ ;
+  wire       [0:0]    FpuPlugin_port_cmd_payload_format /* verilator public */ ;
+  wire       [2:0]    FpuPlugin_port_cmd_payload_roundMode /* verilator public */ ;
   wire                FpuPlugin_port_commit_valid /* verilator public */ ;
   wire                FpuPlugin_port_commit_ready /* verilator public */ ;
-  wire       `FpuOpcode_binary_sequential_type FpuPlugin_port_commit_payload_opcode /* verilator public */ ;
+  wire       [3:0]    FpuPlugin_port_commit_payload_opcode /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_commit_payload_rd /* verilator public */ ;
   wire                FpuPlugin_port_commit_payload_write /* verilator public */ ;
   wire       [31:0]   FpuPlugin_port_commit_payload_value /* verilator public */ ;
@@ -952,14 +914,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -1001,18 +963,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -1031,7 +993,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1078,31 +1039,30 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [41:0]   _zz_decode_FPU_RSP;
   wire                _zz_decode_FPU_RSP_1;
   wire                _zz_decode_FPU_RSP_2;
@@ -1115,15 +1075,14 @@ module VexRiscv (
   wire                _zz_decode_FPU_RSP_9;
   wire                _zz_decode_FPU_RSP_10;
   wire                _zz_decode_FPU_RSP_11;
-  wire                _zz_decode_FPU_RSP_12;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_FPU_OPCODE_2;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [3:0]    _zz_decode_FPU_OPCODE_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -1177,7 +1136,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1215,11 +1174,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1234,59 +1193,59 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1362,8 +1321,8 @@ module VexRiscv (
   wire                FpuPlugin_port_cmd_isStall;
   wire       [2:0]    decode_FpuPlugin_iRoundMode;
   wire       [2:0]    decode_FpuPlugin_roundMode;
-  wire       `FpuRoundMode_opt_type _zz_FpuPlugin_port_cmd_payload_roundMode;
-  wire       `FpuRoundMode_opt_type _zz_FpuPlugin_port_cmd_payload_roundMode_1;
+  wire       [2:0]    _zz_FpuPlugin_port_cmd_payload_roundMode;
+  wire       [2:0]    _zz_FpuPlugin_port_cmd_payload_roundMode_1;
   wire                FpuPlugin_port_cmd_fire_2;
   wire                writeBack_FpuPlugin_isRsp;
   wire                writeBack_FpuPlugin_isCommit;
@@ -1374,23 +1333,23 @@ module VexRiscv (
   wire                when_FpuPlugin_l287;
   wire                writeBack_FpuPlugin_commit_valid /* verilator public */ ;
   wire                writeBack_FpuPlugin_commit_ready /* verilator public */ ;
-  wire       `FpuOpcode_binary_sequential_type writeBack_FpuPlugin_commit_payload_opcode /* verilator public */ ;
+  wire       [3:0]    writeBack_FpuPlugin_commit_payload_opcode /* verilator public */ ;
   wire       [4:0]    writeBack_FpuPlugin_commit_payload_rd /* verilator public */ ;
   wire                writeBack_FpuPlugin_commit_payload_write /* verilator public */ ;
   wire       [31:0]   writeBack_FpuPlugin_commit_payload_value /* verilator public */ ;
   wire                when_FpuPlugin_l301;
   wire                writeBack_FpuPlugin_commit_s2mPipe_valid;
   wire                writeBack_FpuPlugin_commit_s2mPipe_ready;
-  wire       `FpuOpcode_binary_sequential_type writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
+  wire       [3:0]    writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
   wire       [4:0]    writeBack_FpuPlugin_commit_s2mPipe_payload_rd;
   wire                writeBack_FpuPlugin_commit_s2mPipe_payload_write;
   wire       [31:0]   writeBack_FpuPlugin_commit_s2mPipe_payload_value;
   reg                 writeBack_FpuPlugin_commit_rValid;
-  reg        `FpuOpcode_binary_sequential_type writeBack_FpuPlugin_commit_rData_opcode;
+  reg        [3:0]    writeBack_FpuPlugin_commit_rData_opcode;
   reg        [4:0]    writeBack_FpuPlugin_commit_rData_rd;
   reg                 writeBack_FpuPlugin_commit_rData_write;
   reg        [31:0]   writeBack_FpuPlugin_commit_rData_value;
-  wire       `FpuOpcode_binary_sequential_type _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
+  wire       [3:0]    _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1412,7 +1371,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1422,9 +1381,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1448,21 +1407,21 @@ module VexRiscv (
   wire                when_Pipeline_l124_27;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_32;
   reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_36;
   reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_37;
@@ -1496,11 +1455,11 @@ module VexRiscv (
   wire                when_Pipeline_l124_51;
   reg                 memory_to_writeBack_FPU_RSP;
   wire                when_Pipeline_l124_52;
-  reg        `FpuOpcode_binary_sequential_type decode_to_execute_FPU_OPCODE;
+  reg        [3:0]    decode_to_execute_FPU_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        `FpuOpcode_binary_sequential_type execute_to_memory_FPU_OPCODE;
+  reg        [3:0]    execute_to_memory_FPU_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        `FpuOpcode_binary_sequential_type memory_to_writeBack_FPU_OPCODE;
+  reg        [3:0]    memory_to_writeBack_FPU_OPCODE;
   wire                when_Pipeline_l124_55;
   reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_56;
@@ -1561,67 +1520,68 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1264_24;
+  wire                when_CsrPlugin_l1277_24;
   reg                 execute_CsrPlugin_csr_3;
-  wire                when_CsrPlugin_l1264_25;
+  wire                when_CsrPlugin_l1277_25;
   reg                 execute_CsrPlugin_csr_2;
-  wire                when_CsrPlugin_l1264_26;
+  wire                when_CsrPlugin_l1277_26;
   reg                 execute_CsrPlugin_csr_1;
-  wire                when_CsrPlugin_l1264_27;
+  wire                when_CsrPlugin_l1277_27;
   reg                 execute_CsrPlugin_csr_256;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1646,8 +1606,8 @@ module VexRiscv (
   wire       [4:0]    _zz_FpuPlugin_flags_NX_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1770,7 +1730,7 @@ module VexRiscv (
   reg [63:0] memory_to_writeBack_FPU_OPCODE_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_5));
@@ -1784,7 +1744,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1796,6 +1756,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1889,10 +1851,9 @@ module VexRiscv (
   assign _zz__zz_decode_FPU_RSP_2 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_3) == 32'h20001010);
   assign _zz__zz_decode_FPU_RSP_4 = {(_zz__zz_decode_FPU_RSP_5 == _zz__zz_decode_FPU_RSP_6),(_zz__zz_decode_FPU_RSP_7 == _zz__zz_decode_FPU_RSP_8)};
   assign _zz__zz_decode_FPU_RSP_9 = {(_zz__zz_decode_FPU_RSP_10 == _zz__zz_decode_FPU_RSP_11),{_zz__zz_decode_FPU_RSP_12,_zz__zz_decode_FPU_RSP_14}};
-  assign _zz__zz_decode_FPU_RSP_16 = 3'b000;
-  assign _zz__zz_decode_FPU_RSP_17 = ({_zz__zz_decode_FPU_RSP_18,_zz__zz_decode_FPU_RSP_20} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_22 = ({_zz__zz_decode_FPU_RSP_23,_zz__zz_decode_FPU_RSP_26} != 4'b0000);
-  assign _zz__zz_decode_FPU_RSP_35 = {(_zz__zz_decode_FPU_RSP_36 != _zz__zz_decode_FPU_RSP_49),{_zz__zz_decode_FPU_RSP_50,{_zz__zz_decode_FPU_RSP_53,_zz__zz_decode_FPU_RSP_64}}};
+  assign _zz__zz_decode_FPU_RSP_16 = (|{_zz__zz_decode_FPU_RSP_17,_zz__zz_decode_FPU_RSP_19});
+  assign _zz__zz_decode_FPU_RSP_21 = (|{_zz__zz_decode_FPU_RSP_22,_zz__zz_decode_FPU_RSP_25});
+  assign _zz__zz_decode_FPU_RSP_34 = {(|_zz__zz_decode_FPU_RSP_35),{_zz__zz_decode_FPU_RSP_48,{_zz__zz_decode_FPU_RSP_51,_zz__zz_decode_FPU_RSP_61}}};
   assign _zz__zz_decode_FPU_RSP_3 = 32'h20001010;
   assign _zz__zz_decode_FPU_RSP_5 = (decode_INSTRUCTION & 32'h28000010);
   assign _zz__zz_decode_FPU_RSP_6 = 32'h08000010;
@@ -1902,237 +1863,213 @@ module VexRiscv (
   assign _zz__zz_decode_FPU_RSP_11 = 32'h60000010;
   assign _zz__zz_decode_FPU_RSP_12 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_13) == 32'h18000010);
   assign _zz__zz_decode_FPU_RSP_14 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_15) == 32'h20000010);
-  assign _zz__zz_decode_FPU_RSP_18 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_19) == 32'h80000000);
-  assign _zz__zz_decode_FPU_RSP_20 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_21) == 32'h00000040);
-  assign _zz__zz_decode_FPU_RSP_23 = (_zz__zz_decode_FPU_RSP_24 == _zz__zz_decode_FPU_RSP_25);
-  assign _zz__zz_decode_FPU_RSP_26 = {_zz__zz_decode_FPU_RSP_27,{_zz__zz_decode_FPU_RSP_29,_zz__zz_decode_FPU_RSP_32}};
-  assign _zz__zz_decode_FPU_RSP_36 = {_zz_decode_FPU_RSP_9,{_zz__zz_decode_FPU_RSP_37,_zz__zz_decode_FPU_RSP_40}};
-  assign _zz__zz_decode_FPU_RSP_49 = 5'h0;
-  assign _zz__zz_decode_FPU_RSP_50 = ({_zz__zz_decode_FPU_RSP_51,_zz__zz_decode_FPU_RSP_52} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_53 = (_zz__zz_decode_FPU_RSP_54 != _zz__zz_decode_FPU_RSP_63);
-  assign _zz__zz_decode_FPU_RSP_64 = {_zz__zz_decode_FPU_RSP_65,{_zz__zz_decode_FPU_RSP_70,_zz__zz_decode_FPU_RSP_73}};
+  assign _zz__zz_decode_FPU_RSP_17 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_18) == 32'h80000000);
+  assign _zz__zz_decode_FPU_RSP_19 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_20) == 32'h00000040);
+  assign _zz__zz_decode_FPU_RSP_22 = (_zz__zz_decode_FPU_RSP_23 == _zz__zz_decode_FPU_RSP_24);
+  assign _zz__zz_decode_FPU_RSP_25 = {_zz__zz_decode_FPU_RSP_26,{_zz__zz_decode_FPU_RSP_28,_zz__zz_decode_FPU_RSP_31}};
+  assign _zz__zz_decode_FPU_RSP_35 = {_zz_decode_FPU_RSP_9,{_zz__zz_decode_FPU_RSP_36,_zz__zz_decode_FPU_RSP_39}};
+  assign _zz__zz_decode_FPU_RSP_48 = (|{_zz__zz_decode_FPU_RSP_49,_zz__zz_decode_FPU_RSP_50});
+  assign _zz__zz_decode_FPU_RSP_51 = (|_zz__zz_decode_FPU_RSP_52);
+  assign _zz__zz_decode_FPU_RSP_61 = {_zz__zz_decode_FPU_RSP_62,{_zz__zz_decode_FPU_RSP_69,_zz__zz_decode_FPU_RSP_71}};
   assign _zz__zz_decode_FPU_RSP_13 = 32'h18000010;
   assign _zz__zz_decode_FPU_RSP_15 = 32'ha0000010;
-  assign _zz__zz_decode_FPU_RSP_19 = 32'h80000004;
-  assign _zz__zz_decode_FPU_RSP_21 = 32'h00000050;
-  assign _zz__zz_decode_FPU_RSP_24 = (decode_INSTRUCTION & 32'h10001010);
-  assign _zz__zz_decode_FPU_RSP_25 = 32'h00001010;
-  assign _zz__zz_decode_FPU_RSP_27 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_28) == 32'h00000010);
-  assign _zz__zz_decode_FPU_RSP_29 = (_zz__zz_decode_FPU_RSP_30 == _zz__zz_decode_FPU_RSP_31);
-  assign _zz__zz_decode_FPU_RSP_32 = (_zz__zz_decode_FPU_RSP_33 == _zz__zz_decode_FPU_RSP_34);
-  assign _zz__zz_decode_FPU_RSP_37 = (_zz__zz_decode_FPU_RSP_38 == _zz__zz_decode_FPU_RSP_39);
-  assign _zz__zz_decode_FPU_RSP_40 = {_zz__zz_decode_FPU_RSP_41,{_zz__zz_decode_FPU_RSP_43,_zz__zz_decode_FPU_RSP_46}};
-  assign _zz__zz_decode_FPU_RSP_51 = _zz_decode_FPU_RSP_9;
-  assign _zz__zz_decode_FPU_RSP_52 = _zz_decode_FPU_RSP_6;
-  assign _zz__zz_decode_FPU_RSP_54 = {_zz__zz_decode_FPU_RSP_55,{_zz__zz_decode_FPU_RSP_57,_zz__zz_decode_FPU_RSP_60}};
-  assign _zz__zz_decode_FPU_RSP_63 = 3'b000;
-  assign _zz__zz_decode_FPU_RSP_65 = ({_zz__zz_decode_FPU_RSP_66,_zz__zz_decode_FPU_RSP_69} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_70 = (_zz__zz_decode_FPU_RSP_71 != _zz__zz_decode_FPU_RSP_72);
-  assign _zz__zz_decode_FPU_RSP_73 = {_zz__zz_decode_FPU_RSP_74,{_zz__zz_decode_FPU_RSP_75,_zz__zz_decode_FPU_RSP_78}};
-  assign _zz__zz_decode_FPU_RSP_28 = 32'h30000010;
-  assign _zz__zz_decode_FPU_RSP_30 = (decode_INSTRUCTION & 32'h88000010);
-  assign _zz__zz_decode_FPU_RSP_31 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_33 = (decode_INSTRUCTION & 32'h50000010);
-  assign _zz__zz_decode_FPU_RSP_34 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_38 = (decode_INSTRUCTION & 32'h90000010);
-  assign _zz__zz_decode_FPU_RSP_39 = 32'h90000010;
-  assign _zz__zz_decode_FPU_RSP_41 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_42) == 32'h40000010);
-  assign _zz__zz_decode_FPU_RSP_43 = (_zz__zz_decode_FPU_RSP_44 == _zz__zz_decode_FPU_RSP_45);
-  assign _zz__zz_decode_FPU_RSP_46 = (_zz__zz_decode_FPU_RSP_47 == _zz__zz_decode_FPU_RSP_48);
-  assign _zz__zz_decode_FPU_RSP_55 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_56) == 32'h10000000);
-  assign _zz__zz_decode_FPU_RSP_57 = (_zz__zz_decode_FPU_RSP_58 == _zz__zz_decode_FPU_RSP_59);
-  assign _zz__zz_decode_FPU_RSP_60 = (_zz__zz_decode_FPU_RSP_61 == _zz__zz_decode_FPU_RSP_62);
+  assign _zz__zz_decode_FPU_RSP_18 = 32'h80000004;
+  assign _zz__zz_decode_FPU_RSP_20 = 32'h00000050;
+  assign _zz__zz_decode_FPU_RSP_23 = (decode_INSTRUCTION & 32'h10001010);
+  assign _zz__zz_decode_FPU_RSP_24 = 32'h00001010;
+  assign _zz__zz_decode_FPU_RSP_26 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_27) == 32'h00000010);
+  assign _zz__zz_decode_FPU_RSP_28 = (_zz__zz_decode_FPU_RSP_29 == _zz__zz_decode_FPU_RSP_30);
+  assign _zz__zz_decode_FPU_RSP_31 = (_zz__zz_decode_FPU_RSP_32 == _zz__zz_decode_FPU_RSP_33);
+  assign _zz__zz_decode_FPU_RSP_36 = (_zz__zz_decode_FPU_RSP_37 == _zz__zz_decode_FPU_RSP_38);
+  assign _zz__zz_decode_FPU_RSP_39 = {_zz__zz_decode_FPU_RSP_40,{_zz__zz_decode_FPU_RSP_42,_zz__zz_decode_FPU_RSP_45}};
+  assign _zz__zz_decode_FPU_RSP_49 = _zz_decode_FPU_RSP_9;
+  assign _zz__zz_decode_FPU_RSP_50 = _zz_decode_FPU_RSP_6;
+  assign _zz__zz_decode_FPU_RSP_52 = {_zz__zz_decode_FPU_RSP_53,{_zz__zz_decode_FPU_RSP_55,_zz__zz_decode_FPU_RSP_58}};
+  assign _zz__zz_decode_FPU_RSP_62 = (|{_zz__zz_decode_FPU_RSP_63,_zz__zz_decode_FPU_RSP_66});
+  assign _zz__zz_decode_FPU_RSP_69 = (|_zz__zz_decode_FPU_RSP_70);
+  assign _zz__zz_decode_FPU_RSP_71 = {_zz__zz_decode_FPU_RSP_72,{_zz__zz_decode_FPU_RSP_73,_zz__zz_decode_FPU_RSP_75}};
+  assign _zz__zz_decode_FPU_RSP_27 = 32'h30000010;
+  assign _zz__zz_decode_FPU_RSP_29 = (decode_INSTRUCTION & 32'h88000010);
+  assign _zz__zz_decode_FPU_RSP_30 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_32 = (decode_INSTRUCTION & 32'h50000010);
+  assign _zz__zz_decode_FPU_RSP_33 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_37 = (decode_INSTRUCTION & 32'h90000010);
+  assign _zz__zz_decode_FPU_RSP_38 = 32'h90000010;
+  assign _zz__zz_decode_FPU_RSP_40 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_41) == 32'h40000010);
+  assign _zz__zz_decode_FPU_RSP_42 = (_zz__zz_decode_FPU_RSP_43 == _zz__zz_decode_FPU_RSP_44);
+  assign _zz__zz_decode_FPU_RSP_45 = (_zz__zz_decode_FPU_RSP_46 == _zz__zz_decode_FPU_RSP_47);
+  assign _zz__zz_decode_FPU_RSP_53 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_54) == 32'h10000000);
+  assign _zz__zz_decode_FPU_RSP_55 = (_zz__zz_decode_FPU_RSP_56 == _zz__zz_decode_FPU_RSP_57);
+  assign _zz__zz_decode_FPU_RSP_58 = (_zz__zz_decode_FPU_RSP_59 == _zz__zz_decode_FPU_RSP_60);
+  assign _zz__zz_decode_FPU_RSP_63 = (_zz__zz_decode_FPU_RSP_64 == _zz__zz_decode_FPU_RSP_65);
   assign _zz__zz_decode_FPU_RSP_66 = (_zz__zz_decode_FPU_RSP_67 == _zz__zz_decode_FPU_RSP_68);
-  assign _zz__zz_decode_FPU_RSP_69 = _zz_decode_FPU_RSP_10;
-  assign _zz__zz_decode_FPU_RSP_71 = _zz_decode_FPU_RSP_12;
-  assign _zz__zz_decode_FPU_RSP_72 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_74 = (_zz_decode_FPU_RSP_12 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_75 = (_zz__zz_decode_FPU_RSP_76 != _zz__zz_decode_FPU_RSP_77);
-  assign _zz__zz_decode_FPU_RSP_78 = {_zz__zz_decode_FPU_RSP_79,{_zz__zz_decode_FPU_RSP_81,_zz__zz_decode_FPU_RSP_83}};
-  assign _zz__zz_decode_FPU_RSP_42 = 32'hc0000010;
-  assign _zz__zz_decode_FPU_RSP_44 = (decode_INSTRUCTION & 32'h58000010);
-  assign _zz__zz_decode_FPU_RSP_45 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_47 = (decode_INSTRUCTION & 32'hb0000010);
-  assign _zz__zz_decode_FPU_RSP_48 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_56 = 32'h10000020;
-  assign _zz__zz_decode_FPU_RSP_58 = (decode_INSTRUCTION & 32'h80000020);
-  assign _zz__zz_decode_FPU_RSP_59 = 32'h0;
-  assign _zz__zz_decode_FPU_RSP_61 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz__zz_decode_FPU_RSP_62 = 32'h0;
-  assign _zz__zz_decode_FPU_RSP_67 = (decode_INSTRUCTION & 32'h00000060);
-  assign _zz__zz_decode_FPU_RSP_68 = 32'h00000040;
-  assign _zz__zz_decode_FPU_RSP_76 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_FPU_RSP_77 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_79 = (((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_80) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_81 = ({_zz_decode_FPU_RSP_11,_zz__zz_decode_FPU_RSP_82} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_83 = {({_zz__zz_decode_FPU_RSP_84,_zz__zz_decode_FPU_RSP_85} != 2'b00),{(_zz__zz_decode_FPU_RSP_87 != _zz__zz_decode_FPU_RSP_92),{_zz__zz_decode_FPU_RSP_93,{_zz__zz_decode_FPU_RSP_95,_zz__zz_decode_FPU_RSP_97}}}};
-  assign _zz__zz_decode_FPU_RSP_80 = 32'h02004074;
-  assign _zz__zz_decode_FPU_RSP_82 = ((decode_INSTRUCTION & 32'h10203034) == 32'h10000030);
-  assign _zz__zz_decode_FPU_RSP_84 = _zz_decode_FPU_RSP_11;
-  assign _zz__zz_decode_FPU_RSP_85 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_86) == 32'h10000030);
-  assign _zz__zz_decode_FPU_RSP_87 = {(_zz__zz_decode_FPU_RSP_88 == _zz__zz_decode_FPU_RSP_89),(_zz__zz_decode_FPU_RSP_90 == _zz__zz_decode_FPU_RSP_91)};
-  assign _zz__zz_decode_FPU_RSP_92 = 2'b00;
-  assign _zz__zz_decode_FPU_RSP_93 = ({_zz_decode_FPU_RSP_7,_zz__zz_decode_FPU_RSP_94} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_95 = (_zz__zz_decode_FPU_RSP_96 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_97 = {(_zz__zz_decode_FPU_RSP_98 != _zz__zz_decode_FPU_RSP_103),{_zz__zz_decode_FPU_RSP_104,{_zz__zz_decode_FPU_RSP_110,_zz__zz_decode_FPU_RSP_112}}};
-  assign _zz__zz_decode_FPU_RSP_86 = 32'h10403034;
-  assign _zz__zz_decode_FPU_RSP_88 = (decode_INSTRUCTION & 32'h00001070);
-  assign _zz__zz_decode_FPU_RSP_89 = 32'h00001070;
-  assign _zz__zz_decode_FPU_RSP_90 = (decode_INSTRUCTION & 32'h00002070);
-  assign _zz__zz_decode_FPU_RSP_91 = 32'h00002070;
-  assign _zz__zz_decode_FPU_RSP_94 = ((decode_INSTRUCTION & 32'h00002034) == 32'h00000024);
-  assign _zz__zz_decode_FPU_RSP_96 = ((decode_INSTRUCTION & 32'h00000078) == 32'h00000060);
-  assign _zz__zz_decode_FPU_RSP_98 = {(_zz__zz_decode_FPU_RSP_99 == _zz__zz_decode_FPU_RSP_100),(_zz__zz_decode_FPU_RSP_101 == _zz__zz_decode_FPU_RSP_102)};
-  assign _zz__zz_decode_FPU_RSP_103 = 2'b00;
-  assign _zz__zz_decode_FPU_RSP_104 = ({_zz__zz_decode_FPU_RSP_105,{_zz__zz_decode_FPU_RSP_106,_zz__zz_decode_FPU_RSP_108}} != 3'b000);
-  assign _zz__zz_decode_FPU_RSP_110 = (_zz__zz_decode_FPU_RSP_111 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_112 = {(_zz__zz_decode_FPU_RSP_113 != _zz__zz_decode_FPU_RSP_115),{_zz__zz_decode_FPU_RSP_116,{_zz__zz_decode_FPU_RSP_119,_zz__zz_decode_FPU_RSP_124}}};
-  assign _zz__zz_decode_FPU_RSP_99 = (decode_INSTRUCTION & 32'h00007074);
-  assign _zz__zz_decode_FPU_RSP_100 = 32'h00005010;
-  assign _zz__zz_decode_FPU_RSP_101 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_FPU_RSP_102 = 32'h00005020;
-  assign _zz__zz_decode_FPU_RSP_105 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_FPU_RSP_106 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_107) == 32'h00001010);
-  assign _zz__zz_decode_FPU_RSP_108 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_109) == 32'h00001010);
-  assign _zz__zz_decode_FPU_RSP_111 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000034);
-  assign _zz__zz_decode_FPU_RSP_113 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_114) == 32'h00001000);
-  assign _zz__zz_decode_FPU_RSP_115 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_116 = ((_zz__zz_decode_FPU_RSP_117 == _zz__zz_decode_FPU_RSP_118) != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_119 = ({_zz__zz_decode_FPU_RSP_120,_zz__zz_decode_FPU_RSP_122} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_124 = {(_zz__zz_decode_FPU_RSP_125 != _zz__zz_decode_FPU_RSP_127),{_zz__zz_decode_FPU_RSP_128,{_zz__zz_decode_FPU_RSP_131,_zz__zz_decode_FPU_RSP_145}}};
-  assign _zz__zz_decode_FPU_RSP_107 = 32'h00007074;
-  assign _zz__zz_decode_FPU_RSP_109 = 32'h02007054;
-  assign _zz__zz_decode_FPU_RSP_114 = 32'h00001000;
-  assign _zz__zz_decode_FPU_RSP_117 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_FPU_RSP_118 = 32'h00002000;
-  assign _zz__zz_decode_FPU_RSP_120 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_121) == 32'h00002000);
-  assign _zz__zz_decode_FPU_RSP_122 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_123) == 32'h00001000);
-  assign _zz__zz_decode_FPU_RSP_125 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_126) == 32'h00004008);
-  assign _zz__zz_decode_FPU_RSP_127 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_128 = ({_zz__zz_decode_FPU_RSP_129,_zz__zz_decode_FPU_RSP_130} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_131 = ({_zz__zz_decode_FPU_RSP_132,_zz__zz_decode_FPU_RSP_134} != 6'h0);
-  assign _zz__zz_decode_FPU_RSP_145 = {(_zz__zz_decode_FPU_RSP_146 != _zz__zz_decode_FPU_RSP_147),{_zz__zz_decode_FPU_RSP_148,{_zz__zz_decode_FPU_RSP_161,_zz__zz_decode_FPU_RSP_174}}};
-  assign _zz__zz_decode_FPU_RSP_121 = 32'h00002010;
-  assign _zz__zz_decode_FPU_RSP_123 = 32'h00005000;
-  assign _zz__zz_decode_FPU_RSP_126 = 32'h00004048;
-  assign _zz__zz_decode_FPU_RSP_129 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz__zz_decode_FPU_RSP_130 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz__zz_decode_FPU_RSP_132 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_133) == 32'h00001060);
-  assign _zz__zz_decode_FPU_RSP_134 = {(_zz__zz_decode_FPU_RSP_135 == _zz__zz_decode_FPU_RSP_136),{_zz__zz_decode_FPU_RSP_137,{_zz__zz_decode_FPU_RSP_139,_zz__zz_decode_FPU_RSP_142}}};
-  assign _zz__zz_decode_FPU_RSP_146 = _zz_decode_FPU_RSP_9;
-  assign _zz__zz_decode_FPU_RSP_147 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_148 = ({_zz_decode_FPU_RSP_8,{_zz__zz_decode_FPU_RSP_149,_zz__zz_decode_FPU_RSP_152}} != 5'h0);
-  assign _zz__zz_decode_FPU_RSP_161 = ({_zz__zz_decode_FPU_RSP_162,_zz__zz_decode_FPU_RSP_163} != 5'h0);
-  assign _zz__zz_decode_FPU_RSP_174 = {(_zz__zz_decode_FPU_RSP_175 != _zz__zz_decode_FPU_RSP_190),{_zz__zz_decode_FPU_RSP_191,{_zz__zz_decode_FPU_RSP_198,_zz__zz_decode_FPU_RSP_205}}};
-  assign _zz__zz_decode_FPU_RSP_133 = 32'h00001060;
-  assign _zz__zz_decode_FPU_RSP_135 = (decode_INSTRUCTION & 32'h00002060);
-  assign _zz__zz_decode_FPU_RSP_136 = 32'h00002060;
-  assign _zz__zz_decode_FPU_RSP_137 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_138) == 32'h00000060);
-  assign _zz__zz_decode_FPU_RSP_139 = (_zz__zz_decode_FPU_RSP_140 == _zz__zz_decode_FPU_RSP_141);
-  assign _zz__zz_decode_FPU_RSP_142 = {_zz_decode_FPU_RSP_10,_zz__zz_decode_FPU_RSP_143};
+  assign _zz__zz_decode_FPU_RSP_70 = _zz_decode_FPU_RSP_11;
+  assign _zz__zz_decode_FPU_RSP_72 = (|_zz_decode_FPU_RSP_11);
+  assign _zz__zz_decode_FPU_RSP_73 = (|_zz__zz_decode_FPU_RSP_74);
+  assign _zz__zz_decode_FPU_RSP_75 = {_zz__zz_decode_FPU_RSP_76,{_zz__zz_decode_FPU_RSP_78,_zz__zz_decode_FPU_RSP_80}};
+  assign _zz__zz_decode_FPU_RSP_41 = 32'hc0000010;
+  assign _zz__zz_decode_FPU_RSP_43 = (decode_INSTRUCTION & 32'h58000010);
+  assign _zz__zz_decode_FPU_RSP_44 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_46 = (decode_INSTRUCTION & 32'hb0000010);
+  assign _zz__zz_decode_FPU_RSP_47 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_54 = 32'h10000020;
+  assign _zz__zz_decode_FPU_RSP_56 = (decode_INSTRUCTION & 32'h80000020);
+  assign _zz__zz_decode_FPU_RSP_57 = 32'h0;
+  assign _zz__zz_decode_FPU_RSP_59 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_FPU_RSP_60 = 32'h0;
+  assign _zz__zz_decode_FPU_RSP_64 = (decode_INSTRUCTION & 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_65 = 32'h00000040;
+  assign _zz__zz_decode_FPU_RSP_67 = (decode_INSTRUCTION & 32'h0000005c);
+  assign _zz__zz_decode_FPU_RSP_68 = 32'h00000004;
+  assign _zz__zz_decode_FPU_RSP_74 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_FPU_RSP_76 = (|((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_77) == 32'h02000030));
+  assign _zz__zz_decode_FPU_RSP_78 = (|{_zz_decode_FPU_RSP_10,_zz__zz_decode_FPU_RSP_79});
+  assign _zz__zz_decode_FPU_RSP_80 = {(|{_zz__zz_decode_FPU_RSP_81,_zz__zz_decode_FPU_RSP_82}),{(|_zz__zz_decode_FPU_RSP_84),{_zz__zz_decode_FPU_RSP_89,{_zz__zz_decode_FPU_RSP_91,_zz__zz_decode_FPU_RSP_93}}}};
+  assign _zz__zz_decode_FPU_RSP_77 = 32'h02004074;
+  assign _zz__zz_decode_FPU_RSP_79 = ((decode_INSTRUCTION & 32'h10203034) == 32'h10000030);
+  assign _zz__zz_decode_FPU_RSP_81 = _zz_decode_FPU_RSP_10;
+  assign _zz__zz_decode_FPU_RSP_82 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_83) == 32'h10000030);
+  assign _zz__zz_decode_FPU_RSP_84 = {(_zz__zz_decode_FPU_RSP_85 == _zz__zz_decode_FPU_RSP_86),(_zz__zz_decode_FPU_RSP_87 == _zz__zz_decode_FPU_RSP_88)};
+  assign _zz__zz_decode_FPU_RSP_89 = (|{_zz_decode_FPU_RSP_7,_zz__zz_decode_FPU_RSP_90});
+  assign _zz__zz_decode_FPU_RSP_91 = (|_zz__zz_decode_FPU_RSP_92);
+  assign _zz__zz_decode_FPU_RSP_93 = {(|_zz__zz_decode_FPU_RSP_94),{_zz__zz_decode_FPU_RSP_99,{_zz__zz_decode_FPU_RSP_105,_zz__zz_decode_FPU_RSP_107}}};
+  assign _zz__zz_decode_FPU_RSP_83 = 32'h10403034;
+  assign _zz__zz_decode_FPU_RSP_85 = (decode_INSTRUCTION & 32'h00001070);
+  assign _zz__zz_decode_FPU_RSP_86 = 32'h00001070;
+  assign _zz__zz_decode_FPU_RSP_87 = (decode_INSTRUCTION & 32'h00002070);
+  assign _zz__zz_decode_FPU_RSP_88 = 32'h00002070;
+  assign _zz__zz_decode_FPU_RSP_90 = ((decode_INSTRUCTION & 32'h00002034) == 32'h00000024);
+  assign _zz__zz_decode_FPU_RSP_92 = ((decode_INSTRUCTION & 32'h00000078) == 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_94 = {(_zz__zz_decode_FPU_RSP_95 == _zz__zz_decode_FPU_RSP_96),(_zz__zz_decode_FPU_RSP_97 == _zz__zz_decode_FPU_RSP_98)};
+  assign _zz__zz_decode_FPU_RSP_99 = (|{_zz__zz_decode_FPU_RSP_100,{_zz__zz_decode_FPU_RSP_101,_zz__zz_decode_FPU_RSP_103}});
+  assign _zz__zz_decode_FPU_RSP_105 = (|_zz__zz_decode_FPU_RSP_106);
+  assign _zz__zz_decode_FPU_RSP_107 = {(|_zz__zz_decode_FPU_RSP_108),{_zz__zz_decode_FPU_RSP_110,{_zz__zz_decode_FPU_RSP_113,_zz__zz_decode_FPU_RSP_116}}};
+  assign _zz__zz_decode_FPU_RSP_95 = (decode_INSTRUCTION & 32'h00007074);
+  assign _zz__zz_decode_FPU_RSP_96 = 32'h00005010;
+  assign _zz__zz_decode_FPU_RSP_97 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_FPU_RSP_98 = 32'h00005020;
+  assign _zz__zz_decode_FPU_RSP_100 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_FPU_RSP_101 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_102) == 32'h00001010);
+  assign _zz__zz_decode_FPU_RSP_103 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_104) == 32'h00001010);
+  assign _zz__zz_decode_FPU_RSP_106 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000034);
+  assign _zz__zz_decode_FPU_RSP_108 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_109) == 32'h00001000);
+  assign _zz__zz_decode_FPU_RSP_110 = (|(_zz__zz_decode_FPU_RSP_111 == _zz__zz_decode_FPU_RSP_112));
+  assign _zz__zz_decode_FPU_RSP_113 = (|{_zz__zz_decode_FPU_RSP_114,_zz__zz_decode_FPU_RSP_115});
+  assign _zz__zz_decode_FPU_RSP_116 = {(|_zz__zz_decode_FPU_RSP_117),{_zz__zz_decode_FPU_RSP_118,{_zz__zz_decode_FPU_RSP_123,_zz__zz_decode_FPU_RSP_136}}};
+  assign _zz__zz_decode_FPU_RSP_102 = 32'h00007074;
+  assign _zz__zz_decode_FPU_RSP_104 = 32'h02007054;
+  assign _zz__zz_decode_FPU_RSP_109 = 32'h00001000;
+  assign _zz__zz_decode_FPU_RSP_111 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_FPU_RSP_112 = 32'h00002000;
+  assign _zz__zz_decode_FPU_RSP_114 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_FPU_RSP_115 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_FPU_RSP_117 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz__zz_decode_FPU_RSP_118 = (|{(_zz__zz_decode_FPU_RSP_119 == _zz__zz_decode_FPU_RSP_120),(_zz__zz_decode_FPU_RSP_121 == _zz__zz_decode_FPU_RSP_122)});
+  assign _zz__zz_decode_FPU_RSP_123 = (|{_zz__zz_decode_FPU_RSP_124,{_zz__zz_decode_FPU_RSP_125,_zz__zz_decode_FPU_RSP_127}});
+  assign _zz__zz_decode_FPU_RSP_136 = {(|_zz_decode_FPU_RSP_9),{(|_zz__zz_decode_FPU_RSP_137),{_zz__zz_decode_FPU_RSP_148,{_zz__zz_decode_FPU_RSP_161,_zz__zz_decode_FPU_RSP_176}}}};
+  assign _zz__zz_decode_FPU_RSP_119 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz__zz_decode_FPU_RSP_120 = 32'h00000020;
+  assign _zz__zz_decode_FPU_RSP_121 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_FPU_RSP_122 = 32'h00000020;
+  assign _zz__zz_decode_FPU_RSP_124 = ((decode_INSTRUCTION & 32'h00000030) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_125 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_126) == 32'h00001060);
+  assign _zz__zz_decode_FPU_RSP_127 = {(_zz__zz_decode_FPU_RSP_128 == _zz__zz_decode_FPU_RSP_129),{_zz__zz_decode_FPU_RSP_130,{_zz__zz_decode_FPU_RSP_132,_zz__zz_decode_FPU_RSP_133}}};
+  assign _zz__zz_decode_FPU_RSP_137 = {_zz_decode_FPU_RSP_8,{_zz__zz_decode_FPU_RSP_138,{_zz__zz_decode_FPU_RSP_140,_zz__zz_decode_FPU_RSP_143}}};
+  assign _zz__zz_decode_FPU_RSP_148 = (|{_zz_decode_FPU_RSP_8,{_zz__zz_decode_FPU_RSP_149,_zz__zz_decode_FPU_RSP_152}});
+  assign _zz__zz_decode_FPU_RSP_161 = (|{_zz__zz_decode_FPU_RSP_162,_zz__zz_decode_FPU_RSP_163});
+  assign _zz__zz_decode_FPU_RSP_176 = {(|_zz__zz_decode_FPU_RSP_177),{_zz__zz_decode_FPU_RSP_182,{_zz__zz_decode_FPU_RSP_187,_zz__zz_decode_FPU_RSP_191}}};
+  assign _zz__zz_decode_FPU_RSP_126 = 32'h00001060;
+  assign _zz__zz_decode_FPU_RSP_128 = (decode_INSTRUCTION & 32'h00002060);
+  assign _zz__zz_decode_FPU_RSP_129 = 32'h00002060;
+  assign _zz__zz_decode_FPU_RSP_130 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_131) == 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_132 = _zz_decode_FPU_RSP_4;
+  assign _zz__zz_decode_FPU_RSP_133 = (_zz__zz_decode_FPU_RSP_134 == _zz__zz_decode_FPU_RSP_135);
+  assign _zz__zz_decode_FPU_RSP_138 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_139) == 32'h00004020);
+  assign _zz__zz_decode_FPU_RSP_140 = (_zz__zz_decode_FPU_RSP_141 == _zz__zz_decode_FPU_RSP_142);
+  assign _zz__zz_decode_FPU_RSP_143 = {_zz__zz_decode_FPU_RSP_144,_zz__zz_decode_FPU_RSP_146};
   assign _zz__zz_decode_FPU_RSP_149 = (_zz__zz_decode_FPU_RSP_150 == _zz__zz_decode_FPU_RSP_151);
   assign _zz__zz_decode_FPU_RSP_152 = {_zz__zz_decode_FPU_RSP_153,{_zz__zz_decode_FPU_RSP_155,_zz__zz_decode_FPU_RSP_158}};
-  assign _zz__zz_decode_FPU_RSP_162 = _zz_decode_FPU_RSP_8;
+  assign _zz__zz_decode_FPU_RSP_162 = _zz_decode_FPU_RSP_7;
   assign _zz__zz_decode_FPU_RSP_163 = {_zz__zz_decode_FPU_RSP_164,{_zz__zz_decode_FPU_RSP_166,_zz__zz_decode_FPU_RSP_169}};
-  assign _zz__zz_decode_FPU_RSP_175 = {_zz_decode_FPU_RSP_7,{_zz__zz_decode_FPU_RSP_176,_zz__zz_decode_FPU_RSP_179}};
-  assign _zz__zz_decode_FPU_RSP_190 = 7'h0;
-  assign _zz__zz_decode_FPU_RSP_191 = ({_zz__zz_decode_FPU_RSP_192,_zz__zz_decode_FPU_RSP_193} != 4'b0000);
-  assign _zz__zz_decode_FPU_RSP_198 = (_zz__zz_decode_FPU_RSP_199 != _zz__zz_decode_FPU_RSP_204);
-  assign _zz__zz_decode_FPU_RSP_205 = {_zz__zz_decode_FPU_RSP_206,{_zz__zz_decode_FPU_RSP_209,_zz__zz_decode_FPU_RSP_214}};
-  assign _zz__zz_decode_FPU_RSP_138 = 32'h00400060;
-  assign _zz__zz_decode_FPU_RSP_140 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_FPU_RSP_141 = 32'h00000060;
-  assign _zz__zz_decode_FPU_RSP_143 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_144) == 32'h0);
-  assign _zz__zz_decode_FPU_RSP_150 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_FPU_RSP_151 = 32'h00004020;
-  assign _zz__zz_decode_FPU_RSP_153 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_154) == 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_177 = {_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_178,_zz__zz_decode_FPU_RSP_179}};
+  assign _zz__zz_decode_FPU_RSP_182 = (|{_zz__zz_decode_FPU_RSP_183,_zz__zz_decode_FPU_RSP_184});
+  assign _zz__zz_decode_FPU_RSP_187 = (|_zz__zz_decode_FPU_RSP_188);
+  assign _zz__zz_decode_FPU_RSP_191 = {_zz__zz_decode_FPU_RSP_192,{_zz__zz_decode_FPU_RSP_195,_zz__zz_decode_FPU_RSP_207}};
+  assign _zz__zz_decode_FPU_RSP_131 = 32'h10000060;
+  assign _zz__zz_decode_FPU_RSP_134 = (decode_INSTRUCTION & 32'h10400024);
+  assign _zz__zz_decode_FPU_RSP_135 = 32'h10000020;
+  assign _zz__zz_decode_FPU_RSP_139 = 32'h00004020;
+  assign _zz__zz_decode_FPU_RSP_141 = (decode_INSTRUCTION & 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_142 = 32'h00000060;
+  assign _zz__zz_decode_FPU_RSP_144 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_145) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_146 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_147) == 32'h00000010);
+  assign _zz__zz_decode_FPU_RSP_150 = (decode_INSTRUCTION & 32'h00002070);
+  assign _zz__zz_decode_FPU_RSP_151 = 32'h00002010;
+  assign _zz__zz_decode_FPU_RSP_153 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_154) == 32'h00002020);
   assign _zz__zz_decode_FPU_RSP_155 = (_zz__zz_decode_FPU_RSP_156 == _zz__zz_decode_FPU_RSP_157);
   assign _zz__zz_decode_FPU_RSP_158 = (_zz__zz_decode_FPU_RSP_159 == _zz__zz_decode_FPU_RSP_160);
-  assign _zz__zz_decode_FPU_RSP_164 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_165) == 32'h00002010);
+  assign _zz__zz_decode_FPU_RSP_164 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_165) == 32'h00000010);
   assign _zz__zz_decode_FPU_RSP_166 = (_zz__zz_decode_FPU_RSP_167 == _zz__zz_decode_FPU_RSP_168);
-  assign _zz__zz_decode_FPU_RSP_169 = {_zz__zz_decode_FPU_RSP_170,_zz__zz_decode_FPU_RSP_172};
-  assign _zz__zz_decode_FPU_RSP_176 = (_zz__zz_decode_FPU_RSP_177 == _zz__zz_decode_FPU_RSP_178);
-  assign _zz__zz_decode_FPU_RSP_179 = {_zz__zz_decode_FPU_RSP_180,{_zz__zz_decode_FPU_RSP_182,_zz__zz_decode_FPU_RSP_185}};
-  assign _zz__zz_decode_FPU_RSP_192 = _zz_decode_FPU_RSP_3;
-  assign _zz__zz_decode_FPU_RSP_193 = {_zz_decode_FPU_RSP_2,{_zz__zz_decode_FPU_RSP_194,_zz__zz_decode_FPU_RSP_195}};
-  assign _zz__zz_decode_FPU_RSP_199 = {_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_200,_zz__zz_decode_FPU_RSP_203}};
-  assign _zz__zz_decode_FPU_RSP_204 = 3'b000;
-  assign _zz__zz_decode_FPU_RSP_206 = (_zz__zz_decode_FPU_RSP_207 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_209 = (_zz__zz_decode_FPU_RSP_210 != _zz__zz_decode_FPU_RSP_213);
-  assign _zz__zz_decode_FPU_RSP_214 = {_zz__zz_decode_FPU_RSP_215,{_zz__zz_decode_FPU_RSP_228,_zz__zz_decode_FPU_RSP_231}};
-  assign _zz__zz_decode_FPU_RSP_144 = 32'h00000078;
-  assign _zz__zz_decode_FPU_RSP_154 = 32'h00000060;
-  assign _zz__zz_decode_FPU_RSP_156 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz__zz_decode_FPU_RSP_157 = 32'h00000020;
-  assign _zz__zz_decode_FPU_RSP_159 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_FPU_RSP_160 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_165 = 32'h00002070;
-  assign _zz__zz_decode_FPU_RSP_167 = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz__zz_decode_FPU_RSP_168 = 32'h00002020;
-  assign _zz__zz_decode_FPU_RSP_170 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_171) == 32'h00000010);
-  assign _zz__zz_decode_FPU_RSP_172 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_173) == 32'h00000020);
-  assign _zz__zz_decode_FPU_RSP_177 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_FPU_RSP_178 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_180 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_181) == 32'h00001030);
-  assign _zz__zz_decode_FPU_RSP_182 = (_zz__zz_decode_FPU_RSP_183 == _zz__zz_decode_FPU_RSP_184);
-  assign _zz__zz_decode_FPU_RSP_185 = {_zz_decode_FPU_RSP_6,{_zz__zz_decode_FPU_RSP_186,_zz__zz_decode_FPU_RSP_188}};
-  assign _zz__zz_decode_FPU_RSP_194 = _zz_decode_FPU_RSP_5;
-  assign _zz__zz_decode_FPU_RSP_195 = (_zz__zz_decode_FPU_RSP_196 == _zz__zz_decode_FPU_RSP_197);
-  assign _zz__zz_decode_FPU_RSP_200 = (_zz__zz_decode_FPU_RSP_201 == _zz__zz_decode_FPU_RSP_202);
-  assign _zz__zz_decode_FPU_RSP_203 = _zz_decode_FPU_RSP_5;
-  assign _zz__zz_decode_FPU_RSP_207 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_208) == 32'h00004010);
-  assign _zz__zz_decode_FPU_RSP_210 = (_zz__zz_decode_FPU_RSP_211 == _zz__zz_decode_FPU_RSP_212);
-  assign _zz__zz_decode_FPU_RSP_213 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_215 = ({_zz__zz_decode_FPU_RSP_216,_zz__zz_decode_FPU_RSP_218} != 6'h0);
-  assign _zz__zz_decode_FPU_RSP_228 = (_zz__zz_decode_FPU_RSP_229 != _zz__zz_decode_FPU_RSP_230);
-  assign _zz__zz_decode_FPU_RSP_231 = {_zz__zz_decode_FPU_RSP_232,{_zz__zz_decode_FPU_RSP_238,_zz__zz_decode_FPU_RSP_243}};
-  assign _zz__zz_decode_FPU_RSP_171 = 32'h00001070;
-  assign _zz__zz_decode_FPU_RSP_173 = 32'h02003020;
-  assign _zz__zz_decode_FPU_RSP_181 = 32'h00001030;
-  assign _zz__zz_decode_FPU_RSP_183 = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz__zz_decode_FPU_RSP_184 = 32'h00002030;
-  assign _zz__zz_decode_FPU_RSP_186 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_187) == 32'h00000024);
-  assign _zz__zz_decode_FPU_RSP_188 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_189) == 32'h0);
-  assign _zz__zz_decode_FPU_RSP_196 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_FPU_RSP_197 = 32'h00000020;
-  assign _zz__zz_decode_FPU_RSP_201 = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz__zz_decode_FPU_RSP_202 = 32'h0;
-  assign _zz__zz_decode_FPU_RSP_208 = 32'h00004014;
-  assign _zz__zz_decode_FPU_RSP_211 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_FPU_RSP_212 = 32'h00002010;
-  assign _zz__zz_decode_FPU_RSP_216 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_217) == 32'h0);
-  assign _zz__zz_decode_FPU_RSP_218 = {(_zz__zz_decode_FPU_RSP_219 == _zz__zz_decode_FPU_RSP_220),{_zz_decode_FPU_RSP_4,{_zz__zz_decode_FPU_RSP_221,_zz__zz_decode_FPU_RSP_223}}};
-  assign _zz__zz_decode_FPU_RSP_229 = _zz_decode_FPU_RSP_4;
-  assign _zz__zz_decode_FPU_RSP_230 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_232 = ({_zz__zz_decode_FPU_RSP_233,{_zz__zz_decode_FPU_RSP_234,_zz__zz_decode_FPU_RSP_236}} != 3'b000);
-  assign _zz__zz_decode_FPU_RSP_238 = ({_zz__zz_decode_FPU_RSP_239,_zz__zz_decode_FPU_RSP_240} != 3'b000);
-  assign _zz__zz_decode_FPU_RSP_243 = {(_zz__zz_decode_FPU_RSP_244 != _zz__zz_decode_FPU_RSP_245),(_zz__zz_decode_FPU_RSP_246 != _zz__zz_decode_FPU_RSP_248)};
-  assign _zz__zz_decode_FPU_RSP_187 = 32'h00002024;
-  assign _zz__zz_decode_FPU_RSP_189 = 32'h00000064;
-  assign _zz__zz_decode_FPU_RSP_217 = 32'h00000044;
-  assign _zz__zz_decode_FPU_RSP_219 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_FPU_RSP_220 = 32'h00000020;
-  assign _zz__zz_decode_FPU_RSP_221 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_222) == 32'h00002020);
-  assign _zz__zz_decode_FPU_RSP_223 = {(_zz__zz_decode_FPU_RSP_224 == _zz__zz_decode_FPU_RSP_225),(_zz__zz_decode_FPU_RSP_226 == _zz__zz_decode_FPU_RSP_227)};
-  assign _zz__zz_decode_FPU_RSP_233 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_FPU_RSP_234 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_235) == 32'h00002010);
-  assign _zz__zz_decode_FPU_RSP_236 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_237) == 32'h40000030);
-  assign _zz__zz_decode_FPU_RSP_239 = _zz_decode_FPU_RSP_3;
-  assign _zz__zz_decode_FPU_RSP_240 = {_zz_decode_FPU_RSP_1,(_zz__zz_decode_FPU_RSP_241 == _zz__zz_decode_FPU_RSP_242)};
-  assign _zz__zz_decode_FPU_RSP_244 = {_zz_decode_FPU_RSP_2,_zz_decode_FPU_RSP_1};
-  assign _zz__zz_decode_FPU_RSP_245 = 2'b00;
-  assign _zz__zz_decode_FPU_RSP_246 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_247) == 32'h00001008);
-  assign _zz__zz_decode_FPU_RSP_248 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_222 = 32'h00006024;
-  assign _zz__zz_decode_FPU_RSP_224 = (decode_INSTRUCTION & 32'h00005024);
-  assign _zz__zz_decode_FPU_RSP_225 = 32'h00001020;
-  assign _zz__zz_decode_FPU_RSP_226 = (decode_INSTRUCTION & 32'h90000034);
-  assign _zz__zz_decode_FPU_RSP_227 = 32'h90000010;
-  assign _zz__zz_decode_FPU_RSP_235 = 32'h00002014;
-  assign _zz__zz_decode_FPU_RSP_237 = 32'h40000034;
-  assign _zz__zz_decode_FPU_RSP_241 = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz__zz_decode_FPU_RSP_242 = 32'h00000004;
-  assign _zz__zz_decode_FPU_RSP_247 = 32'h00005048;
+  assign _zz__zz_decode_FPU_RSP_169 = {_zz__zz_decode_FPU_RSP_170,{_zz__zz_decode_FPU_RSP_172,_zz__zz_decode_FPU_RSP_173}};
+  assign _zz__zz_decode_FPU_RSP_178 = _zz_decode_FPU_RSP_2;
+  assign _zz__zz_decode_FPU_RSP_179 = {_zz_decode_FPU_RSP_5,_zz__zz_decode_FPU_RSP_180};
+  assign _zz__zz_decode_FPU_RSP_183 = _zz_decode_FPU_RSP_3;
+  assign _zz__zz_decode_FPU_RSP_184 = {_zz__zz_decode_FPU_RSP_185,_zz_decode_FPU_RSP_5};
+  assign _zz__zz_decode_FPU_RSP_188 = (_zz__zz_decode_FPU_RSP_189 == _zz__zz_decode_FPU_RSP_190);
+  assign _zz__zz_decode_FPU_RSP_192 = (|_zz__zz_decode_FPU_RSP_193);
+  assign _zz__zz_decode_FPU_RSP_195 = (|_zz__zz_decode_FPU_RSP_196);
+  assign _zz__zz_decode_FPU_RSP_207 = {_zz__zz_decode_FPU_RSP_208,{_zz__zz_decode_FPU_RSP_209,_zz__zz_decode_FPU_RSP_215}};
+  assign _zz__zz_decode_FPU_RSP_145 = 32'h02000020;
+  assign _zz__zz_decode_FPU_RSP_147 = 32'h00000070;
+  assign _zz__zz_decode_FPU_RSP_154 = 32'h02002060;
+  assign _zz__zz_decode_FPU_RSP_156 = (decode_INSTRUCTION & 32'h00001070);
+  assign _zz__zz_decode_FPU_RSP_157 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_159 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_FPU_RSP_160 = 32'h00000020;
+  assign _zz__zz_decode_FPU_RSP_165 = 32'h00000050;
+  assign _zz__zz_decode_FPU_RSP_167 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_FPU_RSP_168 = 32'h00001030;
+  assign _zz__zz_decode_FPU_RSP_170 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_171) == 32'h00002030);
+  assign _zz__zz_decode_FPU_RSP_172 = _zz_decode_FPU_RSP_6;
+  assign _zz__zz_decode_FPU_RSP_173 = {_zz__zz_decode_FPU_RSP_174,_zz__zz_decode_FPU_RSP_175};
+  assign _zz__zz_decode_FPU_RSP_180 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_181) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_185 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_186) == 32'h0);
+  assign _zz__zz_decode_FPU_RSP_189 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_FPU_RSP_190 = 32'h00004010;
+  assign _zz__zz_decode_FPU_RSP_193 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_194) == 32'h00002010);
+  assign _zz__zz_decode_FPU_RSP_196 = {_zz__zz_decode_FPU_RSP_197,{_zz__zz_decode_FPU_RSP_198,_zz__zz_decode_FPU_RSP_200}};
+  assign _zz__zz_decode_FPU_RSP_208 = (|_zz_decode_FPU_RSP_4);
+  assign _zz__zz_decode_FPU_RSP_209 = (|_zz__zz_decode_FPU_RSP_210);
+  assign _zz__zz_decode_FPU_RSP_215 = {_zz__zz_decode_FPU_RSP_216,{_zz__zz_decode_FPU_RSP_219,_zz__zz_decode_FPU_RSP_222}};
+  assign _zz__zz_decode_FPU_RSP_171 = 32'h00002030;
+  assign _zz__zz_decode_FPU_RSP_174 = ((decode_INSTRUCTION & 32'h00002024) == 32'h00000024);
+  assign _zz__zz_decode_FPU_RSP_175 = ((decode_INSTRUCTION & 32'h00000064) == 32'h0);
+  assign _zz__zz_decode_FPU_RSP_181 = 32'h00000070;
+  assign _zz__zz_decode_FPU_RSP_186 = 32'h00000020;
+  assign _zz__zz_decode_FPU_RSP_194 = 32'h00006014;
+  assign _zz__zz_decode_FPU_RSP_197 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_FPU_RSP_198 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_199) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_200 = {(_zz__zz_decode_FPU_RSP_201 == _zz__zz_decode_FPU_RSP_202),{_zz_decode_FPU_RSP_4,{_zz__zz_decode_FPU_RSP_203,_zz__zz_decode_FPU_RSP_204}}};
+  assign _zz__zz_decode_FPU_RSP_210 = {(_zz__zz_decode_FPU_RSP_211 == _zz__zz_decode_FPU_RSP_212),{_zz__zz_decode_FPU_RSP_213,_zz__zz_decode_FPU_RSP_214}};
+  assign _zz__zz_decode_FPU_RSP_216 = (|{_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_217,_zz__zz_decode_FPU_RSP_218}});
+  assign _zz__zz_decode_FPU_RSP_219 = (|{_zz__zz_decode_FPU_RSP_220,_zz__zz_decode_FPU_RSP_221});
+  assign _zz__zz_decode_FPU_RSP_222 = (|_zz__zz_decode_FPU_RSP_223);
+  assign _zz__zz_decode_FPU_RSP_199 = 32'h00000038;
+  assign _zz__zz_decode_FPU_RSP_201 = (decode_INSTRUCTION & 32'h00004050);
+  assign _zz__zz_decode_FPU_RSP_202 = 32'h00004000;
+  assign _zz__zz_decode_FPU_RSP_203 = ((decode_INSTRUCTION & 32'h00006024) == 32'h00002020);
+  assign _zz__zz_decode_FPU_RSP_204 = {((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_205) == 32'h00001020),((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_206) == 32'h90000010)};
+  assign _zz__zz_decode_FPU_RSP_211 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_FPU_RSP_212 = 32'h00000040;
+  assign _zz__zz_decode_FPU_RSP_213 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_FPU_RSP_214 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_FPU_RSP_217 = _zz_decode_FPU_RSP_1;
+  assign _zz__zz_decode_FPU_RSP_218 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz__zz_decode_FPU_RSP_220 = _zz_decode_FPU_RSP_2;
+  assign _zz__zz_decode_FPU_RSP_221 = _zz_decode_FPU_RSP_1;
+  assign _zz__zz_decode_FPU_RSP_223 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz__zz_decode_FPU_RSP_205 = 32'h00005024;
+  assign _zz__zz_decode_FPU_RSP_206 = 32'h90000034;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -2156,1430 +2093,1413 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   FpuCore FpuPlugin_fpu (
-    .io_port_0_cmd_valid                      (FpuPlugin_port_cmd_valid                             ), //i
-    .io_port_0_cmd_ready                      (FpuPlugin_fpu_io_port_0_cmd_ready                    ), //o
-    .io_port_0_cmd_payload_opcode             (FpuPlugin_port_cmd_payload_opcode                    ), //i
-    .io_port_0_cmd_payload_arg                (FpuPlugin_port_cmd_payload_arg                       ), //i
-    .io_port_0_cmd_payload_rs1                (FpuPlugin_port_cmd_payload_rs1                       ), //i
-    .io_port_0_cmd_payload_rs2                (FpuPlugin_port_cmd_payload_rs2                       ), //i
-    .io_port_0_cmd_payload_rs3                (FpuPlugin_port_cmd_payload_rs3                       ), //i
-    .io_port_0_cmd_payload_rd                 (FpuPlugin_port_cmd_payload_rd                        ), //i
-    .io_port_0_cmd_payload_format             (FpuPlugin_port_cmd_payload_format                    ), //i
-    .io_port_0_cmd_payload_roundMode          (FpuPlugin_port_cmd_payload_roundMode                 ), //i
-    .io_port_0_commit_valid                   (FpuPlugin_port_commit_valid                          ), //i
-    .io_port_0_commit_ready                   (FpuPlugin_fpu_io_port_0_commit_ready                 ), //o
-    .io_port_0_commit_payload_opcode          (FpuPlugin_port_commit_payload_opcode                 ), //i
-    .io_port_0_commit_payload_rd              (FpuPlugin_port_commit_payload_rd                     ), //i
-    .io_port_0_commit_payload_write           (FpuPlugin_port_commit_payload_write                  ), //i
-    .io_port_0_commit_payload_value           (FpuPlugin_port_commit_payload_value                  ), //i
-    .io_port_0_rsp_valid                      (FpuPlugin_fpu_io_port_0_rsp_valid                    ), //o
-    .io_port_0_rsp_ready                      (FpuPlugin_port_rsp_ready                             ), //i
-    .io_port_0_rsp_payload_value              (FpuPlugin_fpu_io_port_0_rsp_payload_value            ), //o
-    .io_port_0_rsp_payload_NV                 (FpuPlugin_fpu_io_port_0_rsp_payload_NV               ), //o
-    .io_port_0_rsp_payload_NX                 (FpuPlugin_fpu_io_port_0_rsp_payload_NX               ), //o
-    .io_port_0_completion_valid               (FpuPlugin_fpu_io_port_0_completion_valid             ), //o
-    .io_port_0_completion_payload_flags_NX    (FpuPlugin_fpu_io_port_0_completion_payload_flags_NX  ), //o
-    .io_port_0_completion_payload_flags_UF    (FpuPlugin_fpu_io_port_0_completion_payload_flags_UF  ), //o
-    .io_port_0_completion_payload_flags_OF    (FpuPlugin_fpu_io_port_0_completion_payload_flags_OF  ), //o
-    .io_port_0_completion_payload_flags_DZ    (FpuPlugin_fpu_io_port_0_completion_payload_flags_DZ  ), //o
-    .io_port_0_completion_payload_flags_NV    (FpuPlugin_fpu_io_port_0_completion_payload_flags_NV  ), //o
-    .io_port_0_completion_payload_written     (FpuPlugin_fpu_io_port_0_completion_payload_written   ), //o
-    .clk                                      (clk                                                  ), //i
-    .reset                                    (reset                                                )  //i
+    .io_port_0_cmd_valid                   (FpuPlugin_port_cmd_valid                           ), //i
+    .io_port_0_cmd_ready                   (FpuPlugin_fpu_io_port_0_cmd_ready                  ), //o
+    .io_port_0_cmd_payload_opcode          (FpuPlugin_port_cmd_payload_opcode[3:0]             ), //i
+    .io_port_0_cmd_payload_arg             (FpuPlugin_port_cmd_payload_arg[1:0]                ), //i
+    .io_port_0_cmd_payload_rs1             (FpuPlugin_port_cmd_payload_rs1[4:0]                ), //i
+    .io_port_0_cmd_payload_rs2             (FpuPlugin_port_cmd_payload_rs2[4:0]                ), //i
+    .io_port_0_cmd_payload_rs3             (FpuPlugin_port_cmd_payload_rs3[4:0]                ), //i
+    .io_port_0_cmd_payload_rd              (FpuPlugin_port_cmd_payload_rd[4:0]                 ), //i
+    .io_port_0_cmd_payload_format          (FpuPlugin_port_cmd_payload_format                  ), //i
+    .io_port_0_cmd_payload_roundMode       (FpuPlugin_port_cmd_payload_roundMode[2:0]          ), //i
+    .io_port_0_commit_valid                (FpuPlugin_port_commit_valid                        ), //i
+    .io_port_0_commit_ready                (FpuPlugin_fpu_io_port_0_commit_ready               ), //o
+    .io_port_0_commit_payload_opcode       (FpuPlugin_port_commit_payload_opcode[3:0]          ), //i
+    .io_port_0_commit_payload_rd           (FpuPlugin_port_commit_payload_rd[4:0]              ), //i
+    .io_port_0_commit_payload_write        (FpuPlugin_port_commit_payload_write                ), //i
+    .io_port_0_commit_payload_value        (FpuPlugin_port_commit_payload_value[31:0]          ), //i
+    .io_port_0_rsp_valid                   (FpuPlugin_fpu_io_port_0_rsp_valid                  ), //o
+    .io_port_0_rsp_ready                   (FpuPlugin_port_rsp_ready                           ), //i
+    .io_port_0_rsp_payload_value           (FpuPlugin_fpu_io_port_0_rsp_payload_value[31:0]    ), //o
+    .io_port_0_rsp_payload_NV              (FpuPlugin_fpu_io_port_0_rsp_payload_NV             ), //o
+    .io_port_0_rsp_payload_NX              (FpuPlugin_fpu_io_port_0_rsp_payload_NX             ), //o
+    .io_port_0_completion_valid            (FpuPlugin_fpu_io_port_0_completion_valid           ), //o
+    .io_port_0_completion_payload_flags_NX (FpuPlugin_fpu_io_port_0_completion_payload_flags_NX), //o
+    .io_port_0_completion_payload_flags_UF (FpuPlugin_fpu_io_port_0_completion_payload_flags_UF), //o
+    .io_port_0_completion_payload_flags_OF (FpuPlugin_fpu_io_port_0_completion_payload_flags_OF), //o
+    .io_port_0_completion_payload_flags_DZ (FpuPlugin_fpu_io_port_0_completion_payload_flags_DZ), //o
+    .io_port_0_completion_payload_flags_NV (FpuPlugin_fpu_io_port_0_completion_payload_flags_NV), //o
+    .io_port_0_completion_payload_written  (FpuPlugin_fpu_io_port_0_completion_payload_written ), //o
+    .clk                                   (clk                                                ), //i
+    .reset                                 (reset                                              )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : memory_FPU_OPCODE_string = "FCVT_X_X";
       default : memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_memory_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_memory_to_writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : execute_FPU_OPCODE_string = "FCVT_X_X";
       default : execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_execute_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_execute_to_memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_execute_to_memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_execute_to_memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_execute_to_memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_execute_to_memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_execute_to_memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_execute_to_memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_execute_to_memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_execute_to_memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_execute_to_memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_execute_to_memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_execute_to_memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_execute_to_memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_execute_to_memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_execute_to_memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_execute_to_memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_execute_to_memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_execute_to_memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_execute_to_memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_execute_to_memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_execute_to_memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_execute_to_memory_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_execute_to_memory_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_execute_to_memory_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_execute_to_memory_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_execute_to_memory_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_execute_to_memory_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_execute_to_memory_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_execute_to_memory_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_execute_to_memory_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_execute_to_memory_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_execute_to_memory_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_execute_to_memory_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_execute_to_memory_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_execute_to_memory_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_execute_to_memory_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_execute_to_memory_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_execute_to_memory_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_execute_to_memory_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_execute_to_memory_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_execute_to_memory_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_execute_to_memory_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_to_execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_to_execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_to_execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_to_execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_to_execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_to_execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_to_execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_to_execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_to_execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_to_execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_to_execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_to_execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_to_execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_to_execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_to_execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_to_execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_to_execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_to_execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_to_execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_to_execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_decode_to_execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_to_execute_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_to_execute_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_to_execute_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_to_execute_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_to_execute_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_to_execute_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_to_execute_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_to_execute_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_to_execute_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_to_execute_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_to_execute_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_to_execute_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_to_execute_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_to_execute_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_to_execute_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_to_execute_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_to_execute_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_to_execute_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_to_execute_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_to_execute_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_decode_to_execute_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : decode_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : decode_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : decode_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : decode_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : decode_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : decode_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : decode_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : decode_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : decode_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : decode_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_FPU_OPCODE_string = "FCVT_X_X";
       default : decode_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_decode_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_decode_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_cmd_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : FpuPlugin_port_cmd_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : FpuPlugin_port_cmd_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : FpuPlugin_port_cmd_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : FpuPlugin_port_cmd_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : FpuPlugin_port_cmd_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : FpuPlugin_port_cmd_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : FpuPlugin_port_cmd_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : FpuPlugin_port_cmd_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : FpuPlugin_port_cmd_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : FpuPlugin_port_cmd_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : FpuPlugin_port_cmd_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : FpuPlugin_port_cmd_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : FpuPlugin_port_cmd_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : FpuPlugin_port_cmd_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : FpuPlugin_port_cmd_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : FpuPlugin_port_cmd_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : FpuPlugin_port_cmd_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : FpuPlugin_port_cmd_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : FpuPlugin_port_cmd_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : FpuPlugin_port_cmd_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : FpuPlugin_port_cmd_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : FpuPlugin_port_cmd_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : FpuPlugin_port_cmd_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : FpuPlugin_port_cmd_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : FpuPlugin_port_cmd_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : FpuPlugin_port_cmd_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : FpuPlugin_port_cmd_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : FpuPlugin_port_cmd_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : FpuPlugin_port_cmd_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : FpuPlugin_port_cmd_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : FpuPlugin_port_cmd_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : FpuPlugin_port_cmd_payload_opcode_string = "FCVT_X_X";
       default : FpuPlugin_port_cmd_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_cmd_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : FpuPlugin_port_cmd_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : FpuPlugin_port_cmd_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : FpuPlugin_port_cmd_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : FpuPlugin_port_cmd_payload_format_string = "DOUBLE";
       default : FpuPlugin_port_cmd_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_cmd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
       default : FpuPlugin_port_cmd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_commit_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : FpuPlugin_port_commit_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : FpuPlugin_port_commit_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : FpuPlugin_port_commit_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : FpuPlugin_port_commit_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : FpuPlugin_port_commit_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : FpuPlugin_port_commit_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : FpuPlugin_port_commit_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : FpuPlugin_port_commit_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : FpuPlugin_port_commit_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : FpuPlugin_port_commit_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : FpuPlugin_port_commit_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : FpuPlugin_port_commit_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : FpuPlugin_port_commit_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : FpuPlugin_port_commit_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : FpuPlugin_port_commit_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : FpuPlugin_port_commit_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : FpuPlugin_port_commit_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : FpuPlugin_port_commit_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : FpuPlugin_port_commit_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : FpuPlugin_port_commit_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : FpuPlugin_port_commit_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : FpuPlugin_port_commit_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : FpuPlugin_port_commit_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : FpuPlugin_port_commit_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : FpuPlugin_port_commit_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : FpuPlugin_port_commit_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : FpuPlugin_port_commit_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : FpuPlugin_port_commit_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : FpuPlugin_port_commit_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : FpuPlugin_port_commit_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : FpuPlugin_port_commit_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : FpuPlugin_port_commit_payload_opcode_string = "FCVT_X_X";
       default : FpuPlugin_port_commit_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_FPU_OPCODE_2)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_FPU_OPCODE_2_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_FPU_OPCODE_2_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_FPU_OPCODE_2_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_FPU_OPCODE_2_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_FPU_OPCODE_2_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_FPU_OPCODE_2_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_FPU_OPCODE_2_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_FPU_OPCODE_2_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_FPU_OPCODE_2_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_FPU_OPCODE_2_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_FPU_OPCODE_2_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_FPU_OPCODE_2_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_FPU_OPCODE_2_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_FPU_OPCODE_2_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_FPU_OPCODE_2_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_FPU_OPCODE_2_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_FPU_OPCODE_2_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_FPU_OPCODE_2_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_FPU_OPCODE_2_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_FPU_OPCODE_2_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_FPU_OPCODE_2_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_FPU_OPCODE_2_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_FPU_OPCODE_2_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_FPU_OPCODE_2_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_FPU_OPCODE_2_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_FPU_OPCODE_2_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_FPU_OPCODE_2_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_FPU_OPCODE_2_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_FPU_OPCODE_2_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_FPU_OPCODE_2_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_FPU_OPCODE_2_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_FPU_OPCODE_2_string = "FCVT_X_X";
       default : _zz_decode_FPU_OPCODE_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_FpuPlugin_port_cmd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
       default : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_FpuPlugin_port_cmd_payload_roundMode_1)
-      `FpuRoundMode_opt_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RMM";
+      FpuRoundMode_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RNE";
+      FpuRoundMode_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RTZ";
+      FpuRoundMode_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RDN";
+      FpuRoundMode_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RUP";
+      FpuRoundMode_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RMM";
       default : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "???";
     endcase
   end
   always @(*) begin
     case(writeBack_FpuPlugin_commit_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FpuPlugin_commit_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FpuPlugin_commit_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FpuPlugin_commit_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FpuPlugin_commit_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FpuPlugin_commit_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FpuPlugin_commit_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FpuPlugin_commit_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FpuPlugin_commit_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FpuPlugin_commit_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FpuPlugin_commit_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FpuPlugin_commit_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FpuPlugin_commit_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FpuPlugin_commit_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FpuPlugin_commit_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FpuPlugin_commit_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FpuPlugin_commit_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FpuPlugin_commit_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FpuPlugin_commit_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FpuPlugin_commit_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FpuPlugin_commit_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FpuPlugin_commit_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FpuPlugin_commit_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FpuPlugin_commit_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FpuPlugin_commit_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FpuPlugin_commit_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FpuPlugin_commit_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FCVT_X_X";
       default : writeBack_FpuPlugin_commit_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(writeBack_FpuPlugin_commit_s2mPipe_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
       default : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(writeBack_FpuPlugin_commit_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FpuPlugin_commit_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FpuPlugin_commit_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FpuPlugin_commit_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FpuPlugin_commit_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FpuPlugin_commit_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FpuPlugin_commit_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FpuPlugin_commit_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FpuPlugin_commit_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FpuPlugin_commit_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FpuPlugin_commit_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FpuPlugin_commit_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FpuPlugin_commit_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FpuPlugin_commit_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FpuPlugin_commit_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FpuPlugin_commit_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FpuPlugin_commit_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FpuPlugin_commit_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FpuPlugin_commit_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FpuPlugin_commit_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FpuPlugin_commit_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FpuPlugin_commit_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FpuPlugin_commit_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FpuPlugin_commit_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FpuPlugin_commit_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FpuPlugin_commit_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FpuPlugin_commit_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FCVT_X_X";
       default : writeBack_FpuPlugin_commit_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
       default : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : decode_to_execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_to_execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_to_execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_to_execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_to_execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_to_execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_to_execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_to_execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_to_execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_to_execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_to_execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : decode_to_execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : decode_to_execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : decode_to_execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : decode_to_execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : decode_to_execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : decode_to_execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : decode_to_execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : decode_to_execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : decode_to_execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
       default : decode_to_execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : execute_to_memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : execute_to_memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : execute_to_memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : execute_to_memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : execute_to_memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : execute_to_memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : execute_to_memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : execute_to_memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : execute_to_memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : execute_to_memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : execute_to_memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : execute_to_memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : execute_to_memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : execute_to_memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : execute_to_memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : execute_to_memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : execute_to_memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : execute_to_memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : execute_to_memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : execute_to_memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
       default : execute_to_memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : memory_to_writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
@@ -3600,7 +3520,7 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign memory_FPU_COMMIT_LOAD = execute_to_memory_FPU_COMMIT_LOAD;
   assign execute_FPU_COMMIT_LOAD = decode_to_execute_FPU_COMMIT_LOAD;
-  assign decode_FPU_COMMIT_LOAD = (decode_FPU_OPCODE == `FpuOpcode_binary_sequential_LOAD);
+  assign decode_FPU_COMMIT_LOAD = (decode_FPU_OPCODE == FpuOpcode_LOAD);
   assign memory_FPU_FORKED = execute_to_memory_FPU_FORKED;
   assign execute_FPU_FORKED = decode_to_execute_FPU_FORKED;
   assign decode_FPU_FORKED = (decode_FpuPlugin_forked || FpuPlugin_port_cmd_fire_2);
@@ -3718,14 +3638,13 @@ module VexRiscv (
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_FPU_RSP[15];
   assign decode_RS1_USE = _zz_decode_FPU_RSP[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -3801,10 +3720,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -3850,10 +3769,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h06000073) == 32'h00000043),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 30'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h06000073) == 32'h00000043),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -3880,6 +3799,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -3937,7 +3857,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
     if(when_FpuPlugin_l238) begin
@@ -3956,7 +3876,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3984,15 +3904,15 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -4001,7 +3921,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
     if(when_FpuPlugin_l214) begin
@@ -4060,7 +3980,7 @@ module VexRiscv (
 
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -4102,10 +4022,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -4116,29 +4036,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -4152,21 +4074,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4207,9 +4129,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -4232,7 +4154,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -4294,24 +4216,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -4336,7 +4264,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -4382,7 +4310,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -4430,7 +4358,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4511,12 +4439,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -4534,7 +4462,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -4553,9 +4481,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -4565,12 +4495,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -4589,7 +4519,7 @@ module VexRiscv (
 
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -4599,7 +4529,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -4618,7 +4548,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -4631,8 +4561,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -4645,7 +4575,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -4697,7 +4627,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -4710,7 +4640,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -4738,10 +4668,9 @@ module VexRiscv (
   assign _zz_decode_FPU_RSP_7 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000028);
   assign _zz_decode_FPU_RSP_8 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_FPU_RSP_9 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_decode_FPU_RSP_10 = ((decode_INSTRUCTION & 32'h0000005c) == 32'h00000004);
-  assign _zz_decode_FPU_RSP_11 = ((decode_INSTRUCTION & 32'h10003070) == 32'h00000070);
-  assign _zz_decode_FPU_RSP_12 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_FPU_RSP = {({_zz_decode_FPU_RSP_8,(_zz__zz_decode_FPU_RSP == _zz__zz_decode_FPU_RSP_1)} != 2'b00),{({_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_2,_zz__zz_decode_FPU_RSP_4}} != 4'b0000),{1'b0,{(_zz__zz_decode_FPU_RSP_9 != _zz__zz_decode_FPU_RSP_16),{_zz__zz_decode_FPU_RSP_17,{_zz__zz_decode_FPU_RSP_22,_zz__zz_decode_FPU_RSP_35}}}}}};
+  assign _zz_decode_FPU_RSP_10 = ((decode_INSTRUCTION & 32'h10003070) == 32'h00000070);
+  assign _zz_decode_FPU_RSP_11 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_FPU_RSP = {(|{_zz_decode_FPU_RSP_8,(_zz__zz_decode_FPU_RSP == _zz__zz_decode_FPU_RSP_1)}),{(|{_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_2,_zz__zz_decode_FPU_RSP_4}}),{1'b0,{(|_zz__zz_decode_FPU_RSP_9),{_zz__zz_decode_FPU_RSP_16,{_zz__zz_decode_FPU_RSP_21,_zz__zz_decode_FPU_RSP_34}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_FPU_RSP[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_FPU_RSP[7 : 6];
@@ -4789,10 +4718,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -4803,10 +4732,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -4817,13 +4746,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1_1 = _zz_execute_SRC1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1_1 = {29'd0, _zz__zz_execute_SRC1_1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1_1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -4882,13 +4811,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -4941,7 +4870,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -5058,9 +4987,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -5078,13 +5007,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -5157,10 +5086,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -5172,7 +5101,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -5207,11 +5136,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -5271,9 +5200,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -5318,28 +5247,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -5347,7 +5276,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -5385,14 +5314,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5502,18 +5431,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -5521,20 +5450,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5547,20 +5476,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5569,9 +5498,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -5582,8 +5511,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -5676,7 +5605,7 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
   assign FpuPlugin_port_cmd_ready = FpuPlugin_fpu_io_port_0_cmd_ready;
   assign FpuPlugin_port_commit_ready = FpuPlugin_fpu_io_port_0_commit_ready;
   assign FpuPlugin_port_rsp_valid = FpuPlugin_fpu_io_port_0_rsp_valid;
@@ -5701,7 +5630,7 @@ module VexRiscv (
   assign FpuPlugin_csrActive = (execute_arbitration_isValid && execute_IS_CSR);
   assign when_FpuPlugin_l214 = (FpuPlugin_csrActive && FpuPlugin_hasPending);
   assign FpuPlugin_sd = (FpuPlugin_fs == 2'b11);
-  assign when_FpuPlugin_l219 = ((writeBack_arbitration_isFiring && writeBack_FPU_ENABLE) && (writeBack_FPU_OPCODE != `FpuOpcode_binary_sequential_STORE));
+  assign when_FpuPlugin_l219 = ((writeBack_arbitration_isFiring && writeBack_FPU_ENABLE) && (writeBack_FPU_OPCODE != FpuOpcode_STORE));
   assign FpuPlugin_port_cmd_fire_1 = (FpuPlugin_port_cmd_valid && FpuPlugin_port_cmd_ready);
   assign when_FpuPlugin_l234 = (! decode_arbitration_isStuck);
   assign decode_FpuPlugin_hazard = (FpuPlugin_pendings[5] || FpuPlugin_csrActive);
@@ -5716,7 +5645,7 @@ module VexRiscv (
   assign FpuPlugin_port_cmd_payload_rs2 = decode_INSTRUCTION[24 : 20];
   assign FpuPlugin_port_cmd_payload_rs3 = decode_INSTRUCTION[31 : 27];
   assign FpuPlugin_port_cmd_payload_rd = decode_INSTRUCTION[11 : 7];
-  assign FpuPlugin_port_cmd_payload_format = `FpuFormat_binary_sequential_FLOAT;
+  assign FpuPlugin_port_cmd_payload_format = FpuFormat_FLOAT;
   assign _zz_FpuPlugin_port_cmd_payload_roundMode_1 = decode_FpuPlugin_roundMode;
   assign _zz_FpuPlugin_port_cmd_payload_roundMode = _zz_FpuPlugin_port_cmd_payload_roundMode_1;
   assign FpuPlugin_port_cmd_payload_roundMode = _zz_FpuPlugin_port_cmd_payload_roundMode;
@@ -5900,34 +5829,34 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5965,12 +5894,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[14 : 13] = FpuPlugin_fs;
       _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = FpuPlugin_sd;
     end
@@ -6134,8 +6064,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_29 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26) | (_zz_CsrPlugin_csrMapping_readDataInit_27 | _zz_CsrPlugin_csrMapping_readDataInit_28))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -6191,11 +6121,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -6207,6 +6135,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -6248,16 +6178,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -6275,13 +6205,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6290,7 +6220,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6299,7 +6229,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6308,7 +6238,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6331,51 +6261,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -6384,7 +6318,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -6395,8 +6329,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -6406,7 +6340,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       FpuPlugin_pendings <= (_zz_FpuPlugin_pendings - _zz_FpuPlugin_pendings_6);
       if(when_FpuPlugin_l199) begin
@@ -6486,9 +6420,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
           FpuPlugin_fs <= CsrPlugin_csrMapping_writeDataSignal[14 : 13];
         end
       end
@@ -6497,6 +6437,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -6582,10 +6542,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -6602,21 +6558,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -6895,88 +6851,88 @@ module VexRiscv (
     if(when_Pipeline_l124_81) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1264_24) begin
+    if(when_CsrPlugin_l1277_24) begin
       execute_CsrPlugin_csr_3 <= (decode_INSTRUCTION[31 : 20] == 12'h003);
     end
-    if(when_CsrPlugin_l1264_25) begin
+    if(when_CsrPlugin_l1277_25) begin
       execute_CsrPlugin_csr_2 <= (decode_INSTRUCTION[31 : 20] == 12'h002);
     end
-    if(when_CsrPlugin_l1264_26) begin
+    if(when_CsrPlugin_l1277_26) begin
       execute_CsrPlugin_csr_1 <= (decode_INSTRUCTION[31 : 20] == 12'h001);
     end
-    if(when_CsrPlugin_l1264_27) begin
+    if(when_CsrPlugin_l1277_27) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -7011,26 +6967,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -7041,17 +6977,17 @@ endmodule
 module FpuCore (
   input               io_port_0_cmd_valid,
   output              io_port_0_cmd_ready,
-  input      `FpuOpcode_binary_sequential_type io_port_0_cmd_payload_opcode,
+  input      [3:0]    io_port_0_cmd_payload_opcode,
   input      [1:0]    io_port_0_cmd_payload_arg,
   input      [4:0]    io_port_0_cmd_payload_rs1,
   input      [4:0]    io_port_0_cmd_payload_rs2,
   input      [4:0]    io_port_0_cmd_payload_rs3,
   input      [4:0]    io_port_0_cmd_payload_rd,
-  input      `FpuFormat_binary_sequential_type io_port_0_cmd_payload_format,
-  input      `FpuRoundMode_opt_type io_port_0_cmd_payload_roundMode,
+  input      [0:0]    io_port_0_cmd_payload_format,
+  input      [2:0]    io_port_0_cmd_payload_roundMode,
   input               io_port_0_commit_valid,
   output              io_port_0_commit_ready,
-  input      `FpuOpcode_binary_sequential_type io_port_0_commit_payload_opcode,
+  input      [3:0]    io_port_0_commit_payload_opcode,
   input      [4:0]    io_port_0_commit_payload_rd,
   input               io_port_0_commit_payload_write,
   input      [31:0]   io_port_0_commit_payload_value,
@@ -7070,6 +7006,30 @@ module FpuCore (
   input               clk,
   input               reset
 );
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+  localparam FpuFormat_FLOAT = 1'd0;
+  localparam FpuFormat_DOUBLE = 1'd1;
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire                streamFork_1_io_outputs_1_ready;
   wire                div_divider_io_input_valid;
   wire       [23:0]   div_divider_io_input_payload_a;
@@ -7091,25 +7051,25 @@ module FpuCore (
   wire       [0:0]    _zz_rf_scoreboards_0_writes_port1;
   wire                streamFork_1_io_input_ready;
   wire                streamFork_1_io_outputs_0_valid;
-  wire       `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_0_payload_opcode;
+  wire       [3:0]    streamFork_1_io_outputs_0_payload_opcode;
   wire       [4:0]    streamFork_1_io_outputs_0_payload_rd;
   wire                streamFork_1_io_outputs_0_payload_write;
   wire       [31:0]   streamFork_1_io_outputs_0_payload_value;
   wire                streamFork_1_io_outputs_1_valid;
-  wire       `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_1_payload_opcode;
+  wire       [3:0]    streamFork_1_io_outputs_1_payload_opcode;
   wire       [4:0]    streamFork_1_io_outputs_1_payload_rd;
   wire                streamFork_1_io_outputs_1_payload_write;
   wire       [31:0]   streamFork_1_io_outputs_1_payload_value;
   wire                cmdArbiter_arbiter_io_inputs_0_ready;
   wire                cmdArbiter_arbiter_io_output_valid;
-  wire       `FpuOpcode_binary_sequential_type cmdArbiter_arbiter_io_output_payload_opcode;
+  wire       [3:0]    cmdArbiter_arbiter_io_output_payload_opcode;
   wire       [1:0]    cmdArbiter_arbiter_io_output_payload_arg;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rs1;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rs2;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rs3;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rd;
-  wire       `FpuFormat_binary_sequential_type cmdArbiter_arbiter_io_output_payload_format;
-  wire       `FpuRoundMode_opt_type cmdArbiter_arbiter_io_output_payload_roundMode;
+  wire       [0:0]    cmdArbiter_arbiter_io_output_payload_format;
+  wire       [2:0]    cmdArbiter_arbiter_io_output_payload_roundMode;
   wire       [0:0]    cmdArbiter_arbiter_io_chosenOH;
   wire                div_divider_io_input_ready;
   wire                div_divider_io_output_valid;
@@ -7132,7 +7092,7 @@ module FpuCore (
   wire                streamArbiter_2_io_output_payload_value_sign;
   wire                streamArbiter_2_io_output_payload_value_special;
   wire                streamArbiter_2_io_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type streamArbiter_2_io_output_payload_roundMode;
+  wire       [2:0]    streamArbiter_2_io_output_payload_roundMode;
   wire                streamArbiter_2_io_output_payload_NV;
   wire                streamArbiter_2_io_output_payload_DZ;
   wire       [2:0]    streamArbiter_2_io_chosen;
@@ -7170,7 +7130,7 @@ module FpuCore (
   wire       [3:0]    _zz_commitLogic_0_short_counter_3;
   wire       [0:0]    _zz_commitLogic_0_short_counter_4;
   wire       [0:0]    _zz_rf_scoreboards_0_writes_port;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_shortPipHit;
+  wire       [3:0]    _zz_decode_shortPipHit;
   wire                _zz_decode_shortPipHit_1;
   wire       [0:0]    _zz_decode_shortPipHit_2;
   wire       [0:0]    _zz_decode_shortPipHit_3;
@@ -7325,28 +7285,28 @@ module FpuCore (
   reg                 rf_scoreboards_0_hitWrite_payload_data;
   wire                commitFork_load_0_valid;
   reg                 commitFork_load_0_ready;
-  wire       `FpuOpcode_binary_sequential_type commitFork_load_0_payload_opcode;
+  wire       [3:0]    commitFork_load_0_payload_opcode;
   wire       [4:0]    commitFork_load_0_payload_rd;
   wire                commitFork_load_0_payload_write;
   wire       [31:0]   commitFork_load_0_payload_value;
   wire                commitFork_commit_0_valid;
   wire                commitFork_commit_0_ready;
-  wire       `FpuOpcode_binary_sequential_type commitFork_commit_0_payload_opcode;
+  wire       [3:0]    commitFork_commit_0_payload_opcode;
   wire       [4:0]    commitFork_commit_0_payload_rd;
   wire                commitFork_commit_0_payload_write;
   wire       [31:0]   commitFork_commit_0_payload_value;
   wire                streamFork_1_io_outputs_1_s2mPipe_valid;
   wire                streamFork_1_io_outputs_1_s2mPipe_ready;
-  wire       `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_1_s2mPipe_payload_opcode;
+  wire       [3:0]    streamFork_1_io_outputs_1_s2mPipe_payload_opcode;
   wire       [4:0]    streamFork_1_io_outputs_1_s2mPipe_payload_rd;
   wire                streamFork_1_io_outputs_1_s2mPipe_payload_write;
   wire       [31:0]   streamFork_1_io_outputs_1_s2mPipe_payload_value;
   reg                 streamFork_1_io_outputs_1_rValid;
-  reg        `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_1_rData_opcode;
+  reg        [3:0]    streamFork_1_io_outputs_1_rData_opcode;
   reg        [4:0]    streamFork_1_io_outputs_1_rData_rd;
   reg                 streamFork_1_io_outputs_1_rData_write;
   reg        [31:0]   streamFork_1_io_outputs_1_rData_value;
-  wire       `FpuOpcode_binary_sequential_type _zz_payload_opcode;
+  wire       [3:0]    _zz_payload_opcode;
   reg        [3:0]    commitLogic_0_pending_counter;
   wire                commitLogic_0_pending_full;
   wire                commitLogic_0_pending_notEmpty;
@@ -7378,9 +7338,9 @@ module FpuCore (
   reg                 commitLogic_0_short_inc;
   reg                 commitLogic_0_short_dec;
   wire                _zz_commitFork_commit_0_ready;
-  wire       `FpuOpcode_binary_sequential_type _zz_commitLogic_0_input_payload_opcode;
+  wire       [3:0]    _zz_commitLogic_0_input_payload_opcode;
   wire                commitLogic_0_input_valid;
-  wire       `FpuOpcode_binary_sequential_type commitLogic_0_input_payload_opcode;
+  wire       [3:0]    commitLogic_0_input_payload_opcode;
   wire       [4:0]    commitLogic_0_input_payload_rd;
   wire                commitLogic_0_input_payload_write;
   wire       [31:0]   commitLogic_0_input_payload_value;
@@ -7389,28 +7349,28 @@ module FpuCore (
   wire                when_FpuCore_l210;
   wire                when_FpuCore_l211;
   wire                when_FpuCore_l212;
-  wire                io_port_0_cmd_input_valid;
-  wire                io_port_0_cmd_input_ready;
-  wire       `FpuOpcode_binary_sequential_type io_port_0_cmd_input_payload_opcode;
-  wire       [1:0]    io_port_0_cmd_input_payload_arg;
-  wire       [4:0]    io_port_0_cmd_input_payload_rs1;
-  wire       [4:0]    io_port_0_cmd_input_payload_rs2;
-  wire       [4:0]    io_port_0_cmd_input_payload_rs3;
-  wire       [4:0]    io_port_0_cmd_input_payload_rd;
-  wire       `FpuFormat_binary_sequential_type io_port_0_cmd_input_payload_format;
-  wire       `FpuRoundMode_opt_type io_port_0_cmd_input_payload_roundMode;
+  wire                scheduler_0_input_valid;
+  wire                scheduler_0_input_ready;
+  wire       [3:0]    scheduler_0_input_payload_opcode;
+  wire       [1:0]    scheduler_0_input_payload_arg;
+  wire       [4:0]    scheduler_0_input_payload_rs1;
+  wire       [4:0]    scheduler_0_input_payload_rs2;
+  wire       [4:0]    scheduler_0_input_payload_rs3;
+  wire       [4:0]    scheduler_0_input_payload_rd;
+  wire       [0:0]    scheduler_0_input_payload_format;
+  wire       [2:0]    scheduler_0_input_payload_roundMode;
   reg                 io_port_0_cmd_rValid;
-  reg        `FpuOpcode_binary_sequential_type io_port_0_cmd_rData_opcode;
+  reg        [3:0]    io_port_0_cmd_rData_opcode;
   reg        [1:0]    io_port_0_cmd_rData_arg;
   reg        [4:0]    io_port_0_cmd_rData_rs1;
   reg        [4:0]    io_port_0_cmd_rData_rs2;
   reg        [4:0]    io_port_0_cmd_rData_rs3;
   reg        [4:0]    io_port_0_cmd_rData_rd;
-  reg        `FpuFormat_binary_sequential_type io_port_0_cmd_rData_format;
-  reg        `FpuRoundMode_opt_type io_port_0_cmd_rData_roundMode;
-  wire       `FpuOpcode_binary_sequential_type _zz_io_port_0_cmd_input_payload_opcode;
-  wire       `FpuFormat_binary_sequential_type _zz_io_port_0_cmd_input_payload_format;
-  wire       `FpuRoundMode_opt_type _zz_io_port_0_cmd_input_payload_roundMode;
+  reg        [0:0]    io_port_0_cmd_rData_format;
+  reg        [2:0]    io_port_0_cmd_rData_roundMode;
+  wire       [3:0]    _zz_scheduler_0_input_payload_opcode;
+  wire       [0:0]    _zz_scheduler_0_input_payload_format;
+  wire       [2:0]    _zz_scheduler_0_input_payload_roundMode;
   reg                 scheduler_0_useRs1;
   reg                 scheduler_0_useRs2;
   reg                 scheduler_0_useRs3;
@@ -7432,63 +7392,63 @@ module FpuCore (
   wire                scheduler_0_hits_2;
   wire                scheduler_0_hits_3;
   wire                scheduler_0_hazard;
-  wire                _zz_io_port_0_cmd_input_ready;
+  wire                _zz_scheduler_0_input_ready;
   wire                scheduler_0_output_valid;
   wire                scheduler_0_output_ready;
-  wire       `FpuOpcode_binary_sequential_type scheduler_0_output_payload_opcode;
+  wire       [3:0]    scheduler_0_output_payload_opcode;
   wire       [1:0]    scheduler_0_output_payload_arg;
   reg        [4:0]    scheduler_0_output_payload_rs1;
   wire       [4:0]    scheduler_0_output_payload_rs2;
   wire       [4:0]    scheduler_0_output_payload_rs3;
   wire       [4:0]    scheduler_0_output_payload_rd;
-  wire       `FpuFormat_binary_sequential_type scheduler_0_output_payload_format;
-  wire       `FpuRoundMode_opt_type scheduler_0_output_payload_roundMode;
+  wire       [0:0]    scheduler_0_output_payload_format;
+  wire       [2:0]    scheduler_0_output_payload_roundMode;
   wire                when_FpuCore_l258;
   wire                when_FpuCore_l261;
   wire                scheduler_0_output_fire;
   wire                when_FpuCore_l265;
-  wire       `FpuOpcode_binary_sequential_type _zz_io_inputs_0_payload_opcode;
-  wire       `FpuFormat_binary_sequential_type _zz_io_inputs_0_payload_format;
-  wire       `FpuRoundMode_opt_type _zz_io_inputs_0_payload_roundMode;
+  wire       [3:0]    _zz_io_inputs_0_payload_opcode;
+  wire       [0:0]    _zz_io_inputs_0_payload_format;
+  wire       [2:0]    _zz_io_inputs_0_payload_roundMode;
   wire                cmdArbiter_output_valid;
   wire                cmdArbiter_output_ready;
-  wire       `FpuOpcode_binary_sequential_type cmdArbiter_output_payload_opcode;
+  wire       [3:0]    cmdArbiter_output_payload_opcode;
   wire       [4:0]    cmdArbiter_output_payload_rs1;
   wire       [4:0]    cmdArbiter_output_payload_rs2;
   wire       [4:0]    cmdArbiter_output_payload_rs3;
   wire       [4:0]    cmdArbiter_output_payload_rd;
   wire       [1:0]    cmdArbiter_output_payload_arg;
-  wire       `FpuRoundMode_opt_type cmdArbiter_output_payload_roundMode;
+  wire       [2:0]    cmdArbiter_output_payload_roundMode;
   wire                read_s0_valid;
   reg                 read_s0_ready;
-  wire       `FpuOpcode_binary_sequential_type read_s0_payload_opcode;
+  wire       [3:0]    read_s0_payload_opcode;
   wire       [4:0]    read_s0_payload_rs1;
   wire       [4:0]    read_s0_payload_rs2;
   wire       [4:0]    read_s0_payload_rs3;
   wire       [4:0]    read_s0_payload_rd;
   wire       [1:0]    read_s0_payload_arg;
-  wire       `FpuRoundMode_opt_type read_s0_payload_roundMode;
-  wire                read_s0_s1_valid;
-  wire                read_s0_s1_ready;
-  wire       `FpuOpcode_binary_sequential_type read_s0_s1_payload_opcode;
-  wire       [4:0]    read_s0_s1_payload_rs1;
-  wire       [4:0]    read_s0_s1_payload_rs2;
-  wire       [4:0]    read_s0_s1_payload_rs3;
-  wire       [4:0]    read_s0_s1_payload_rd;
-  wire       [1:0]    read_s0_s1_payload_arg;
-  wire       `FpuRoundMode_opt_type read_s0_s1_payload_roundMode;
+  wire       [2:0]    read_s0_payload_roundMode;
+  wire                read_s1_valid;
+  wire                read_s1_ready;
+  wire       [3:0]    read_s1_payload_opcode;
+  wire       [4:0]    read_s1_payload_rs1;
+  wire       [4:0]    read_s1_payload_rs2;
+  wire       [4:0]    read_s1_payload_rs3;
+  wire       [4:0]    read_s1_payload_rd;
+  wire       [1:0]    read_s1_payload_arg;
+  wire       [2:0]    read_s1_payload_roundMode;
   reg                 read_s0_rValid;
-  reg        `FpuOpcode_binary_sequential_type read_s0_rData_opcode;
+  reg        [3:0]    read_s0_rData_opcode;
   reg        [4:0]    read_s0_rData_rs1;
   reg        [4:0]    read_s0_rData_rs2;
   reg        [4:0]    read_s0_rData_rs3;
   reg        [4:0]    read_s0_rData_rd;
   reg        [1:0]    read_s0_rData_arg;
-  reg        `FpuRoundMode_opt_type read_s0_rData_roundMode;
-  wire                when_Stream_l342;
+  reg        [2:0]    read_s0_rData_roundMode;
+  wire                when_Stream_l368;
   wire                read_output_valid;
   wire                read_output_ready;
-  wire       `FpuOpcode_binary_sequential_type read_output_payload_opcode;
+  wire       [3:0]    read_output_payload_opcode;
   wire       [22:0]   read_output_payload_rs1_mantissa;
   wire       [8:0]    read_output_payload_rs1_exponent;
   wire                read_output_payload_rs1_sign;
@@ -7503,7 +7463,7 @@ module FpuCore (
   wire                read_output_payload_rs3_special;
   wire       [4:0]    read_output_payload_rd;
   wire       [1:0]    read_output_payload_arg;
-  wire       `FpuRoundMode_opt_type read_output_payload_roundMode;
+  wire       [2:0]    read_output_payload_roundMode;
   wire       [4:0]    _zz_read_rs_0_value_mantissa;
   wire                read_output_isStall;
   wire                _zz_read_rs_0_value_mantissa_1;
@@ -7530,7 +7490,7 @@ module FpuCore (
   wire       [33:0]   _zz_read_rs_2_value_mantissa_2;
   wire                decode_input_valid;
   reg                 decode_input_ready;
-  wire       `FpuOpcode_binary_sequential_type decode_input_payload_opcode;
+  wire       [3:0]    decode_input_payload_opcode;
   wire       [22:0]   decode_input_payload_rs1_mantissa;
   wire       [8:0]    decode_input_payload_rs1_exponent;
   wire                decode_input_payload_rs1_sign;
@@ -7545,19 +7505,19 @@ module FpuCore (
   wire                decode_input_payload_rs3_special;
   wire       [4:0]    decode_input_payload_rd;
   wire       [1:0]    decode_input_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_input_payload_roundMode;
+  wire       [2:0]    decode_input_payload_roundMode;
   wire                decode_loadHit;
   wire                decode_load_valid;
   wire                decode_load_ready;
   wire       [4:0]    decode_load_payload_rd;
   wire                decode_load_payload_i2f;
   wire       [1:0]    decode_load_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_payload_roundMode;
+  wire       [2:0]    decode_load_payload_roundMode;
   wire                when_FpuCore_l329;
   wire                decode_shortPipHit;
   wire                decode_shortPip_valid;
   reg                 decode_shortPip_ready;
-  wire       `FpuOpcode_binary_sequential_type decode_shortPip_payload_opcode;
+  wire       [3:0]    decode_shortPip_payload_opcode;
   wire       [22:0]   decode_shortPip_payload_rs1_mantissa;
   wire       [8:0]    decode_shortPip_payload_rs1_exponent;
   wire                decode_shortPip_payload_rs1_sign;
@@ -7569,7 +7529,7 @@ module FpuCore (
   wire       [4:0]    decode_shortPip_payload_rd;
   wire       [31:0]   decode_shortPip_payload_value;
   wire       [1:0]    decode_shortPip_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_shortPip_payload_roundMode;
+  wire       [2:0]    decode_shortPip_payload_roundMode;
   wire                when_FpuCore_l335;
   wire                decode_divSqrtHit;
   wire                decode_divSqrt_valid;
@@ -7584,7 +7544,7 @@ module FpuCore (
   wire                decode_divSqrt_payload_rs2_special;
   wire       [4:0]    decode_divSqrt_payload_rd;
   wire                decode_divSqrt_payload_div;
-  wire       `FpuRoundMode_opt_type decode_divSqrt_payload_roundMode;
+  wire       [2:0]    decode_divSqrt_payload_roundMode;
   wire                decode_divHit;
   wire                decode_div_valid;
   wire                decode_div_ready;
@@ -7597,7 +7557,7 @@ module FpuCore (
   wire                decode_div_payload_rs2_sign;
   wire                decode_div_payload_rs2_special;
   wire       [4:0]    decode_div_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_div_payload_roundMode;
+  wire       [2:0]    decode_div_payload_roundMode;
   wire                when_FpuCore_l351;
   wire                decode_sqrtHit;
   wire                decode_sqrt_valid;
@@ -7607,7 +7567,7 @@ module FpuCore (
   wire                decode_sqrt_payload_rs1_sign;
   wire                decode_sqrt_payload_rs1_special;
   wire       [4:0]    decode_sqrt_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_sqrt_payload_roundMode;
+  wire       [2:0]    decode_sqrt_payload_roundMode;
   wire                when_FpuCore_l359;
   wire                decode_fmaHit;
   wire                decode_mulHit;
@@ -7630,7 +7590,7 @@ module FpuCore (
   reg                 decode_mul_payload_divSqrt;
   reg                 decode_mul_payload_msb1;
   reg                 decode_mul_payload_msb2;
-  reg        `FpuRoundMode_opt_type decode_mul_payload_roundMode;
+  reg        [2:0]    decode_mul_payload_roundMode;
   wire                decode_divSqrtToMul_valid;
   wire                decode_divSqrtToMul_ready;
   wire       [22:0]   decode_divSqrtToMul_payload_rs1_mantissa;
@@ -7650,7 +7610,7 @@ module FpuCore (
   wire                decode_divSqrtToMul_payload_divSqrt;
   wire                decode_divSqrtToMul_payload_msb1;
   wire                decode_divSqrtToMul_payload_msb2;
-  wire       `FpuRoundMode_opt_type decode_divSqrtToMul_payload_roundMode;
+  wire       [2:0]    decode_divSqrtToMul_payload_roundMode;
   wire                when_FpuCore_l375;
   wire                when_FpuCore_l380;
   wire                decode_addHit;
@@ -7665,7 +7625,7 @@ module FpuCore (
   reg                 decode_add_payload_rs2_sign;
   reg                 decode_add_payload_rs2_special;
   reg        [4:0]    decode_add_payload_rd;
-  reg        `FpuRoundMode_opt_type decode_add_payload_roundMode;
+  reg        [2:0]    decode_add_payload_roundMode;
   reg                 decode_add_payload_needCommit;
   wire                decode_mulToAdd_valid;
   wire                decode_mulToAdd_ready;
@@ -7678,7 +7638,7 @@ module FpuCore (
   wire                decode_mulToAdd_payload_rs2_sign;
   wire                decode_mulToAdd_payload_rs2_special;
   wire       [4:0]    decode_mulToAdd_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_mulToAdd_payload_roundMode;
+  wire       [2:0]    decode_mulToAdd_payload_roundMode;
   wire                decode_mulToAdd_payload_needCommit;
   wire                when_FpuCore_l399;
   wire                when_FpuCore_l404;
@@ -7687,67 +7647,67 @@ module FpuCore (
   wire       [4:0]    decode_load_s2mPipe_payload_rd;
   wire                decode_load_s2mPipe_payload_i2f;
   wire       [1:0]    decode_load_s2mPipe_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_s2mPipe_payload_roundMode;
+  wire       [2:0]    decode_load_s2mPipe_payload_roundMode;
   reg                 decode_load_rValid;
   reg        [4:0]    decode_load_rData_rd;
   reg                 decode_load_rData_i2f;
   reg        [1:0]    decode_load_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_load_rData_roundMode;
-  wire       `FpuRoundMode_opt_type _zz_decode_load_s2mPipe_payload_roundMode;
+  reg        [2:0]    decode_load_rData_roundMode;
+  wire       [2:0]    _zz_decode_load_s2mPipe_payload_roundMode;
   wire                decode_load_s2mPipe_m2sPipe_valid;
   reg                 decode_load_s2mPipe_m2sPipe_ready;
   wire       [4:0]    decode_load_s2mPipe_m2sPipe_payload_rd;
   wire                decode_load_s2mPipe_m2sPipe_payload_i2f;
   wire       [1:0]    decode_load_s2mPipe_m2sPipe_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_s2mPipe_m2sPipe_payload_roundMode;
+  wire       [2:0]    decode_load_s2mPipe_m2sPipe_payload_roundMode;
   reg                 decode_load_s2mPipe_rValid;
   reg        [4:0]    decode_load_s2mPipe_rData_rd;
   reg                 decode_load_s2mPipe_rData_i2f;
   reg        [1:0]    decode_load_s2mPipe_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_load_s2mPipe_rData_roundMode;
-  wire                when_Stream_l342_1;
-  wire                decode_load_s2mPipe_m2sPipe_input_valid;
-  wire                decode_load_s2mPipe_m2sPipe_input_ready;
-  wire       [4:0]    decode_load_s2mPipe_m2sPipe_input_payload_rd;
-  wire                decode_load_s2mPipe_m2sPipe_input_payload_i2f;
-  wire       [1:0]    decode_load_s2mPipe_m2sPipe_input_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_s2mPipe_m2sPipe_input_payload_roundMode;
+  reg        [2:0]    decode_load_s2mPipe_rData_roundMode;
+  wire                when_Stream_l368_1;
+  wire                load_s0_input_valid;
+  wire                load_s0_input_ready;
+  wire       [4:0]    load_s0_input_payload_rd;
+  wire                load_s0_input_payload_i2f;
+  wire       [1:0]    load_s0_input_payload_arg;
+  wire       [2:0]    load_s0_input_payload_roundMode;
   reg                 decode_load_s2mPipe_m2sPipe_rValid;
   reg        [4:0]    decode_load_s2mPipe_m2sPipe_rData_rd;
   reg                 decode_load_s2mPipe_m2sPipe_rData_i2f;
   reg        [1:0]    decode_load_s2mPipe_m2sPipe_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_load_s2mPipe_m2sPipe_rData_roundMode;
-  wire                when_Stream_l342_2;
-  wire                when_Stream_l408;
+  reg        [2:0]    decode_load_s2mPipe_m2sPipe_rData_roundMode;
+  wire                when_Stream_l368_2;
+  wire                when_Stream_l438;
   reg                 load_s0_filtred_0_valid;
   reg                 load_s0_filtred_0_ready;
-  wire       `FpuOpcode_binary_sequential_type load_s0_filtred_0_payload_opcode;
+  wire       [3:0]    load_s0_filtred_0_payload_opcode;
   wire       [4:0]    load_s0_filtred_0_payload_rd;
   wire                load_s0_filtred_0_payload_write;
   wire       [31:0]   load_s0_filtred_0_payload_value;
   wire                load_s0_hazard;
-  wire                _zz_decode_load_s2mPipe_m2sPipe_input_ready;
+  wire                _zz_load_s0_input_ready;
   wire                load_s0_output_valid;
   reg                 load_s0_output_ready;
   wire       [4:0]    load_s0_output_payload_rd;
   wire       [31:0]   load_s0_output_payload_value;
   wire                load_s0_output_payload_i2f;
   wire       [1:0]    load_s0_output_payload_arg;
-  wire       `FpuRoundMode_opt_type load_s0_output_payload_roundMode;
-  wire                load_s0_output_input_valid;
-  wire                load_s0_output_input_ready;
-  wire       [4:0]    load_s0_output_input_payload_rd;
-  wire       [31:0]   load_s0_output_input_payload_value;
-  wire                load_s0_output_input_payload_i2f;
-  wire       [1:0]    load_s0_output_input_payload_arg;
-  wire       `FpuRoundMode_opt_type load_s0_output_input_payload_roundMode;
+  wire       [2:0]    load_s0_output_payload_roundMode;
+  wire                load_s1_input_valid;
+  wire                load_s1_input_ready;
+  wire       [4:0]    load_s1_input_payload_rd;
+  wire       [31:0]   load_s1_input_payload_value;
+  wire                load_s1_input_payload_i2f;
+  wire       [1:0]    load_s1_input_payload_arg;
+  wire       [2:0]    load_s1_input_payload_roundMode;
   reg                 load_s0_output_rValid;
   reg        [4:0]    load_s0_output_rData_rd;
   reg        [31:0]   load_s0_output_rData_value;
   reg                 load_s0_output_rData_i2f;
   reg        [1:0]    load_s0_output_rData_arg;
-  reg        `FpuRoundMode_opt_type load_s0_output_rData_roundMode;
-  wire                when_Stream_l342_3;
+  reg        [2:0]    load_s0_output_rData_roundMode;
+  wire                when_Stream_l368_3;
   reg                 load_s1_busy;
   wire       [22:0]   load_s1_f32_mantissa;
   wire       [7:0]    load_s1_f32_exponent;
@@ -7812,7 +7772,7 @@ module FpuCore (
   wire                _zz_load_s1_fsm_shift_by_31;
   wire                _zz_load_s1_fsm_shift_by_32;
   reg        [8:0]    load_s1_fsm_expOffset;
-  wire                load_s0_output_input_isStall;
+  wire                load_s1_input_isStall;
   wire                when_FpuCore_l551;
   wire       [23:0]   load_s1_i2fHigh;
   wire       [7:0]    load_s1_i2fLow;
@@ -7821,7 +7781,7 @@ module FpuCore (
   reg        [8:0]    load_s1_recoded_exponent;
   wire                load_s1_recoded_sign;
   reg                 load_s1_recoded_special;
-  wire                _zz_load_s0_output_input_ready;
+  wire                _zz_load_s1_input_ready;
   wire                load_s1_output_valid;
   reg                 load_s1_output_ready;
   wire       [4:0]    load_s1_output_payload_rd;
@@ -7830,27 +7790,27 @@ module FpuCore (
   reg                 load_s1_output_payload_value_sign;
   reg                 load_s1_output_payload_value_special;
   reg                 load_s1_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type load_s1_output_payload_roundMode;
+  wire       [2:0]    load_s1_output_payload_roundMode;
   wire                load_s1_output_payload_NV;
   wire                load_s1_output_payload_DZ;
   wire                when_FpuCore_l594;
-  wire                decode_shortPip_input_valid;
-  wire                decode_shortPip_input_ready;
-  wire       `FpuOpcode_binary_sequential_type decode_shortPip_input_payload_opcode;
-  wire       [22:0]   decode_shortPip_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_shortPip_input_payload_rs1_exponent;
-  wire                decode_shortPip_input_payload_rs1_sign;
-  wire                decode_shortPip_input_payload_rs1_special;
-  wire       [22:0]   decode_shortPip_input_payload_rs2_mantissa;
-  wire       [8:0]    decode_shortPip_input_payload_rs2_exponent;
-  wire                decode_shortPip_input_payload_rs2_sign;
-  wire                decode_shortPip_input_payload_rs2_special;
-  wire       [4:0]    decode_shortPip_input_payload_rd;
-  wire       [31:0]   decode_shortPip_input_payload_value;
-  wire       [1:0]    decode_shortPip_input_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_shortPip_input_payload_roundMode;
+  wire                shortPip_input_valid;
+  wire                shortPip_input_ready;
+  wire       [3:0]    shortPip_input_payload_opcode;
+  wire       [22:0]   shortPip_input_payload_rs1_mantissa;
+  wire       [8:0]    shortPip_input_payload_rs1_exponent;
+  wire                shortPip_input_payload_rs1_sign;
+  wire                shortPip_input_payload_rs1_special;
+  wire       [22:0]   shortPip_input_payload_rs2_mantissa;
+  wire       [8:0]    shortPip_input_payload_rs2_exponent;
+  wire                shortPip_input_payload_rs2_sign;
+  wire                shortPip_input_payload_rs2_special;
+  wire       [4:0]    shortPip_input_payload_rd;
+  wire       [31:0]   shortPip_input_payload_value;
+  wire       [1:0]    shortPip_input_payload_arg;
+  wire       [2:0]    shortPip_input_payload_roundMode;
   reg                 decode_shortPip_rValid;
-  reg        `FpuOpcode_binary_sequential_type decode_shortPip_rData_opcode;
+  reg        [3:0]    decode_shortPip_rData_opcode;
   reg        [22:0]   decode_shortPip_rData_rs1_mantissa;
   reg        [8:0]    decode_shortPip_rData_rs1_exponent;
   reg                 decode_shortPip_rData_rs1_sign;
@@ -7862,8 +7822,8 @@ module FpuCore (
   reg        [4:0]    decode_shortPip_rData_rd;
   reg        [31:0]   decode_shortPip_rData_value;
   reg        [1:0]    decode_shortPip_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_shortPip_rData_roundMode;
-  wire                when_Stream_l342_4;
+  reg        [2:0]    decode_shortPip_rData_roundMode;
+  wire                when_Stream_l368_4;
   wire                shortPip_toFpuRf;
   wire                shortPip_rfOutput_valid;
   wire                shortPip_rfOutput_ready;
@@ -7873,10 +7833,10 @@ module FpuCore (
   reg                 shortPip_rfOutput_payload_value_sign;
   reg                 shortPip_rfOutput_payload_value_special;
   wire                shortPip_rfOutput_payload_scrap;
-  wire       `FpuRoundMode_opt_type shortPip_rfOutput_payload_roundMode;
+  wire       [2:0]    shortPip_rfOutput_payload_roundMode;
   wire                shortPip_rfOutput_payload_NV;
   wire                shortPip_rfOutput_payload_DZ;
-  wire                decode_shortPip_input_fire;
+  wire                shortPip_input_fire;
   wire                when_FpuCore_l221;
   wire                shortPip_isCommited;
   wire                _zz_shortPip_rfOutput_ready;
@@ -7888,7 +7848,7 @@ module FpuCore (
   wire                shortPip_output_payload_value_sign;
   wire                shortPip_output_payload_value_special;
   wire                shortPip_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type shortPip_output_payload_roundMode;
+  wire       [2:0]    shortPip_output_payload_roundMode;
   wire                shortPip_output_payload_NV;
   wire                shortPip_output_payload_DZ;
   reg        [31:0]   shortPip_result;
@@ -7921,7 +7881,7 @@ module FpuCore (
   wire                when_FpuCore_l658;
   wire       [8:0]    _zz_shortPip_fsm_shift_by;
   wire       [5:0]    _zz_shortPip_fsm_shift_by_1;
-  wire                decode_shortPip_input_isStall;
+  wire                shortPip_input_isStall;
   wire                when_FpuCore_l672;
   reg                 shortPip_mantissaForced;
   reg                 shortPip_exponentForced;
@@ -7949,7 +7909,7 @@ module FpuCore (
   wire                when_FpuCore_l782;
   wire                when_FpuCore_l783;
   wire                when_FpuCore_l784;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   reg                 shortPip_rs1Smaller;
   wire                shortPip_minMaxSelectRs2;
   wire                shortPip_minMaxSelectNanQuiet;
@@ -7986,27 +7946,27 @@ module FpuCore (
   reg        [31:0]   shortPip_rspStreams_0_rData_value;
   reg                 shortPip_rspStreams_0_rData_NV;
   reg                 shortPip_rspStreams_0_rData_NX;
-  wire                when_Stream_l342_5;
-  wire                decode_mul_input_valid;
-  wire                decode_mul_input_ready;
-  wire       [22:0]   decode_mul_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_mul_input_payload_rs1_exponent;
-  wire                decode_mul_input_payload_rs1_sign;
-  wire                decode_mul_input_payload_rs1_special;
-  wire       [22:0]   decode_mul_input_payload_rs2_mantissa;
-  wire       [8:0]    decode_mul_input_payload_rs2_exponent;
-  wire                decode_mul_input_payload_rs2_sign;
-  wire                decode_mul_input_payload_rs2_special;
-  wire       [22:0]   decode_mul_input_payload_rs3_mantissa;
-  wire       [8:0]    decode_mul_input_payload_rs3_exponent;
-  wire                decode_mul_input_payload_rs3_sign;
-  wire                decode_mul_input_payload_rs3_special;
-  wire       [4:0]    decode_mul_input_payload_rd;
-  wire                decode_mul_input_payload_add;
-  wire                decode_mul_input_payload_divSqrt;
-  wire                decode_mul_input_payload_msb1;
-  wire                decode_mul_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type decode_mul_input_payload_roundMode;
+  wire                when_Stream_l368_5;
+  wire                mul_preMul_input_valid;
+  wire                mul_preMul_input_ready;
+  wire       [22:0]   mul_preMul_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_preMul_input_payload_rs1_exponent;
+  wire                mul_preMul_input_payload_rs1_sign;
+  wire                mul_preMul_input_payload_rs1_special;
+  wire       [22:0]   mul_preMul_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_preMul_input_payload_rs2_exponent;
+  wire                mul_preMul_input_payload_rs2_sign;
+  wire                mul_preMul_input_payload_rs2_special;
+  wire       [22:0]   mul_preMul_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_preMul_input_payload_rs3_exponent;
+  wire                mul_preMul_input_payload_rs3_sign;
+  wire                mul_preMul_input_payload_rs3_special;
+  wire       [4:0]    mul_preMul_input_payload_rd;
+  wire                mul_preMul_input_payload_add;
+  wire                mul_preMul_input_payload_divSqrt;
+  wire                mul_preMul_input_payload_msb1;
+  wire                mul_preMul_input_payload_msb2;
+  wire       [2:0]    mul_preMul_input_payload_roundMode;
   reg                 decode_mul_rValid;
   reg        [22:0]   decode_mul_rData_rs1_mantissa;
   reg        [8:0]    decode_mul_rData_rs1_exponent;
@@ -8025,8 +7985,8 @@ module FpuCore (
   reg                 decode_mul_rData_divSqrt;
   reg                 decode_mul_rData_msb1;
   reg                 decode_mul_rData_msb2;
-  reg        `FpuRoundMode_opt_type decode_mul_rData_roundMode;
-  wire                when_Stream_l342_6;
+  reg        [2:0]    decode_mul_rData_roundMode;
+  wire                when_Stream_l368_6;
   wire                mul_preMul_output_valid;
   reg                 mul_preMul_output_ready;
   wire       [22:0]   mul_preMul_output_payload_rs1_mantissa;
@@ -8046,29 +8006,29 @@ module FpuCore (
   wire                mul_preMul_output_payload_divSqrt;
   wire                mul_preMul_output_payload_msb1;
   wire                mul_preMul_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_preMul_output_payload_roundMode;
+  wire       [2:0]    mul_preMul_output_payload_roundMode;
   wire       [9:0]    mul_preMul_output_payload_exp;
-  wire                mul_preMul_output_input_valid;
-  wire                mul_preMul_output_input_ready;
-  wire       [22:0]   mul_preMul_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_preMul_output_input_payload_rs1_exponent;
-  wire                mul_preMul_output_input_payload_rs1_sign;
-  wire                mul_preMul_output_input_payload_rs1_special;
-  wire       [22:0]   mul_preMul_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_preMul_output_input_payload_rs2_exponent;
-  wire                mul_preMul_output_input_payload_rs2_sign;
-  wire                mul_preMul_output_input_payload_rs2_special;
-  wire       [22:0]   mul_preMul_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_preMul_output_input_payload_rs3_exponent;
-  wire                mul_preMul_output_input_payload_rs3_sign;
-  wire                mul_preMul_output_input_payload_rs3_special;
-  wire       [4:0]    mul_preMul_output_input_payload_rd;
-  wire                mul_preMul_output_input_payload_add;
-  wire                mul_preMul_output_input_payload_divSqrt;
-  wire                mul_preMul_output_input_payload_msb1;
-  wire                mul_preMul_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_preMul_output_input_payload_roundMode;
-  wire       [9:0]    mul_preMul_output_input_payload_exp;
+  wire                mul_mul_input_valid;
+  wire                mul_mul_input_ready;
+  wire       [22:0]   mul_mul_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_mul_input_payload_rs1_exponent;
+  wire                mul_mul_input_payload_rs1_sign;
+  wire                mul_mul_input_payload_rs1_special;
+  wire       [22:0]   mul_mul_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_mul_input_payload_rs2_exponent;
+  wire                mul_mul_input_payload_rs2_sign;
+  wire                mul_mul_input_payload_rs2_special;
+  wire       [22:0]   mul_mul_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_mul_input_payload_rs3_exponent;
+  wire                mul_mul_input_payload_rs3_sign;
+  wire                mul_mul_input_payload_rs3_special;
+  wire       [4:0]    mul_mul_input_payload_rd;
+  wire                mul_mul_input_payload_add;
+  wire                mul_mul_input_payload_divSqrt;
+  wire                mul_mul_input_payload_msb1;
+  wire                mul_mul_input_payload_msb2;
+  wire       [2:0]    mul_mul_input_payload_roundMode;
+  wire       [9:0]    mul_mul_input_payload_exp;
   reg                 mul_preMul_output_rValid;
   reg        [22:0]   mul_preMul_output_rData_rs1_mantissa;
   reg        [8:0]    mul_preMul_output_rData_rs1_exponent;
@@ -8087,9 +8047,9 @@ module FpuCore (
   reg                 mul_preMul_output_rData_divSqrt;
   reg                 mul_preMul_output_rData_msb1;
   reg                 mul_preMul_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_preMul_output_rData_roundMode;
+  reg        [2:0]    mul_preMul_output_rData_roundMode;
   reg        [9:0]    mul_preMul_output_rData_exp;
-  wire                when_Stream_l342_7;
+  wire                when_Stream_l368_7;
   wire                mul_mul_output_valid;
   reg                 mul_mul_output_ready;
   wire       [22:0]   mul_mul_output_payload_rs1_mantissa;
@@ -8109,7 +8069,7 @@ module FpuCore (
   wire                mul_mul_output_payload_divSqrt;
   wire                mul_mul_output_payload_msb1;
   wire                mul_mul_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_mul_output_payload_roundMode;
+  wire       [2:0]    mul_mul_output_payload_roundMode;
   wire       [9:0]    mul_mul_output_payload_exp;
   wire       [35:0]   mul_mul_output_payload_muls_0;
   wire       [23:0]   mul_mul_output_payload_muls_1;
@@ -8117,31 +8077,31 @@ module FpuCore (
   wire       [11:0]   mul_mul_output_payload_muls_3;
   wire       [23:0]   mul_mul_mulA;
   wire       [23:0]   mul_mul_mulB;
-  wire                mul_mul_output_input_valid;
-  wire                mul_mul_output_input_ready;
-  wire       [22:0]   mul_mul_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_mul_output_input_payload_rs1_exponent;
-  wire                mul_mul_output_input_payload_rs1_sign;
-  wire                mul_mul_output_input_payload_rs1_special;
-  wire       [22:0]   mul_mul_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_mul_output_input_payload_rs2_exponent;
-  wire                mul_mul_output_input_payload_rs2_sign;
-  wire                mul_mul_output_input_payload_rs2_special;
-  wire       [22:0]   mul_mul_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_mul_output_input_payload_rs3_exponent;
-  wire                mul_mul_output_input_payload_rs3_sign;
-  wire                mul_mul_output_input_payload_rs3_special;
-  wire       [4:0]    mul_mul_output_input_payload_rd;
-  wire                mul_mul_output_input_payload_add;
-  wire                mul_mul_output_input_payload_divSqrt;
-  wire                mul_mul_output_input_payload_msb1;
-  wire                mul_mul_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_mul_output_input_payload_roundMode;
-  wire       [9:0]    mul_mul_output_input_payload_exp;
-  wire       [35:0]   mul_mul_output_input_payload_muls_0;
-  wire       [23:0]   mul_mul_output_input_payload_muls_1;
-  wire       [23:0]   mul_mul_output_input_payload_muls_2;
-  wire       [11:0]   mul_mul_output_input_payload_muls_3;
+  wire                mul_sum1_input_valid;
+  wire                mul_sum1_input_ready;
+  wire       [22:0]   mul_sum1_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_sum1_input_payload_rs1_exponent;
+  wire                mul_sum1_input_payload_rs1_sign;
+  wire                mul_sum1_input_payload_rs1_special;
+  wire       [22:0]   mul_sum1_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_sum1_input_payload_rs2_exponent;
+  wire                mul_sum1_input_payload_rs2_sign;
+  wire                mul_sum1_input_payload_rs2_special;
+  wire       [22:0]   mul_sum1_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_sum1_input_payload_rs3_exponent;
+  wire                mul_sum1_input_payload_rs3_sign;
+  wire                mul_sum1_input_payload_rs3_special;
+  wire       [4:0]    mul_sum1_input_payload_rd;
+  wire                mul_sum1_input_payload_add;
+  wire                mul_sum1_input_payload_divSqrt;
+  wire                mul_sum1_input_payload_msb1;
+  wire                mul_sum1_input_payload_msb2;
+  wire       [2:0]    mul_sum1_input_payload_roundMode;
+  wire       [9:0]    mul_sum1_input_payload_exp;
+  wire       [35:0]   mul_sum1_input_payload_muls_0;
+  wire       [23:0]   mul_sum1_input_payload_muls_1;
+  wire       [23:0]   mul_sum1_input_payload_muls_2;
+  wire       [11:0]   mul_sum1_input_payload_muls_3;
   reg                 mul_mul_output_rValid;
   reg        [22:0]   mul_mul_output_rData_rs1_mantissa;
   reg        [8:0]    mul_mul_output_rData_rs1_exponent;
@@ -8160,13 +8120,13 @@ module FpuCore (
   reg                 mul_mul_output_rData_divSqrt;
   reg                 mul_mul_output_rData_msb1;
   reg                 mul_mul_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_mul_output_rData_roundMode;
+  reg        [2:0]    mul_mul_output_rData_roundMode;
   reg        [9:0]    mul_mul_output_rData_exp;
   reg        [35:0]   mul_mul_output_rData_muls_0;
   reg        [23:0]   mul_mul_output_rData_muls_1;
   reg        [23:0]   mul_mul_output_rData_muls_2;
   reg        [11:0]   mul_mul_output_rData_muls_3;
-  wire                when_Stream_l342_8;
+  wire                when_Stream_l368_8;
   wire       [47:0]   mul_sum1_sum;
   wire                mul_sum1_output_valid;
   reg                 mul_sum1_output_ready;
@@ -8187,35 +8147,35 @@ module FpuCore (
   wire                mul_sum1_output_payload_divSqrt;
   wire                mul_sum1_output_payload_msb1;
   wire                mul_sum1_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum1_output_payload_roundMode;
+  wire       [2:0]    mul_sum1_output_payload_roundMode;
   wire       [9:0]    mul_sum1_output_payload_exp;
   wire       [23:0]   mul_sum1_output_payload_muls2_0;
   wire       [11:0]   mul_sum1_output_payload_muls2_1;
   wire       [47:0]   mul_sum1_output_payload_mulC2;
-  wire                mul_sum1_output_input_valid;
-  wire                mul_sum1_output_input_ready;
-  wire       [22:0]   mul_sum1_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_sum1_output_input_payload_rs1_exponent;
-  wire                mul_sum1_output_input_payload_rs1_sign;
-  wire                mul_sum1_output_input_payload_rs1_special;
-  wire       [22:0]   mul_sum1_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_sum1_output_input_payload_rs2_exponent;
-  wire                mul_sum1_output_input_payload_rs2_sign;
-  wire                mul_sum1_output_input_payload_rs2_special;
-  wire       [22:0]   mul_sum1_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_sum1_output_input_payload_rs3_exponent;
-  wire                mul_sum1_output_input_payload_rs3_sign;
-  wire                mul_sum1_output_input_payload_rs3_special;
-  wire       [4:0]    mul_sum1_output_input_payload_rd;
-  wire                mul_sum1_output_input_payload_add;
-  wire                mul_sum1_output_input_payload_divSqrt;
-  wire                mul_sum1_output_input_payload_msb1;
-  wire                mul_sum1_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum1_output_input_payload_roundMode;
-  wire       [9:0]    mul_sum1_output_input_payload_exp;
-  wire       [23:0]   mul_sum1_output_input_payload_muls2_0;
-  wire       [11:0]   mul_sum1_output_input_payload_muls2_1;
-  wire       [47:0]   mul_sum1_output_input_payload_mulC2;
+  wire                mul_sum2_input_valid;
+  wire                mul_sum2_input_ready;
+  wire       [22:0]   mul_sum2_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_sum2_input_payload_rs1_exponent;
+  wire                mul_sum2_input_payload_rs1_sign;
+  wire                mul_sum2_input_payload_rs1_special;
+  wire       [22:0]   mul_sum2_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_sum2_input_payload_rs2_exponent;
+  wire                mul_sum2_input_payload_rs2_sign;
+  wire                mul_sum2_input_payload_rs2_special;
+  wire       [22:0]   mul_sum2_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_sum2_input_payload_rs3_exponent;
+  wire                mul_sum2_input_payload_rs3_sign;
+  wire                mul_sum2_input_payload_rs3_special;
+  wire       [4:0]    mul_sum2_input_payload_rd;
+  wire                mul_sum2_input_payload_add;
+  wire                mul_sum2_input_payload_divSqrt;
+  wire                mul_sum2_input_payload_msb1;
+  wire                mul_sum2_input_payload_msb2;
+  wire       [2:0]    mul_sum2_input_payload_roundMode;
+  wire       [9:0]    mul_sum2_input_payload_exp;
+  wire       [23:0]   mul_sum2_input_payload_muls2_0;
+  wire       [11:0]   mul_sum2_input_payload_muls2_1;
+  wire       [47:0]   mul_sum2_input_payload_mulC2;
   reg                 mul_sum1_output_rValid;
   reg        [22:0]   mul_sum1_output_rData_rs1_mantissa;
   reg        [8:0]    mul_sum1_output_rData_rs1_exponent;
@@ -8234,17 +8194,17 @@ module FpuCore (
   reg                 mul_sum1_output_rData_divSqrt;
   reg                 mul_sum1_output_rData_msb1;
   reg                 mul_sum1_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_sum1_output_rData_roundMode;
+  reg        [2:0]    mul_sum1_output_rData_roundMode;
   reg        [9:0]    mul_sum1_output_rData_exp;
   reg        [23:0]   mul_sum1_output_rData_muls2_0;
   reg        [11:0]   mul_sum1_output_rData_muls2_1;
   reg        [47:0]   mul_sum1_output_rData_mulC2;
-  wire                when_Stream_l342_9;
+  wire                when_Stream_l368_9;
   wire       [47:0]   mul_sum2_sum;
-  wire                mul_sum1_output_input_fire;
+  wire                mul_sum2_input_fire;
   wire                when_FpuCore_l221_1;
   wire                mul_sum2_isCommited;
-  wire                _zz_mul_sum1_output_input_ready;
+  wire                _zz_mul_sum2_input_ready;
   wire                mul_sum2_output_valid;
   reg                 mul_sum2_output_ready;
   wire       [22:0]   mul_sum2_output_payload_rs1_mantissa;
@@ -8264,31 +8224,31 @@ module FpuCore (
   wire                mul_sum2_output_payload_divSqrt;
   wire                mul_sum2_output_payload_msb1;
   wire                mul_sum2_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum2_output_payload_roundMode;
+  wire       [2:0]    mul_sum2_output_payload_roundMode;
   wire       [9:0]    mul_sum2_output_payload_exp;
   wire       [47:0]   mul_sum2_output_payload_mulC;
-  wire                mul_sum2_output_input_valid;
-  wire                mul_sum2_output_input_ready;
-  wire       [22:0]   mul_sum2_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_sum2_output_input_payload_rs1_exponent;
-  wire                mul_sum2_output_input_payload_rs1_sign;
-  wire                mul_sum2_output_input_payload_rs1_special;
-  wire       [22:0]   mul_sum2_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_sum2_output_input_payload_rs2_exponent;
-  wire                mul_sum2_output_input_payload_rs2_sign;
-  wire                mul_sum2_output_input_payload_rs2_special;
-  wire       [22:0]   mul_sum2_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_sum2_output_input_payload_rs3_exponent;
-  wire                mul_sum2_output_input_payload_rs3_sign;
-  wire                mul_sum2_output_input_payload_rs3_special;
-  wire       [4:0]    mul_sum2_output_input_payload_rd;
-  wire                mul_sum2_output_input_payload_add;
-  wire                mul_sum2_output_input_payload_divSqrt;
-  wire                mul_sum2_output_input_payload_msb1;
-  wire                mul_sum2_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum2_output_input_payload_roundMode;
-  wire       [9:0]    mul_sum2_output_input_payload_exp;
-  wire       [47:0]   mul_sum2_output_input_payload_mulC;
+  wire                mul_norm_input_valid;
+  wire                mul_norm_input_ready;
+  wire       [22:0]   mul_norm_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_norm_input_payload_rs1_exponent;
+  wire                mul_norm_input_payload_rs1_sign;
+  wire                mul_norm_input_payload_rs1_special;
+  wire       [22:0]   mul_norm_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_norm_input_payload_rs2_exponent;
+  wire                mul_norm_input_payload_rs2_sign;
+  wire                mul_norm_input_payload_rs2_special;
+  wire       [22:0]   mul_norm_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_norm_input_payload_rs3_exponent;
+  wire                mul_norm_input_payload_rs3_sign;
+  wire                mul_norm_input_payload_rs3_special;
+  wire       [4:0]    mul_norm_input_payload_rd;
+  wire                mul_norm_input_payload_add;
+  wire                mul_norm_input_payload_divSqrt;
+  wire                mul_norm_input_payload_msb1;
+  wire                mul_norm_input_payload_msb2;
+  wire       [2:0]    mul_norm_input_payload_roundMode;
+  wire       [9:0]    mul_norm_input_payload_exp;
+  wire       [47:0]   mul_norm_input_payload_mulC;
   reg                 mul_sum2_output_rValid;
   reg        [22:0]   mul_sum2_output_rData_rs1_mantissa;
   reg        [8:0]    mul_sum2_output_rData_rs1_exponent;
@@ -8307,10 +8267,10 @@ module FpuCore (
   reg                 mul_sum2_output_rData_divSqrt;
   reg                 mul_sum2_output_rData_msb1;
   reg                 mul_sum2_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_sum2_output_rData_roundMode;
+  reg        [2:0]    mul_sum2_output_rData_roundMode;
   reg        [9:0]    mul_sum2_output_rData_exp;
   reg        [47:0]   mul_sum2_output_rData_mulC;
-  wire                when_Stream_l342_10;
+  wire                when_Stream_l368_10;
   wire       [25:0]   mul_norm_mulHigh;
   wire       [21:0]   mul_norm_mulLow;
   reg                 mul_norm_scrap;
@@ -8342,7 +8302,7 @@ module FpuCore (
   wire                mul_result_output_payload_value_sign;
   wire                mul_result_output_payload_value_special;
   wire                mul_result_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type mul_result_output_payload_roundMode;
+  wire       [2:0]    mul_result_output_payload_roundMode;
   wire                mul_result_output_payload_NV;
   wire                mul_result_output_payload_DZ;
   wire                mul_result_mulToAdd_valid;
@@ -8356,7 +8316,7 @@ module FpuCore (
   wire                mul_result_mulToAdd_payload_rs2_sign;
   wire                mul_result_mulToAdd_payload_rs2_special;
   wire       [4:0]    mul_result_mulToAdd_payload_rd;
-  wire       `FpuRoundMode_opt_type mul_result_mulToAdd_payload_roundMode;
+  wire       [2:0]    mul_result_mulToAdd_payload_roundMode;
   wire                mul_result_mulToAdd_payload_needCommit;
   wire                mul_result_mulToAdd_m2sPipe_valid;
   wire                mul_result_mulToAdd_m2sPipe_ready;
@@ -8369,7 +8329,7 @@ module FpuCore (
   wire                mul_result_mulToAdd_m2sPipe_payload_rs2_sign;
   wire                mul_result_mulToAdd_m2sPipe_payload_rs2_special;
   wire       [4:0]    mul_result_mulToAdd_m2sPipe_payload_rd;
-  wire       `FpuRoundMode_opt_type mul_result_mulToAdd_m2sPipe_payload_roundMode;
+  wire       [2:0]    mul_result_mulToAdd_m2sPipe_payload_roundMode;
   wire                mul_result_mulToAdd_m2sPipe_payload_needCommit;
   reg                 mul_result_mulToAdd_rValid;
   reg        [24:0]   mul_result_mulToAdd_rData_rs1_mantissa;
@@ -8381,23 +8341,23 @@ module FpuCore (
   reg                 mul_result_mulToAdd_rData_rs2_sign;
   reg                 mul_result_mulToAdd_rData_rs2_special;
   reg        [4:0]    mul_result_mulToAdd_rData_rd;
-  reg        `FpuRoundMode_opt_type mul_result_mulToAdd_rData_roundMode;
+  reg        [2:0]    mul_result_mulToAdd_rData_roundMode;
   reg                 mul_result_mulToAdd_rData_needCommit;
-  wire                when_Stream_l342_11;
-  wire                decode_div_input_valid;
-  wire                decode_div_input_ready;
-  wire       [22:0]   decode_div_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_div_input_payload_rs1_exponent;
-  wire                decode_div_input_payload_rs1_sign;
-  wire                decode_div_input_payload_rs1_special;
-  wire       [22:0]   decode_div_input_payload_rs2_mantissa;
-  wire       [8:0]    decode_div_input_payload_rs2_exponent;
-  wire                decode_div_input_payload_rs2_sign;
-  wire                decode_div_input_payload_rs2_special;
-  wire       [4:0]    decode_div_input_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_div_input_payload_roundMode;
+  wire                when_Stream_l368_11;
+  wire                div_input_valid;
+  wire                div_input_ready;
+  wire       [22:0]   div_input_payload_rs1_mantissa;
+  wire       [8:0]    div_input_payload_rs1_exponent;
+  wire                div_input_payload_rs1_sign;
+  wire                div_input_payload_rs1_special;
+  wire       [22:0]   div_input_payload_rs2_mantissa;
+  wire       [8:0]    div_input_payload_rs2_exponent;
+  wire                div_input_payload_rs2_sign;
+  wire                div_input_payload_rs2_special;
+  wire       [4:0]    div_input_payload_rd;
+  wire       [2:0]    div_input_payload_roundMode;
   reg                 decode_div_rValid;
-  wire                decode_div_input_fire;
+  wire                div_input_fire;
   reg        [22:0]   decode_div_rData_rs1_mantissa;
   reg        [8:0]    decode_div_rData_rs1_exponent;
   reg                 decode_div_rData_rs1_sign;
@@ -8407,12 +8367,12 @@ module FpuCore (
   reg                 decode_div_rData_rs2_sign;
   reg                 decode_div_rData_rs2_special;
   reg        [4:0]    decode_div_rData_rd;
-  reg        `FpuRoundMode_opt_type decode_div_rData_roundMode;
+  reg        [2:0]    decode_div_rData_roundMode;
   reg                 div_haltIt;
-  wire                decode_div_input_fire_1;
+  wire                div_input_fire_1;
   wire                when_FpuCore_l221_2;
   reg                 div_isCommited;
-  wire                _zz_decode_div_input_ready;
+  wire                _zz_div_input_ready;
   wire                div_output_valid;
   wire                div_output_ready;
   wire       [4:0]    div_output_payload_rd;
@@ -8421,7 +8381,7 @@ module FpuCore (
   wire                div_output_payload_value_sign;
   reg                 div_output_payload_value_special;
   wire                div_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type div_output_payload_roundMode;
+  wire       [2:0]    div_output_payload_roundMode;
   reg                 div_output_payload_NV;
   wire                div_output_payload_DZ;
   wire       [25:0]   div_dividerResult;
@@ -8443,27 +8403,27 @@ module FpuCore (
   wire                div_forceZero;
   wire                when_FpuCore_l1089;
   wire                when_FpuCore_l1093;
-  wire                decode_sqrt_input_valid;
-  wire                decode_sqrt_input_ready;
-  wire       [22:0]   decode_sqrt_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_sqrt_input_payload_rs1_exponent;
-  wire                decode_sqrt_input_payload_rs1_sign;
-  wire                decode_sqrt_input_payload_rs1_special;
-  wire       [4:0]    decode_sqrt_input_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_sqrt_input_payload_roundMode;
+  wire                sqrt_input_valid;
+  wire                sqrt_input_ready;
+  wire       [22:0]   sqrt_input_payload_rs1_mantissa;
+  wire       [8:0]    sqrt_input_payload_rs1_exponent;
+  wire                sqrt_input_payload_rs1_sign;
+  wire                sqrt_input_payload_rs1_special;
+  wire       [4:0]    sqrt_input_payload_rd;
+  wire       [2:0]    sqrt_input_payload_roundMode;
   reg                 decode_sqrt_rValid;
-  wire                decode_sqrt_input_fire;
+  wire                sqrt_input_fire;
   reg        [22:0]   decode_sqrt_rData_rs1_mantissa;
   reg        [8:0]    decode_sqrt_rData_rs1_exponent;
   reg                 decode_sqrt_rData_rs1_sign;
   reg                 decode_sqrt_rData_rs1_special;
   reg        [4:0]    decode_sqrt_rData_rd;
-  reg        `FpuRoundMode_opt_type decode_sqrt_rData_roundMode;
+  reg        [2:0]    decode_sqrt_rData_roundMode;
   reg                 sqrt_haltIt;
-  wire                decode_sqrt_input_fire_1;
+  wire                sqrt_input_fire_1;
   wire                when_FpuCore_l221_3;
   reg                 sqrt_isCommited;
-  wire                _zz_decode_sqrt_input_ready;
+  wire                _zz_sqrt_input_ready;
   wire                sqrt_output_valid;
   wire                sqrt_output_ready;
   wire       [4:0]    sqrt_output_payload_rd;
@@ -8472,7 +8432,7 @@ module FpuCore (
   wire                sqrt_output_payload_value_sign;
   reg                 sqrt_output_payload_value_special;
   wire                sqrt_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type sqrt_output_payload_roundMode;
+  wire       [2:0]    sqrt_output_payload_roundMode;
   reg                 sqrt_output_payload_NV;
   wire                sqrt_output_payload_DZ;
   wire                sqrt_needShift;
@@ -8496,7 +8456,7 @@ module FpuCore (
   wire                add_preShifter_input_payload_rs2_sign;
   wire                add_preShifter_input_payload_rs2_special;
   wire       [4:0]    add_preShifter_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_preShifter_input_payload_roundMode;
+  wire       [2:0]    add_preShifter_input_payload_roundMode;
   wire                add_preShifter_input_payload_needCommit;
   wire                add_preShifter_output_valid;
   reg                 add_preShifter_output_ready;
@@ -8509,7 +8469,7 @@ module FpuCore (
   wire                add_preShifter_output_payload_rs2_sign;
   wire                add_preShifter_output_payload_rs2_special;
   wire       [4:0]    add_preShifter_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_preShifter_output_payload_roundMode;
+  wire       [2:0]    add_preShifter_output_payload_roundMode;
   wire                add_preShifter_output_payload_needCommit;
   wire                add_preShifter_output_payload_absRs1Bigger;
   wire                add_preShifter_output_payload_rs1ExponentBigger;
@@ -8518,21 +8478,21 @@ module FpuCore (
   wire                add_preShifter_rs1ExponentEqual;
   wire                add_preShifter_rs1MantissaBigger;
   wire                add_preShifter_absRs1Bigger;
-  wire                add_preShifter_output_input_valid;
-  wire                add_preShifter_output_input_ready;
-  wire       [24:0]   add_preShifter_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_preShifter_output_input_payload_rs1_exponent;
-  wire                add_preShifter_output_input_payload_rs1_sign;
-  wire                add_preShifter_output_input_payload_rs1_special;
-  wire       [24:0]   add_preShifter_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_preShifter_output_input_payload_rs2_exponent;
-  wire                add_preShifter_output_input_payload_rs2_sign;
-  wire                add_preShifter_output_input_payload_rs2_special;
-  wire       [4:0]    add_preShifter_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_preShifter_output_input_payload_roundMode;
-  wire                add_preShifter_output_input_payload_needCommit;
-  wire                add_preShifter_output_input_payload_absRs1Bigger;
-  wire                add_preShifter_output_input_payload_rs1ExponentBigger;
+  wire                add_shifter_input_valid;
+  wire                add_shifter_input_ready;
+  wire       [24:0]   add_shifter_input_payload_rs1_mantissa;
+  wire       [8:0]    add_shifter_input_payload_rs1_exponent;
+  wire                add_shifter_input_payload_rs1_sign;
+  wire                add_shifter_input_payload_rs1_special;
+  wire       [24:0]   add_shifter_input_payload_rs2_mantissa;
+  wire       [8:0]    add_shifter_input_payload_rs2_exponent;
+  wire                add_shifter_input_payload_rs2_sign;
+  wire                add_shifter_input_payload_rs2_special;
+  wire       [4:0]    add_shifter_input_payload_rd;
+  wire       [2:0]    add_shifter_input_payload_roundMode;
+  wire                add_shifter_input_payload_needCommit;
+  wire                add_shifter_input_payload_absRs1Bigger;
+  wire                add_shifter_input_payload_rs1ExponentBigger;
   reg                 add_preShifter_output_rValid;
   reg        [24:0]   add_preShifter_output_rData_rs1_mantissa;
   reg        [8:0]    add_preShifter_output_rData_rs1_exponent;
@@ -8543,11 +8503,11 @@ module FpuCore (
   reg                 add_preShifter_output_rData_rs2_sign;
   reg                 add_preShifter_output_rData_rs2_special;
   reg        [4:0]    add_preShifter_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_preShifter_output_rData_roundMode;
+  reg        [2:0]    add_preShifter_output_rData_roundMode;
   reg                 add_preShifter_output_rData_needCommit;
   reg                 add_preShifter_output_rData_absRs1Bigger;
   reg                 add_preShifter_output_rData_rs1ExponentBigger;
-  wire                when_Stream_l342_12;
+  wire                when_Stream_l368_12;
   wire                add_shifter_output_valid;
   reg                 add_shifter_output_ready;
   wire       [24:0]   add_shifter_output_payload_rs1_mantissa;
@@ -8559,7 +8519,7 @@ module FpuCore (
   wire                add_shifter_output_payload_rs2_sign;
   wire                add_shifter_output_payload_rs2_special;
   wire       [4:0]    add_shifter_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_shifter_output_payload_roundMode;
+  wire       [2:0]    add_shifter_output_payload_roundMode;
   wire                add_shifter_output_payload_needCommit;
   wire                add_shifter_output_payload_xSign;
   wire                add_shifter_output_payload_ySign;
@@ -8584,26 +8544,26 @@ module FpuCore (
   wire                when_FpuCore_l1419_3;
   wire                when_FpuCore_l1419_4;
   wire                when_FpuCore_l1424;
-  wire                add_shifter_output_input_valid;
-  wire                add_shifter_output_input_ready;
-  wire       [24:0]   add_shifter_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_shifter_output_input_payload_rs1_exponent;
-  wire                add_shifter_output_input_payload_rs1_sign;
-  wire                add_shifter_output_input_payload_rs1_special;
-  wire       [24:0]   add_shifter_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_shifter_output_input_payload_rs2_exponent;
-  wire                add_shifter_output_input_payload_rs2_sign;
-  wire                add_shifter_output_input_payload_rs2_special;
-  wire       [4:0]    add_shifter_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_shifter_output_input_payload_roundMode;
-  wire                add_shifter_output_input_payload_needCommit;
-  wire                add_shifter_output_input_payload_xSign;
-  wire                add_shifter_output_input_payload_ySign;
-  wire       [25:0]   add_shifter_output_input_payload_xMantissa;
-  wire       [25:0]   add_shifter_output_input_payload_yMantissa;
-  wire       [8:0]    add_shifter_output_input_payload_xyExponent;
-  wire                add_shifter_output_input_payload_xySign;
-  wire                add_shifter_output_input_payload_roundingScrap;
+  wire                add_math_input_valid;
+  wire                add_math_input_ready;
+  wire       [24:0]   add_math_input_payload_rs1_mantissa;
+  wire       [8:0]    add_math_input_payload_rs1_exponent;
+  wire                add_math_input_payload_rs1_sign;
+  wire                add_math_input_payload_rs1_special;
+  wire       [24:0]   add_math_input_payload_rs2_mantissa;
+  wire       [8:0]    add_math_input_payload_rs2_exponent;
+  wire                add_math_input_payload_rs2_sign;
+  wire                add_math_input_payload_rs2_special;
+  wire       [4:0]    add_math_input_payload_rd;
+  wire       [2:0]    add_math_input_payload_roundMode;
+  wire                add_math_input_payload_needCommit;
+  wire                add_math_input_payload_xSign;
+  wire                add_math_input_payload_ySign;
+  wire       [25:0]   add_math_input_payload_xMantissa;
+  wire       [25:0]   add_math_input_payload_yMantissa;
+  wire       [8:0]    add_math_input_payload_xyExponent;
+  wire                add_math_input_payload_xySign;
+  wire                add_math_input_payload_roundingScrap;
   reg                 add_shifter_output_rValid;
   reg        [24:0]   add_shifter_output_rData_rs1_mantissa;
   reg        [8:0]    add_shifter_output_rData_rs1_exponent;
@@ -8614,7 +8574,7 @@ module FpuCore (
   reg                 add_shifter_output_rData_rs2_sign;
   reg                 add_shifter_output_rData_rs2_special;
   reg        [4:0]    add_shifter_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_shifter_output_rData_roundMode;
+  reg        [2:0]    add_shifter_output_rData_roundMode;
   reg                 add_shifter_output_rData_needCommit;
   reg                 add_shifter_output_rData_xSign;
   reg                 add_shifter_output_rData_ySign;
@@ -8623,7 +8583,7 @@ module FpuCore (
   reg        [8:0]    add_shifter_output_rData_xyExponent;
   reg                 add_shifter_output_rData_xySign;
   reg                 add_shifter_output_rData_roundingScrap;
-  wire                when_Stream_l342_13;
+  wire                when_Stream_l368_13;
   wire                add_math_output_valid;
   reg                 add_math_output_ready;
   wire       [24:0]   add_math_output_payload_rs1_mantissa;
@@ -8635,7 +8595,7 @@ module FpuCore (
   wire                add_math_output_payload_rs2_sign;
   wire                add_math_output_payload_rs2_special;
   wire       [4:0]    add_math_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_math_output_payload_roundMode;
+  wire       [2:0]    add_math_output_payload_roundMode;
   wire                add_math_output_payload_needCommit;
   wire                add_math_output_payload_xSign;
   wire                add_math_output_payload_ySign;
@@ -8647,27 +8607,27 @@ module FpuCore (
   wire       [26:0]   add_math_output_payload_xyMantissa;
   wire       [26:0]   add_math_xSigned;
   wire       [26:0]   add_math_ySigned;
-  wire                add_math_output_input_valid;
-  wire                add_math_output_input_ready;
-  wire       [24:0]   add_math_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_math_output_input_payload_rs1_exponent;
-  wire                add_math_output_input_payload_rs1_sign;
-  wire                add_math_output_input_payload_rs1_special;
-  wire       [24:0]   add_math_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_math_output_input_payload_rs2_exponent;
-  wire                add_math_output_input_payload_rs2_sign;
-  wire                add_math_output_input_payload_rs2_special;
-  wire       [4:0]    add_math_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_math_output_input_payload_roundMode;
-  wire                add_math_output_input_payload_needCommit;
-  wire                add_math_output_input_payload_xSign;
-  wire                add_math_output_input_payload_ySign;
-  wire       [25:0]   add_math_output_input_payload_xMantissa;
-  wire       [25:0]   add_math_output_input_payload_yMantissa;
-  wire       [8:0]    add_math_output_input_payload_xyExponent;
-  wire                add_math_output_input_payload_xySign;
-  wire                add_math_output_input_payload_roundingScrap;
-  wire       [26:0]   add_math_output_input_payload_xyMantissa;
+  wire                add_oh_input_valid;
+  wire                add_oh_input_ready;
+  wire       [24:0]   add_oh_input_payload_rs1_mantissa;
+  wire       [8:0]    add_oh_input_payload_rs1_exponent;
+  wire                add_oh_input_payload_rs1_sign;
+  wire                add_oh_input_payload_rs1_special;
+  wire       [24:0]   add_oh_input_payload_rs2_mantissa;
+  wire       [8:0]    add_oh_input_payload_rs2_exponent;
+  wire                add_oh_input_payload_rs2_sign;
+  wire                add_oh_input_payload_rs2_special;
+  wire       [4:0]    add_oh_input_payload_rd;
+  wire       [2:0]    add_oh_input_payload_roundMode;
+  wire                add_oh_input_payload_needCommit;
+  wire                add_oh_input_payload_xSign;
+  wire                add_oh_input_payload_ySign;
+  wire       [25:0]   add_oh_input_payload_xMantissa;
+  wire       [25:0]   add_oh_input_payload_yMantissa;
+  wire       [8:0]    add_oh_input_payload_xyExponent;
+  wire                add_oh_input_payload_xySign;
+  wire                add_oh_input_payload_roundingScrap;
+  wire       [26:0]   add_oh_input_payload_xyMantissa;
   reg                 add_math_output_rValid;
   reg        [24:0]   add_math_output_rData_rs1_mantissa;
   reg        [8:0]    add_math_output_rData_rs1_exponent;
@@ -8678,7 +8638,7 @@ module FpuCore (
   reg                 add_math_output_rData_rs2_sign;
   reg                 add_math_output_rData_rs2_special;
   reg        [4:0]    add_math_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_math_output_rData_roundMode;
+  reg        [2:0]    add_math_output_rData_roundMode;
   reg                 add_math_output_rData_needCommit;
   reg                 add_math_output_rData_xSign;
   reg                 add_math_output_rData_ySign;
@@ -8688,11 +8648,11 @@ module FpuCore (
   reg                 add_math_output_rData_xySign;
   reg                 add_math_output_rData_roundingScrap;
   reg        [26:0]   add_math_output_rData_xyMantissa;
-  wire                when_Stream_l342_14;
-  wire                add_math_output_input_fire;
+  wire                when_Stream_l368_14;
+  wire                add_oh_input_fire;
   wire                when_FpuCore_l221_4;
   wire                add_oh_isCommited;
-  wire                _zz_add_math_output_input_ready;
+  wire                _zz_add_oh_input_ready;
   wire                add_oh_output_valid;
   reg                 add_oh_output_ready;
   wire       [24:0]   add_oh_output_payload_rs1_mantissa;
@@ -8704,7 +8664,7 @@ module FpuCore (
   wire                add_oh_output_payload_rs2_sign;
   wire                add_oh_output_payload_rs2_special;
   wire       [4:0]    add_oh_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_oh_output_payload_roundMode;
+  wire       [2:0]    add_oh_output_payload_roundMode;
   wire                add_oh_output_payload_needCommit;
   wire                add_oh_output_payload_xSign;
   wire                add_oh_output_payload_ySign;
@@ -8744,28 +8704,28 @@ module FpuCore (
   wire                _zz_add_oh_shift_26;
   wire                _zz_add_oh_shift_27;
   wire       [4:0]    add_oh_shift;
-  wire                add_oh_output_input_valid;
-  wire                add_oh_output_input_ready;
-  wire       [24:0]   add_oh_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_oh_output_input_payload_rs1_exponent;
-  wire                add_oh_output_input_payload_rs1_sign;
-  wire                add_oh_output_input_payload_rs1_special;
-  wire       [24:0]   add_oh_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_oh_output_input_payload_rs2_exponent;
-  wire                add_oh_output_input_payload_rs2_sign;
-  wire                add_oh_output_input_payload_rs2_special;
-  wire       [4:0]    add_oh_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_oh_output_input_payload_roundMode;
-  wire                add_oh_output_input_payload_needCommit;
-  wire                add_oh_output_input_payload_xSign;
-  wire                add_oh_output_input_payload_ySign;
-  wire       [25:0]   add_oh_output_input_payload_xMantissa;
-  wire       [25:0]   add_oh_output_input_payload_yMantissa;
-  wire       [8:0]    add_oh_output_input_payload_xyExponent;
-  wire                add_oh_output_input_payload_xySign;
-  wire                add_oh_output_input_payload_roundingScrap;
-  wire       [26:0]   add_oh_output_input_payload_xyMantissa;
-  wire       [4:0]    add_oh_output_input_payload_shift;
+  wire                add_norm_input_valid;
+  wire                add_norm_input_ready;
+  wire       [24:0]   add_norm_input_payload_rs1_mantissa;
+  wire       [8:0]    add_norm_input_payload_rs1_exponent;
+  wire                add_norm_input_payload_rs1_sign;
+  wire                add_norm_input_payload_rs1_special;
+  wire       [24:0]   add_norm_input_payload_rs2_mantissa;
+  wire       [8:0]    add_norm_input_payload_rs2_exponent;
+  wire                add_norm_input_payload_rs2_sign;
+  wire                add_norm_input_payload_rs2_special;
+  wire       [4:0]    add_norm_input_payload_rd;
+  wire       [2:0]    add_norm_input_payload_roundMode;
+  wire                add_norm_input_payload_needCommit;
+  wire                add_norm_input_payload_xSign;
+  wire                add_norm_input_payload_ySign;
+  wire       [25:0]   add_norm_input_payload_xMantissa;
+  wire       [25:0]   add_norm_input_payload_yMantissa;
+  wire       [8:0]    add_norm_input_payload_xyExponent;
+  wire                add_norm_input_payload_xySign;
+  wire                add_norm_input_payload_roundingScrap;
+  wire       [26:0]   add_norm_input_payload_xyMantissa;
+  wire       [4:0]    add_norm_input_payload_shift;
   reg                 add_oh_output_rValid;
   reg        [24:0]   add_oh_output_rData_rs1_mantissa;
   reg        [8:0]    add_oh_output_rData_rs1_exponent;
@@ -8776,7 +8736,7 @@ module FpuCore (
   reg                 add_oh_output_rData_rs2_sign;
   reg                 add_oh_output_rData_rs2_special;
   reg        [4:0]    add_oh_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_oh_output_rData_roundMode;
+  reg        [2:0]    add_oh_output_rData_roundMode;
   reg                 add_oh_output_rData_needCommit;
   reg                 add_oh_output_rData_xSign;
   reg                 add_oh_output_rData_ySign;
@@ -8787,7 +8747,7 @@ module FpuCore (
   reg                 add_oh_output_rData_roundingScrap;
   reg        [26:0]   add_oh_output_rData_xyMantissa;
   reg        [4:0]    add_oh_output_rData_shift;
-  wire                when_Stream_l342_15;
+  wire                when_Stream_l368_15;
   wire                add_norm_output_valid;
   wire                add_norm_output_ready;
   wire       [24:0]   add_norm_output_payload_rs1_mantissa;
@@ -8799,7 +8759,7 @@ module FpuCore (
   wire                add_norm_output_payload_rs2_sign;
   wire                add_norm_output_payload_rs2_special;
   wire       [4:0]    add_norm_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_norm_output_payload_roundMode;
+  wire       [2:0]    add_norm_output_payload_roundMode;
   wire                add_norm_output_payload_needCommit;
   wire       [26:0]   add_norm_output_payload_mantissa;
   wire       [9:0]    add_norm_output_payload_exponent;
@@ -8821,7 +8781,7 @@ module FpuCore (
   wire                add_result_input_payload_rs2_sign;
   wire                add_result_input_payload_rs2_special;
   wire       [4:0]    add_result_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_result_input_payload_roundMode;
+  wire       [2:0]    add_result_input_payload_roundMode;
   wire                add_result_input_payload_needCommit;
   wire       [26:0]   add_result_input_payload_mantissa;
   wire       [9:0]    add_result_input_payload_exponent;
@@ -8840,7 +8800,7 @@ module FpuCore (
   reg                 add_result_output_payload_value_sign;
   reg                 add_result_output_payload_value_special;
   wire                add_result_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type add_result_output_payload_roundMode;
+  wire       [2:0]    add_result_output_payload_roundMode;
   wire                add_result_output_payload_NV;
   wire                add_result_output_payload_DZ;
   wire                when_FpuCore_l1513;
@@ -8853,7 +8813,7 @@ module FpuCore (
   wire                load_s1_output_m2sPipe_payload_value_sign;
   wire                load_s1_output_m2sPipe_payload_value_special;
   wire                load_s1_output_m2sPipe_payload_scrap;
-  wire       `FpuRoundMode_opt_type load_s1_output_m2sPipe_payload_roundMode;
+  wire       [2:0]    load_s1_output_m2sPipe_payload_roundMode;
   wire                load_s1_output_m2sPipe_payload_NV;
   wire                load_s1_output_m2sPipe_payload_DZ;
   reg                 load_s1_output_rValid;
@@ -8863,10 +8823,10 @@ module FpuCore (
   reg                 load_s1_output_rData_value_sign;
   reg                 load_s1_output_rData_value_special;
   reg                 load_s1_output_rData_scrap;
-  reg        `FpuRoundMode_opt_type load_s1_output_rData_roundMode;
+  reg        [2:0]    load_s1_output_rData_roundMode;
   reg                 load_s1_output_rData_NV;
   reg                 load_s1_output_rData_DZ;
-  wire                when_Stream_l342_16;
+  wire                when_Stream_l368_16;
   wire                shortPip_output_m2sPipe_valid;
   wire                shortPip_output_m2sPipe_ready;
   wire       [4:0]    shortPip_output_m2sPipe_payload_rd;
@@ -8875,7 +8835,7 @@ module FpuCore (
   wire                shortPip_output_m2sPipe_payload_value_sign;
   wire                shortPip_output_m2sPipe_payload_value_special;
   wire                shortPip_output_m2sPipe_payload_scrap;
-  wire       `FpuRoundMode_opt_type shortPip_output_m2sPipe_payload_roundMode;
+  wire       [2:0]    shortPip_output_m2sPipe_payload_roundMode;
   wire                shortPip_output_m2sPipe_payload_NV;
   wire                shortPip_output_m2sPipe_payload_DZ;
   reg                 shortPip_output_rValid;
@@ -8885,10 +8845,10 @@ module FpuCore (
   reg                 shortPip_output_rData_value_sign;
   reg                 shortPip_output_rData_value_special;
   reg                 shortPip_output_rData_scrap;
-  reg        `FpuRoundMode_opt_type shortPip_output_rData_roundMode;
+  reg        [2:0]    shortPip_output_rData_roundMode;
   reg                 shortPip_output_rData_NV;
   reg                 shortPip_output_rData_DZ;
-  wire                when_Stream_l342_17;
+  wire                when_Stream_l368_17;
   wire                merge_arbitrated_valid;
   wire       [4:0]    merge_arbitrated_payload_rd;
   wire       [23:0]   merge_arbitrated_payload_value_mantissa;
@@ -8896,7 +8856,7 @@ module FpuCore (
   wire                merge_arbitrated_payload_value_sign;
   wire                merge_arbitrated_payload_value_special;
   wire                merge_arbitrated_payload_scrap;
-  wire       `FpuRoundMode_opt_type merge_arbitrated_payload_roundMode;
+  wire       [2:0]    merge_arbitrated_payload_roundMode;
   wire                merge_arbitrated_payload_NV;
   wire                merge_arbitrated_payload_DZ;
   reg                 roundFront_input_valid;
@@ -8906,7 +8866,7 @@ module FpuCore (
   reg                 roundFront_input_payload_value_sign;
   reg                 roundFront_input_payload_value_special;
   reg                 roundFront_input_payload_scrap;
-  reg        `FpuRoundMode_opt_type roundFront_input_payload_roundMode;
+  reg        [2:0]    roundFront_input_payload_roundMode;
   reg                 roundFront_input_payload_NV;
   reg                 roundFront_input_payload_DZ;
   wire                roundFront_output_valid;
@@ -8916,7 +8876,7 @@ module FpuCore (
   wire                roundFront_output_payload_value_sign;
   wire                roundFront_output_payload_value_special;
   wire                roundFront_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type roundFront_output_payload_roundMode;
+  wire       [2:0]    roundFront_output_payload_roundMode;
   wire                roundFront_output_payload_NV;
   wire                roundFront_output_payload_DZ;
   wire                roundFront_output_payload_mantissaIncrement;
@@ -8938,7 +8898,7 @@ module FpuCore (
   reg                 roundBack_input_payload_value_sign;
   reg                 roundBack_input_payload_value_special;
   reg                 roundBack_input_payload_scrap;
-  reg        `FpuRoundMode_opt_type roundBack_input_payload_roundMode;
+  reg        [2:0]    roundBack_input_payload_roundMode;
   reg                 roundBack_input_payload_NV;
   reg                 roundBack_input_payload_DZ;
   reg                 roundBack_input_payload_mantissaIncrement;
@@ -9017,15 +8977,15 @@ module FpuCore (
   reg [63:0] _zz_payload_opcode_string;
   reg [63:0] _zz_commitLogic_0_input_payload_opcode_string;
   reg [63:0] commitLogic_0_input_payload_opcode_string;
-  reg [63:0] io_port_0_cmd_input_payload_opcode_string;
-  reg [47:0] io_port_0_cmd_input_payload_format_string;
-  reg [23:0] io_port_0_cmd_input_payload_roundMode_string;
+  reg [63:0] scheduler_0_input_payload_opcode_string;
+  reg [47:0] scheduler_0_input_payload_format_string;
+  reg [23:0] scheduler_0_input_payload_roundMode_string;
   reg [63:0] io_port_0_cmd_rData_opcode_string;
   reg [47:0] io_port_0_cmd_rData_format_string;
   reg [23:0] io_port_0_cmd_rData_roundMode_string;
-  reg [63:0] _zz_io_port_0_cmd_input_payload_opcode_string;
-  reg [47:0] _zz_io_port_0_cmd_input_payload_format_string;
-  reg [23:0] _zz_io_port_0_cmd_input_payload_roundMode_string;
+  reg [63:0] _zz_scheduler_0_input_payload_opcode_string;
+  reg [47:0] _zz_scheduler_0_input_payload_format_string;
+  reg [23:0] _zz_scheduler_0_input_payload_roundMode_string;
   reg [63:0] scheduler_0_output_payload_opcode_string;
   reg [47:0] scheduler_0_output_payload_format_string;
   reg [23:0] scheduler_0_output_payload_roundMode_string;
@@ -9036,8 +8996,8 @@ module FpuCore (
   reg [23:0] cmdArbiter_output_payload_roundMode_string;
   reg [63:0] read_s0_payload_opcode_string;
   reg [23:0] read_s0_payload_roundMode_string;
-  reg [63:0] read_s0_s1_payload_opcode_string;
-  reg [23:0] read_s0_s1_payload_roundMode_string;
+  reg [63:0] read_s1_payload_opcode_string;
+  reg [23:0] read_s1_payload_roundMode_string;
   reg [63:0] read_s0_rData_opcode_string;
   reg [23:0] read_s0_rData_roundMode_string;
   reg [63:0] read_output_payload_opcode_string;
@@ -9059,55 +9019,55 @@ module FpuCore (
   reg [23:0] _zz_decode_load_s2mPipe_payload_roundMode_string;
   reg [23:0] decode_load_s2mPipe_m2sPipe_payload_roundMode_string;
   reg [23:0] decode_load_s2mPipe_rData_roundMode_string;
-  reg [23:0] decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string;
+  reg [23:0] load_s0_input_payload_roundMode_string;
   reg [23:0] decode_load_s2mPipe_m2sPipe_rData_roundMode_string;
   reg [63:0] load_s0_filtred_0_payload_opcode_string;
   reg [23:0] load_s0_output_payload_roundMode_string;
-  reg [23:0] load_s0_output_input_payload_roundMode_string;
+  reg [23:0] load_s1_input_payload_roundMode_string;
   reg [23:0] load_s0_output_rData_roundMode_string;
   reg [23:0] load_s1_output_payload_roundMode_string;
-  reg [63:0] decode_shortPip_input_payload_opcode_string;
-  reg [23:0] decode_shortPip_input_payload_roundMode_string;
+  reg [63:0] shortPip_input_payload_opcode_string;
+  reg [23:0] shortPip_input_payload_roundMode_string;
   reg [63:0] decode_shortPip_rData_opcode_string;
   reg [23:0] decode_shortPip_rData_roundMode_string;
   reg [23:0] shortPip_rfOutput_payload_roundMode_string;
   reg [23:0] shortPip_output_payload_roundMode_string;
-  reg [23:0] decode_mul_input_payload_roundMode_string;
+  reg [23:0] mul_preMul_input_payload_roundMode_string;
   reg [23:0] decode_mul_rData_roundMode_string;
   reg [23:0] mul_preMul_output_payload_roundMode_string;
-  reg [23:0] mul_preMul_output_input_payload_roundMode_string;
+  reg [23:0] mul_mul_input_payload_roundMode_string;
   reg [23:0] mul_preMul_output_rData_roundMode_string;
   reg [23:0] mul_mul_output_payload_roundMode_string;
-  reg [23:0] mul_mul_output_input_payload_roundMode_string;
+  reg [23:0] mul_sum1_input_payload_roundMode_string;
   reg [23:0] mul_mul_output_rData_roundMode_string;
   reg [23:0] mul_sum1_output_payload_roundMode_string;
-  reg [23:0] mul_sum1_output_input_payload_roundMode_string;
+  reg [23:0] mul_sum2_input_payload_roundMode_string;
   reg [23:0] mul_sum1_output_rData_roundMode_string;
   reg [23:0] mul_sum2_output_payload_roundMode_string;
-  reg [23:0] mul_sum2_output_input_payload_roundMode_string;
+  reg [23:0] mul_norm_input_payload_roundMode_string;
   reg [23:0] mul_sum2_output_rData_roundMode_string;
   reg [23:0] mul_result_output_payload_roundMode_string;
   reg [23:0] mul_result_mulToAdd_payload_roundMode_string;
   reg [23:0] mul_result_mulToAdd_m2sPipe_payload_roundMode_string;
   reg [23:0] mul_result_mulToAdd_rData_roundMode_string;
-  reg [23:0] decode_div_input_payload_roundMode_string;
+  reg [23:0] div_input_payload_roundMode_string;
   reg [23:0] decode_div_rData_roundMode_string;
   reg [23:0] div_output_payload_roundMode_string;
-  reg [23:0] decode_sqrt_input_payload_roundMode_string;
+  reg [23:0] sqrt_input_payload_roundMode_string;
   reg [23:0] decode_sqrt_rData_roundMode_string;
   reg [23:0] sqrt_output_payload_roundMode_string;
   reg [23:0] add_preShifter_input_payload_roundMode_string;
   reg [23:0] add_preShifter_output_payload_roundMode_string;
-  reg [23:0] add_preShifter_output_input_payload_roundMode_string;
+  reg [23:0] add_shifter_input_payload_roundMode_string;
   reg [23:0] add_preShifter_output_rData_roundMode_string;
   reg [23:0] add_shifter_output_payload_roundMode_string;
-  reg [23:0] add_shifter_output_input_payload_roundMode_string;
+  reg [23:0] add_math_input_payload_roundMode_string;
   reg [23:0] add_shifter_output_rData_roundMode_string;
   reg [23:0] add_math_output_payload_roundMode_string;
-  reg [23:0] add_math_output_input_payload_roundMode_string;
+  reg [23:0] add_oh_input_payload_roundMode_string;
   reg [23:0] add_math_output_rData_roundMode_string;
   reg [23:0] add_oh_output_payload_roundMode_string;
-  reg [23:0] add_oh_output_input_payload_roundMode_string;
+  reg [23:0] add_norm_input_payload_roundMode_string;
   reg [23:0] add_oh_output_rData_roundMode_string;
   reg [23:0] add_norm_output_payload_roundMode_string;
   reg [23:0] add_result_input_payload_roundMode_string;
@@ -9122,7 +9082,7 @@ module FpuCore (
   reg [23:0] roundBack_input_payload_roundMode_string;
   `endif
 
-  (* ram_style = "block" *) reg [33:0] rf_ram [0:31];
+  (* no_rw_check , ram_style = "block" *) reg [33:0] rf_ram [0:31];
   (* ram_style = "distributed" *) reg [0:0] rf_scoreboards_0_target [0:31];
   (* ram_style = "distributed" *) reg [0:0] rf_scoreboards_0_hit [0:31];
   (* ram_style = "distributed" *) reg [0:0] rf_scoreboards_0_writes [0:31];
@@ -9173,7 +9133,7 @@ module FpuCore (
   assign _zz_load_s1_recoded_exponent_1 = ({1'b0,load_s1_passThroughFloat_exponent} - {1'b0,load_s1_fsm_expOffset});
   assign _zz_load_s1_recoded_exponent_2 = {1'd0, load_s1_recodedExpOffset};
   assign _zz_load_s1_output_payload_value_exponent = {4'd0, load_s1_fsm_shift_by};
-  assign _zz_shortPip_f32_exp = (decode_shortPip_input_payload_rs1_exponent - 9'h080);
+  assign _zz_shortPip_f32_exp = (shortPip_input_payload_rs1_exponent - 9'h080);
   assign _zz_shortPip_expInSubnormalRange = {1'd0, shortPip_expSubnormalThreshold};
   assign _zz_shortPip_fsm_shift_input_1 = (shortPip_fsm_shift_input >>> 6'h20);
   assign _zz_shortPip_fsm_shift_input_2 = (shortPip_fsm_shift_input_1 >>> 5'h10);
@@ -9184,17 +9144,17 @@ module FpuCore (
   assign _zz_shortPip_fsm_shift_by_2 = (((_zz_shortPip_fsm_shift_by < _zz_shortPip_fsm_shift_by_3) ? _zz_shortPip_fsm_shift_by : _zz_shortPip_fsm_shift_by_4) + 9'h0);
   assign _zz_shortPip_fsm_shift_by_3 = {3'd0, _zz_shortPip_fsm_shift_by_1};
   assign _zz_shortPip_fsm_shift_by_4 = {3'd0, _zz_shortPip_fsm_shift_by_1};
-  assign _zz_shortPip_fsm_shift_by_5 = (_zz_shortPip_fsm_shift_by_6 - decode_shortPip_input_payload_rs1_exponent);
+  assign _zz_shortPip_fsm_shift_by_5 = (_zz_shortPip_fsm_shift_by_6 - shortPip_input_payload_rs1_exponent);
   assign _zz_shortPip_fsm_shift_by_6 = {1'd0, shortPip_fsm_formatShiftOffset};
   assign _zz_shortPip_f2i_result_1 = (shortPip_f2i_resign ^ shortPip_f2i_increment);
   assign _zz_shortPip_f2i_result = {31'd0, _zz_shortPip_f2i_result_1};
-  assign _zz_mul_sum1_sum = {12'd0, mul_mul_output_input_payload_muls_0};
-  assign _zz_mul_sum1_sum_2 = ({18'd0,mul_mul_output_input_payload_muls_1} <<< 18);
+  assign _zz_mul_sum1_sum = {12'd0, mul_sum1_input_payload_muls_0};
+  assign _zz_mul_sum1_sum_2 = ({18'd0,mul_sum1_input_payload_muls_1} <<< 18);
   assign _zz_mul_sum1_sum_1 = {6'd0, _zz_mul_sum1_sum_2};
   assign _zz_mul_sum2_sum = (_zz_mul_sum2_sum_1 + _zz_mul_sum2_sum_3);
-  assign _zz_mul_sum2_sum_2 = ({18'd0,mul_sum1_output_input_payload_muls2_0} <<< 18);
+  assign _zz_mul_sum2_sum_2 = ({18'd0,mul_sum2_input_payload_muls2_0} <<< 18);
   assign _zz_mul_sum2_sum_1 = {6'd0, _zz_mul_sum2_sum_2};
-  assign _zz_mul_sum2_sum_4 = ({36'd0,mul_sum1_output_input_payload_muls2_1} <<< 36);
+  assign _zz_mul_sum2_sum_4 = ({36'd0,mul_sum2_input_payload_muls2_1} <<< 36);
   assign _zz_mul_sum2_sum_3 = _zz_mul_sum2_sum_4;
   assign _zz_mul_norm_exp_1 = mul_norm_needShift;
   assign _zz_mul_norm_exp = {9'd0, _zz_mul_norm_exp_1};
@@ -9202,15 +9162,15 @@ module FpuCore (
   assign _zz_mul_norm_output_exponent = (mul_norm_exp - 10'h0ff);
   assign _zz_div_exponent = (_zz_div_exponent_1 - _zz_div_exponent_3);
   assign _zz_div_exponent_1 = (_zz_div_exponent_2 + 11'h4ff);
-  assign _zz_div_exponent_2 = {2'd0, decode_div_input_payload_rs1_exponent};
-  assign _zz_div_exponent_3 = {2'd0, decode_div_input_payload_rs2_exponent};
+  assign _zz_div_exponent_2 = {2'd0, div_input_payload_rs1_exponent};
+  assign _zz_div_exponent_3 = {2'd0, div_input_payload_rs2_exponent};
   assign _zz_div_exponent_5 = div_needShift;
   assign _zz_div_exponent_4 = {10'd0, _zz_div_exponent_5};
   assign _zz_sqrt_exponent = (_zz_sqrt_exponent_1 + {1'b0,_zz_sqrt_exponent_3});
   assign _zz_sqrt_exponent_2 = {1'b0,7'h7f};
   assign _zz_sqrt_exponent_1 = {1'd0, _zz_sqrt_exponent_2};
-  assign _zz_sqrt_exponent_3 = (decode_sqrt_input_payload_rs1_exponent >>> 1);
-  assign _zz_sqrt_exponent_5 = decode_sqrt_input_payload_rs1_exponent[0];
+  assign _zz_sqrt_exponent_3 = (sqrt_input_payload_rs1_exponent >>> 1);
+  assign _zz_sqrt_exponent_5 = sqrt_input_payload_rs1_exponent[0];
   assign _zz_sqrt_exponent_4 = {8'd0, _zz_sqrt_exponent_5};
   assign _zz_add_shifter_shiftBy_1 = (_zz_add_shifter_shiftBy[9] ? _zz_add_shifter_shiftBy_2 : _zz_add_shifter_shiftBy);
   assign _zz_add_shifter_shiftBy_2 = (~ _zz_add_shifter_shiftBy);
@@ -9221,19 +9181,19 @@ module FpuCore (
   assign _zz_add_shifter_yMantissa_3 = (add_shifter_yMantissa_2 >>> 3'b100);
   assign _zz_add_shifter_yMantissa_4 = (add_shifter_yMantissa_3 >>> 2'b10);
   assign _zz_add_shifter_yMantissa_5 = (add_shifter_yMantissa_4 >>> 1'b1);
-  assign _zz_add_math_xSigned = ({add_shifter_output_input_payload_xSign,(add_shifter_output_input_payload_xSign ? (~ add_shifter_output_input_payload_xMantissa) : add_shifter_output_input_payload_xMantissa)} + _zz_add_math_xSigned_1);
-  assign _zz_add_math_xSigned_2 = add_shifter_output_input_payload_xSign;
+  assign _zz_add_math_xSigned = ({add_math_input_payload_xSign,(add_math_input_payload_xSign ? (~ add_math_input_payload_xMantissa) : add_math_input_payload_xMantissa)} + _zz_add_math_xSigned_1);
+  assign _zz_add_math_xSigned_2 = add_math_input_payload_xSign;
   assign _zz_add_math_xSigned_1 = {26'd0, _zz_add_math_xSigned_2};
-  assign _zz_add_math_ySigned = ({add_shifter_output_input_payload_ySign,(add_shifter_output_input_payload_ySign ? (~ add_shifter_output_input_payload_yMantissa) : add_shifter_output_input_payload_yMantissa)} + _zz_add_math_ySigned_1);
-  assign _zz_add_math_ySigned_2 = (add_shifter_output_input_payload_ySign && (! add_shifter_output_input_payload_roundingScrap));
+  assign _zz_add_math_ySigned = ({add_math_input_payload_ySign,(add_math_input_payload_ySign ? (~ add_math_input_payload_yMantissa) : add_math_input_payload_yMantissa)} + _zz_add_math_ySigned_1);
+  assign _zz_add_math_ySigned_2 = (add_math_input_payload_ySign && (! add_math_input_payload_roundingScrap));
   assign _zz_add_math_ySigned_1 = {26'd0, _zz_add_math_ySigned_2};
   assign _zz_add_math_output_payload_xyMantissa = _zz_add_math_output_payload_xyMantissa_1;
   assign _zz_add_math_output_payload_xyMantissa_1 = ($signed(_zz_add_math_output_payload_xyMantissa_2) + $signed(_zz_add_math_output_payload_xyMantissa_3));
   assign _zz_add_math_output_payload_xyMantissa_2 = {add_math_xSigned[26],add_math_xSigned};
   assign _zz_add_math_output_payload_xyMantissa_3 = {add_math_ySigned[26],add_math_ySigned};
   assign _zz__zz_add_oh_shift_1_1 = (_zz_add_oh_shift - 27'h0000001);
-  assign _zz_add_norm_output_payload_exponent = ({1'b0,add_oh_output_input_payload_xyExponent} - _zz_add_norm_output_payload_exponent_1);
-  assign _zz_add_norm_output_payload_exponent_2 = {1'b0,add_oh_output_input_payload_shift};
+  assign _zz_add_norm_output_payload_exponent = ({1'b0,add_norm_input_payload_xyExponent} - _zz_add_norm_output_payload_exponent_1);
+  assign _zz_add_norm_output_payload_exponent_2 = {1'b0,add_norm_input_payload_shift};
   assign _zz_add_norm_output_payload_exponent_1 = {4'd0, _zz_add_norm_output_payload_exponent_2};
   assign _zz_add_result_output_payload_value_mantissa = (add_result_input_payload_mantissa >>> 2);
   assign _zz_roundFront_expDif_1 = {1'b0,roundFront_expBase};
@@ -9256,10 +9216,10 @@ module FpuCore (
   assign _zz_rf_scoreboards_0_target_port = rf_scoreboards_0_targetWrite_payload_data;
   assign _zz_rf_scoreboards_0_hit_port = rf_scoreboards_0_hitWrite_payload_data;
   assign _zz_rf_scoreboards_0_writes_port = commitLogic_0_input_payload_write;
-  assign _zz_decode_shortPipHit = `FpuOpcode_binary_sequential_MIN_MAX;
-  assign _zz_decode_shortPipHit_1 = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_CMP);
-  assign _zz_decode_shortPipHit_2 = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_F2I);
-  assign _zz_decode_shortPipHit_3 = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_STORE);
+  assign _zz_decode_shortPipHit = FpuOpcode_MIN_MAX;
+  assign _zz_decode_shortPipHit_1 = (decode_input_payload_opcode == FpuOpcode_CMP);
+  assign _zz_decode_shortPipHit_2 = (decode_input_payload_opcode == FpuOpcode_F2I);
+  assign _zz_decode_shortPipHit_3 = (decode_input_payload_opcode == FpuOpcode_STORE);
   assign _zz__zz_load_s1_fsm_shift_by = load_s1_fsm_ohInput[9];
   assign _zz__zz_load_s1_fsm_shift_by_1 = load_s1_fsm_ohInput[10];
   assign _zz__zz_load_s1_fsm_shift_by_2 = {load_s1_fsm_ohInput[11],{load_s1_fsm_ohInput[12],{load_s1_fsm_ohInput[13],{load_s1_fsm_ohInput[14],{load_s1_fsm_ohInput[15],{load_s1_fsm_ohInput[16],{load_s1_fsm_ohInput[17],{load_s1_fsm_ohInput[18],{load_s1_fsm_ohInput[19],{_zz__zz_load_s1_fsm_shift_by_3,{_zz__zz_load_s1_fsm_shift_by_4,_zz__zz_load_s1_fsm_shift_by_5}}}}}}}}}}};
@@ -9314,20 +9274,20 @@ module FpuCore (
     end
   end
 
-  assign _zz_rf_scoreboards_0_target_port1 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rs1];
-  assign _zz_rf_scoreboards_0_target_port2 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rs2];
-  assign _zz_rf_scoreboards_0_target_port3 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rs3];
-  assign _zz_rf_scoreboards_0_target_port4 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rd];
+  assign _zz_rf_scoreboards_0_target_port1 = rf_scoreboards_0_target[scheduler_0_input_payload_rs1];
+  assign _zz_rf_scoreboards_0_target_port2 = rf_scoreboards_0_target[scheduler_0_input_payload_rs2];
+  assign _zz_rf_scoreboards_0_target_port3 = rf_scoreboards_0_target[scheduler_0_input_payload_rs3];
+  assign _zz_rf_scoreboards_0_target_port4 = rf_scoreboards_0_target[scheduler_0_input_payload_rd];
   always @(posedge clk) begin
     if(_zz_3) begin
       rf_scoreboards_0_hit[rf_scoreboards_0_hitWrite_payload_address] <= _zz_rf_scoreboards_0_hit_port;
     end
   end
 
-  assign _zz_rf_scoreboards_0_hit_port1 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rs1];
-  assign _zz_rf_scoreboards_0_hit_port2 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rs2];
-  assign _zz_rf_scoreboards_0_hit_port3 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rs3];
-  assign _zz_rf_scoreboards_0_hit_port4 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rd];
+  assign _zz_rf_scoreboards_0_hit_port1 = rf_scoreboards_0_hit[scheduler_0_input_payload_rs1];
+  assign _zz_rf_scoreboards_0_hit_port2 = rf_scoreboards_0_hit[scheduler_0_input_payload_rs2];
+  assign _zz_rf_scoreboards_0_hit_port3 = rf_scoreboards_0_hit[scheduler_0_input_payload_rs3];
+  assign _zz_rf_scoreboards_0_hit_port4 = rf_scoreboards_0_hit[scheduler_0_input_payload_rd];
   assign _zz_rf_scoreboards_0_hit_port5 = rf_scoreboards_0_hit[writeback_input_payload_rd];
   always @(posedge clk) begin
     if(_zz_2) begin
@@ -9337,1540 +9297,1540 @@ module FpuCore (
 
   assign _zz_rf_scoreboards_0_writes_port1 = rf_scoreboards_0_writes[roundBack_input_payload_rd];
   StreamFork streamFork_1 (
-    .io_input_valid                 (io_port_0_commit_valid                    ), //i
-    .io_input_ready                 (streamFork_1_io_input_ready               ), //o
-    .io_input_payload_opcode        (io_port_0_commit_payload_opcode           ), //i
-    .io_input_payload_rd            (io_port_0_commit_payload_rd               ), //i
-    .io_input_payload_write         (io_port_0_commit_payload_write            ), //i
-    .io_input_payload_value         (io_port_0_commit_payload_value            ), //i
-    .io_outputs_0_valid             (streamFork_1_io_outputs_0_valid           ), //o
-    .io_outputs_0_ready             (commitFork_load_0_ready                   ), //i
-    .io_outputs_0_payload_opcode    (streamFork_1_io_outputs_0_payload_opcode  ), //o
-    .io_outputs_0_payload_rd        (streamFork_1_io_outputs_0_payload_rd      ), //o
-    .io_outputs_0_payload_write     (streamFork_1_io_outputs_0_payload_write   ), //o
-    .io_outputs_0_payload_value     (streamFork_1_io_outputs_0_payload_value   ), //o
-    .io_outputs_1_valid             (streamFork_1_io_outputs_1_valid           ), //o
-    .io_outputs_1_ready             (streamFork_1_io_outputs_1_ready           ), //i
-    .io_outputs_1_payload_opcode    (streamFork_1_io_outputs_1_payload_opcode  ), //o
-    .io_outputs_1_payload_rd        (streamFork_1_io_outputs_1_payload_rd      ), //o
-    .io_outputs_1_payload_write     (streamFork_1_io_outputs_1_payload_write   ), //o
-    .io_outputs_1_payload_value     (streamFork_1_io_outputs_1_payload_value   )  //o
+    .io_input_valid              (io_port_0_commit_valid                       ), //i
+    .io_input_ready              (streamFork_1_io_input_ready                  ), //o
+    .io_input_payload_opcode     (io_port_0_commit_payload_opcode[3:0]         ), //i
+    .io_input_payload_rd         (io_port_0_commit_payload_rd[4:0]             ), //i
+    .io_input_payload_write      (io_port_0_commit_payload_write               ), //i
+    .io_input_payload_value      (io_port_0_commit_payload_value[31:0]         ), //i
+    .io_outputs_0_valid          (streamFork_1_io_outputs_0_valid              ), //o
+    .io_outputs_0_ready          (commitFork_load_0_ready                      ), //i
+    .io_outputs_0_payload_opcode (streamFork_1_io_outputs_0_payload_opcode[3:0]), //o
+    .io_outputs_0_payload_rd     (streamFork_1_io_outputs_0_payload_rd[4:0]    ), //o
+    .io_outputs_0_payload_write  (streamFork_1_io_outputs_0_payload_write      ), //o
+    .io_outputs_0_payload_value  (streamFork_1_io_outputs_0_payload_value[31:0]), //o
+    .io_outputs_1_valid          (streamFork_1_io_outputs_1_valid              ), //o
+    .io_outputs_1_ready          (streamFork_1_io_outputs_1_ready              ), //i
+    .io_outputs_1_payload_opcode (streamFork_1_io_outputs_1_payload_opcode[3:0]), //o
+    .io_outputs_1_payload_rd     (streamFork_1_io_outputs_1_payload_rd[4:0]    ), //o
+    .io_outputs_1_payload_write  (streamFork_1_io_outputs_1_payload_write      ), //o
+    .io_outputs_1_payload_value  (streamFork_1_io_outputs_1_payload_value[31:0])  //o
   );
   StreamArbiter cmdArbiter_arbiter (
-    .io_inputs_0_valid                (scheduler_0_output_valid                        ), //i
-    .io_inputs_0_ready                (cmdArbiter_arbiter_io_inputs_0_ready            ), //o
-    .io_inputs_0_payload_opcode       (_zz_io_inputs_0_payload_opcode                  ), //i
-    .io_inputs_0_payload_arg          (scheduler_0_output_payload_arg                  ), //i
-    .io_inputs_0_payload_rs1          (scheduler_0_output_payload_rs1                  ), //i
-    .io_inputs_0_payload_rs2          (scheduler_0_output_payload_rs2                  ), //i
-    .io_inputs_0_payload_rs3          (scheduler_0_output_payload_rs3                  ), //i
-    .io_inputs_0_payload_rd           (scheduler_0_output_payload_rd                   ), //i
-    .io_inputs_0_payload_format       (_zz_io_inputs_0_payload_format                  ), //i
-    .io_inputs_0_payload_roundMode    (_zz_io_inputs_0_payload_roundMode               ), //i
-    .io_output_valid                  (cmdArbiter_arbiter_io_output_valid              ), //o
-    .io_output_ready                  (cmdArbiter_output_ready                         ), //i
-    .io_output_payload_opcode         (cmdArbiter_arbiter_io_output_payload_opcode     ), //o
-    .io_output_payload_arg            (cmdArbiter_arbiter_io_output_payload_arg        ), //o
-    .io_output_payload_rs1            (cmdArbiter_arbiter_io_output_payload_rs1        ), //o
-    .io_output_payload_rs2            (cmdArbiter_arbiter_io_output_payload_rs2        ), //o
-    .io_output_payload_rs3            (cmdArbiter_arbiter_io_output_payload_rs3        ), //o
-    .io_output_payload_rd             (cmdArbiter_arbiter_io_output_payload_rd         ), //o
-    .io_output_payload_format         (cmdArbiter_arbiter_io_output_payload_format     ), //o
-    .io_output_payload_roundMode      (cmdArbiter_arbiter_io_output_payload_roundMode  ), //o
-    .io_chosenOH                      (cmdArbiter_arbiter_io_chosenOH                  ), //o
-    .clk                              (clk                                             ), //i
-    .reset                            (reset                                           )  //i
+    .io_inputs_0_valid             (scheduler_0_output_valid                           ), //i
+    .io_inputs_0_ready             (cmdArbiter_arbiter_io_inputs_0_ready               ), //o
+    .io_inputs_0_payload_opcode    (_zz_io_inputs_0_payload_opcode[3:0]                ), //i
+    .io_inputs_0_payload_arg       (scheduler_0_output_payload_arg[1:0]                ), //i
+    .io_inputs_0_payload_rs1       (scheduler_0_output_payload_rs1[4:0]                ), //i
+    .io_inputs_0_payload_rs2       (scheduler_0_output_payload_rs2[4:0]                ), //i
+    .io_inputs_0_payload_rs3       (scheduler_0_output_payload_rs3[4:0]                ), //i
+    .io_inputs_0_payload_rd        (scheduler_0_output_payload_rd[4:0]                 ), //i
+    .io_inputs_0_payload_format    (_zz_io_inputs_0_payload_format                     ), //i
+    .io_inputs_0_payload_roundMode (_zz_io_inputs_0_payload_roundMode[2:0]             ), //i
+    .io_output_valid               (cmdArbiter_arbiter_io_output_valid                 ), //o
+    .io_output_ready               (cmdArbiter_output_ready                            ), //i
+    .io_output_payload_opcode      (cmdArbiter_arbiter_io_output_payload_opcode[3:0]   ), //o
+    .io_output_payload_arg         (cmdArbiter_arbiter_io_output_payload_arg[1:0]      ), //o
+    .io_output_payload_rs1         (cmdArbiter_arbiter_io_output_payload_rs1[4:0]      ), //o
+    .io_output_payload_rs2         (cmdArbiter_arbiter_io_output_payload_rs2[4:0]      ), //o
+    .io_output_payload_rs3         (cmdArbiter_arbiter_io_output_payload_rs3[4:0]      ), //o
+    .io_output_payload_rd          (cmdArbiter_arbiter_io_output_payload_rd[4:0]       ), //o
+    .io_output_payload_format      (cmdArbiter_arbiter_io_output_payload_format        ), //o
+    .io_output_payload_roundMode   (cmdArbiter_arbiter_io_output_payload_roundMode[2:0]), //o
+    .io_chosenOH                   (cmdArbiter_arbiter_io_chosenOH                     ), //o
+    .clk                           (clk                                                ), //i
+    .reset                         (reset                                              )  //i
   );
   FpuDiv div_divider (
-    .io_input_valid              (div_divider_io_input_valid            ), //i
-    .io_input_ready              (div_divider_io_input_ready            ), //o
-    .io_input_payload_a          (div_divider_io_input_payload_a        ), //i
-    .io_input_payload_b          (div_divider_io_input_payload_b        ), //i
-    .io_output_valid             (div_divider_io_output_valid           ), //o
-    .io_output_ready             (decode_div_input_ready                ), //i
-    .io_output_payload_result    (div_divider_io_output_payload_result  ), //o
-    .io_output_payload_remain    (div_divider_io_output_payload_remain  ), //o
-    .clk                         (clk                                   ), //i
-    .reset                       (reset                                 )  //i
+    .io_input_valid           (div_divider_io_input_valid                ), //i
+    .io_input_ready           (div_divider_io_input_ready                ), //o
+    .io_input_payload_a       (div_divider_io_input_payload_a[23:0]      ), //i
+    .io_input_payload_b       (div_divider_io_input_payload_b[23:0]      ), //i
+    .io_output_valid          (div_divider_io_output_valid               ), //o
+    .io_output_ready          (div_input_ready                           ), //i
+    .io_output_payload_result (div_divider_io_output_payload_result[26:0]), //o
+    .io_output_payload_remain (div_divider_io_output_payload_remain[24:0]), //o
+    .clk                      (clk                                       ), //i
+    .reset                    (reset                                     )  //i
   );
   FpuSqrt sqrt_sqrt (
-    .io_input_valid              (sqrt_sqrt_io_input_valid            ), //i
-    .io_input_ready              (sqrt_sqrt_io_input_ready            ), //o
-    .io_input_payload_a          (sqrt_sqrt_io_input_payload_a        ), //i
-    .io_output_valid             (sqrt_sqrt_io_output_valid           ), //o
-    .io_output_ready             (decode_sqrt_input_ready             ), //i
-    .io_output_payload_result    (sqrt_sqrt_io_output_payload_result  ), //o
-    .io_output_payload_remain    (sqrt_sqrt_io_output_payload_remain  ), //o
-    .clk                         (clk                                 ), //i
-    .reset                       (reset                               )  //i
+    .io_input_valid           (sqrt_sqrt_io_input_valid                ), //i
+    .io_input_ready           (sqrt_sqrt_io_input_ready                ), //o
+    .io_input_payload_a       (sqrt_sqrt_io_input_payload_a[24:0]      ), //i
+    .io_output_valid          (sqrt_sqrt_io_output_valid               ), //o
+    .io_output_ready          (sqrt_input_ready                        ), //i
+    .io_output_payload_result (sqrt_sqrt_io_output_payload_result[23:0]), //o
+    .io_output_payload_remain (sqrt_sqrt_io_output_payload_remain[27:0]), //o
+    .clk                      (clk                                     ), //i
+    .reset                    (reset                                   )  //i
   );
   StreamArbiter_1 streamArbiter_2 (
-    .io_inputs_0_valid                     (load_s1_output_m2sPipe_valid                      ), //i
-    .io_inputs_0_ready                     (streamArbiter_2_io_inputs_0_ready                 ), //o
-    .io_inputs_0_payload_rd                (load_s1_output_m2sPipe_payload_rd                 ), //i
-    .io_inputs_0_payload_value_mantissa    (load_s1_output_m2sPipe_payload_value_mantissa     ), //i
-    .io_inputs_0_payload_value_exponent    (load_s1_output_m2sPipe_payload_value_exponent     ), //i
-    .io_inputs_0_payload_value_sign        (load_s1_output_m2sPipe_payload_value_sign         ), //i
-    .io_inputs_0_payload_value_special     (load_s1_output_m2sPipe_payload_value_special      ), //i
-    .io_inputs_0_payload_scrap             (load_s1_output_m2sPipe_payload_scrap              ), //i
-    .io_inputs_0_payload_roundMode         (load_s1_output_m2sPipe_payload_roundMode          ), //i
-    .io_inputs_0_payload_NV                (load_s1_output_m2sPipe_payload_NV                 ), //i
-    .io_inputs_0_payload_DZ                (load_s1_output_m2sPipe_payload_DZ                 ), //i
-    .io_inputs_1_valid                     (sqrt_output_valid                                 ), //i
-    .io_inputs_1_ready                     (streamArbiter_2_io_inputs_1_ready                 ), //o
-    .io_inputs_1_payload_rd                (sqrt_output_payload_rd                            ), //i
-    .io_inputs_1_payload_value_mantissa    (sqrt_output_payload_value_mantissa                ), //i
-    .io_inputs_1_payload_value_exponent    (sqrt_output_payload_value_exponent                ), //i
-    .io_inputs_1_payload_value_sign        (sqrt_output_payload_value_sign                    ), //i
-    .io_inputs_1_payload_value_special     (sqrt_output_payload_value_special                 ), //i
-    .io_inputs_1_payload_scrap             (sqrt_output_payload_scrap                         ), //i
-    .io_inputs_1_payload_roundMode         (sqrt_output_payload_roundMode                     ), //i
-    .io_inputs_1_payload_NV                (sqrt_output_payload_NV                            ), //i
-    .io_inputs_1_payload_DZ                (sqrt_output_payload_DZ                            ), //i
-    .io_inputs_2_valid                     (div_output_valid                                  ), //i
-    .io_inputs_2_ready                     (streamArbiter_2_io_inputs_2_ready                 ), //o
-    .io_inputs_2_payload_rd                (div_output_payload_rd                             ), //i
-    .io_inputs_2_payload_value_mantissa    (div_output_payload_value_mantissa                 ), //i
-    .io_inputs_2_payload_value_exponent    (div_output_payload_value_exponent                 ), //i
-    .io_inputs_2_payload_value_sign        (div_output_payload_value_sign                     ), //i
-    .io_inputs_2_payload_value_special     (div_output_payload_value_special                  ), //i
-    .io_inputs_2_payload_scrap             (div_output_payload_scrap                          ), //i
-    .io_inputs_2_payload_roundMode         (div_output_payload_roundMode                      ), //i
-    .io_inputs_2_payload_NV                (div_output_payload_NV                             ), //i
-    .io_inputs_2_payload_DZ                (div_output_payload_DZ                             ), //i
-    .io_inputs_3_valid                     (add_result_output_valid                           ), //i
-    .io_inputs_3_ready                     (streamArbiter_2_io_inputs_3_ready                 ), //o
-    .io_inputs_3_payload_rd                (add_result_output_payload_rd                      ), //i
-    .io_inputs_3_payload_value_mantissa    (add_result_output_payload_value_mantissa          ), //i
-    .io_inputs_3_payload_value_exponent    (add_result_output_payload_value_exponent          ), //i
-    .io_inputs_3_payload_value_sign        (add_result_output_payload_value_sign              ), //i
-    .io_inputs_3_payload_value_special     (add_result_output_payload_value_special           ), //i
-    .io_inputs_3_payload_scrap             (add_result_output_payload_scrap                   ), //i
-    .io_inputs_3_payload_roundMode         (add_result_output_payload_roundMode               ), //i
-    .io_inputs_3_payload_NV                (add_result_output_payload_NV                      ), //i
-    .io_inputs_3_payload_DZ                (add_result_output_payload_DZ                      ), //i
-    .io_inputs_4_valid                     (mul_result_output_valid                           ), //i
-    .io_inputs_4_ready                     (streamArbiter_2_io_inputs_4_ready                 ), //o
-    .io_inputs_4_payload_rd                (mul_result_output_payload_rd                      ), //i
-    .io_inputs_4_payload_value_mantissa    (mul_result_output_payload_value_mantissa          ), //i
-    .io_inputs_4_payload_value_exponent    (mul_result_output_payload_value_exponent          ), //i
-    .io_inputs_4_payload_value_sign        (mul_result_output_payload_value_sign              ), //i
-    .io_inputs_4_payload_value_special     (mul_result_output_payload_value_special           ), //i
-    .io_inputs_4_payload_scrap             (mul_result_output_payload_scrap                   ), //i
-    .io_inputs_4_payload_roundMode         (mul_result_output_payload_roundMode               ), //i
-    .io_inputs_4_payload_NV                (mul_result_output_payload_NV                      ), //i
-    .io_inputs_4_payload_DZ                (mul_result_output_payload_DZ                      ), //i
-    .io_inputs_5_valid                     (shortPip_output_m2sPipe_valid                     ), //i
-    .io_inputs_5_ready                     (streamArbiter_2_io_inputs_5_ready                 ), //o
-    .io_inputs_5_payload_rd                (shortPip_output_m2sPipe_payload_rd                ), //i
-    .io_inputs_5_payload_value_mantissa    (shortPip_output_m2sPipe_payload_value_mantissa    ), //i
-    .io_inputs_5_payload_value_exponent    (shortPip_output_m2sPipe_payload_value_exponent    ), //i
-    .io_inputs_5_payload_value_sign        (shortPip_output_m2sPipe_payload_value_sign        ), //i
-    .io_inputs_5_payload_value_special     (shortPip_output_m2sPipe_payload_value_special     ), //i
-    .io_inputs_5_payload_scrap             (shortPip_output_m2sPipe_payload_scrap             ), //i
-    .io_inputs_5_payload_roundMode         (shortPip_output_m2sPipe_payload_roundMode         ), //i
-    .io_inputs_5_payload_NV                (shortPip_output_m2sPipe_payload_NV                ), //i
-    .io_inputs_5_payload_DZ                (shortPip_output_m2sPipe_payload_DZ                ), //i
-    .io_output_valid                       (streamArbiter_2_io_output_valid                   ), //o
-    .io_output_ready                       (1'b1                                              ), //i
-    .io_output_payload_rd                  (streamArbiter_2_io_output_payload_rd              ), //o
-    .io_output_payload_value_mantissa      (streamArbiter_2_io_output_payload_value_mantissa  ), //o
-    .io_output_payload_value_exponent      (streamArbiter_2_io_output_payload_value_exponent  ), //o
-    .io_output_payload_value_sign          (streamArbiter_2_io_output_payload_value_sign      ), //o
-    .io_output_payload_value_special       (streamArbiter_2_io_output_payload_value_special   ), //o
-    .io_output_payload_scrap               (streamArbiter_2_io_output_payload_scrap           ), //o
-    .io_output_payload_roundMode           (streamArbiter_2_io_output_payload_roundMode       ), //o
-    .io_output_payload_NV                  (streamArbiter_2_io_output_payload_NV              ), //o
-    .io_output_payload_DZ                  (streamArbiter_2_io_output_payload_DZ              ), //o
-    .io_chosen                             (streamArbiter_2_io_chosen                         ), //o
-    .io_chosenOH                           (streamArbiter_2_io_chosenOH                       ), //o
-    .clk                                   (clk                                               ), //i
-    .reset                                 (reset                                             )  //i
+    .io_inputs_0_valid                  (load_s1_output_m2sPipe_valid                          ), //i
+    .io_inputs_0_ready                  (streamArbiter_2_io_inputs_0_ready                     ), //o
+    .io_inputs_0_payload_rd             (load_s1_output_m2sPipe_payload_rd[4:0]                ), //i
+    .io_inputs_0_payload_value_mantissa (load_s1_output_m2sPipe_payload_value_mantissa[23:0]   ), //i
+    .io_inputs_0_payload_value_exponent (load_s1_output_m2sPipe_payload_value_exponent[8:0]    ), //i
+    .io_inputs_0_payload_value_sign     (load_s1_output_m2sPipe_payload_value_sign             ), //i
+    .io_inputs_0_payload_value_special  (load_s1_output_m2sPipe_payload_value_special          ), //i
+    .io_inputs_0_payload_scrap          (load_s1_output_m2sPipe_payload_scrap                  ), //i
+    .io_inputs_0_payload_roundMode      (load_s1_output_m2sPipe_payload_roundMode[2:0]         ), //i
+    .io_inputs_0_payload_NV             (load_s1_output_m2sPipe_payload_NV                     ), //i
+    .io_inputs_0_payload_DZ             (load_s1_output_m2sPipe_payload_DZ                     ), //i
+    .io_inputs_1_valid                  (sqrt_output_valid                                     ), //i
+    .io_inputs_1_ready                  (streamArbiter_2_io_inputs_1_ready                     ), //o
+    .io_inputs_1_payload_rd             (sqrt_output_payload_rd[4:0]                           ), //i
+    .io_inputs_1_payload_value_mantissa (sqrt_output_payload_value_mantissa[23:0]              ), //i
+    .io_inputs_1_payload_value_exponent (sqrt_output_payload_value_exponent[8:0]               ), //i
+    .io_inputs_1_payload_value_sign     (sqrt_output_payload_value_sign                        ), //i
+    .io_inputs_1_payload_value_special  (sqrt_output_payload_value_special                     ), //i
+    .io_inputs_1_payload_scrap          (sqrt_output_payload_scrap                             ), //i
+    .io_inputs_1_payload_roundMode      (sqrt_output_payload_roundMode[2:0]                    ), //i
+    .io_inputs_1_payload_NV             (sqrt_output_payload_NV                                ), //i
+    .io_inputs_1_payload_DZ             (sqrt_output_payload_DZ                                ), //i
+    .io_inputs_2_valid                  (div_output_valid                                      ), //i
+    .io_inputs_2_ready                  (streamArbiter_2_io_inputs_2_ready                     ), //o
+    .io_inputs_2_payload_rd             (div_output_payload_rd[4:0]                            ), //i
+    .io_inputs_2_payload_value_mantissa (div_output_payload_value_mantissa[23:0]               ), //i
+    .io_inputs_2_payload_value_exponent (div_output_payload_value_exponent[8:0]                ), //i
+    .io_inputs_2_payload_value_sign     (div_output_payload_value_sign                         ), //i
+    .io_inputs_2_payload_value_special  (div_output_payload_value_special                      ), //i
+    .io_inputs_2_payload_scrap          (div_output_payload_scrap                              ), //i
+    .io_inputs_2_payload_roundMode      (div_output_payload_roundMode[2:0]                     ), //i
+    .io_inputs_2_payload_NV             (div_output_payload_NV                                 ), //i
+    .io_inputs_2_payload_DZ             (div_output_payload_DZ                                 ), //i
+    .io_inputs_3_valid                  (add_result_output_valid                               ), //i
+    .io_inputs_3_ready                  (streamArbiter_2_io_inputs_3_ready                     ), //o
+    .io_inputs_3_payload_rd             (add_result_output_payload_rd[4:0]                     ), //i
+    .io_inputs_3_payload_value_mantissa (add_result_output_payload_value_mantissa[23:0]        ), //i
+    .io_inputs_3_payload_value_exponent (add_result_output_payload_value_exponent[8:0]         ), //i
+    .io_inputs_3_payload_value_sign     (add_result_output_payload_value_sign                  ), //i
+    .io_inputs_3_payload_value_special  (add_result_output_payload_value_special               ), //i
+    .io_inputs_3_payload_scrap          (add_result_output_payload_scrap                       ), //i
+    .io_inputs_3_payload_roundMode      (add_result_output_payload_roundMode[2:0]              ), //i
+    .io_inputs_3_payload_NV             (add_result_output_payload_NV                          ), //i
+    .io_inputs_3_payload_DZ             (add_result_output_payload_DZ                          ), //i
+    .io_inputs_4_valid                  (mul_result_output_valid                               ), //i
+    .io_inputs_4_ready                  (streamArbiter_2_io_inputs_4_ready                     ), //o
+    .io_inputs_4_payload_rd             (mul_result_output_payload_rd[4:0]                     ), //i
+    .io_inputs_4_payload_value_mantissa (mul_result_output_payload_value_mantissa[23:0]        ), //i
+    .io_inputs_4_payload_value_exponent (mul_result_output_payload_value_exponent[8:0]         ), //i
+    .io_inputs_4_payload_value_sign     (mul_result_output_payload_value_sign                  ), //i
+    .io_inputs_4_payload_value_special  (mul_result_output_payload_value_special               ), //i
+    .io_inputs_4_payload_scrap          (mul_result_output_payload_scrap                       ), //i
+    .io_inputs_4_payload_roundMode      (mul_result_output_payload_roundMode[2:0]              ), //i
+    .io_inputs_4_payload_NV             (mul_result_output_payload_NV                          ), //i
+    .io_inputs_4_payload_DZ             (mul_result_output_payload_DZ                          ), //i
+    .io_inputs_5_valid                  (shortPip_output_m2sPipe_valid                         ), //i
+    .io_inputs_5_ready                  (streamArbiter_2_io_inputs_5_ready                     ), //o
+    .io_inputs_5_payload_rd             (shortPip_output_m2sPipe_payload_rd[4:0]               ), //i
+    .io_inputs_5_payload_value_mantissa (shortPip_output_m2sPipe_payload_value_mantissa[23:0]  ), //i
+    .io_inputs_5_payload_value_exponent (shortPip_output_m2sPipe_payload_value_exponent[8:0]   ), //i
+    .io_inputs_5_payload_value_sign     (shortPip_output_m2sPipe_payload_value_sign            ), //i
+    .io_inputs_5_payload_value_special  (shortPip_output_m2sPipe_payload_value_special         ), //i
+    .io_inputs_5_payload_scrap          (shortPip_output_m2sPipe_payload_scrap                 ), //i
+    .io_inputs_5_payload_roundMode      (shortPip_output_m2sPipe_payload_roundMode[2:0]        ), //i
+    .io_inputs_5_payload_NV             (shortPip_output_m2sPipe_payload_NV                    ), //i
+    .io_inputs_5_payload_DZ             (shortPip_output_m2sPipe_payload_DZ                    ), //i
+    .io_output_valid                    (streamArbiter_2_io_output_valid                       ), //o
+    .io_output_ready                    (1'b1                                                  ), //i
+    .io_output_payload_rd               (streamArbiter_2_io_output_payload_rd[4:0]             ), //o
+    .io_output_payload_value_mantissa   (streamArbiter_2_io_output_payload_value_mantissa[23:0]), //o
+    .io_output_payload_value_exponent   (streamArbiter_2_io_output_payload_value_exponent[8:0] ), //o
+    .io_output_payload_value_sign       (streamArbiter_2_io_output_payload_value_sign          ), //o
+    .io_output_payload_value_special    (streamArbiter_2_io_output_payload_value_special       ), //o
+    .io_output_payload_scrap            (streamArbiter_2_io_output_payload_scrap               ), //o
+    .io_output_payload_roundMode        (streamArbiter_2_io_output_payload_roundMode[2:0]      ), //o
+    .io_output_payload_NV               (streamArbiter_2_io_output_payload_NV                  ), //o
+    .io_output_payload_DZ               (streamArbiter_2_io_output_payload_DZ                  ), //o
+    .io_chosen                          (streamArbiter_2_io_chosen[2:0]                        ), //o
+    .io_chosenOH                        (streamArbiter_2_io_chosenOH[5:0]                      ), //o
+    .clk                                (clk                                                   ), //i
+    .reset                              (reset                                                 )  //i
   );
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_port_0_cmd_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_cmd_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_cmd_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_cmd_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_cmd_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_cmd_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_cmd_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_cmd_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_cmd_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_cmd_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_cmd_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_cmd_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_cmd_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_cmd_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_cmd_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_cmd_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_cmd_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_port_0_cmd_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_port_0_cmd_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_port_0_cmd_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_port_0_cmd_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_port_0_cmd_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_port_0_cmd_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_port_0_cmd_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_port_0_cmd_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_port_0_cmd_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_port_0_cmd_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_port_0_cmd_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_port_0_cmd_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_port_0_cmd_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_port_0_cmd_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_port_0_cmd_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_port_0_cmd_payload_opcode_string = "FCVT_X_X";
       default : io_port_0_cmd_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_port_0_cmd_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_port_0_cmd_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_port_0_cmd_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_port_0_cmd_payload_format_string = "DOUBLE";
       default : io_port_0_cmd_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_port_0_cmd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_port_0_cmd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_port_0_cmd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_port_0_cmd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_port_0_cmd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_port_0_cmd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_port_0_cmd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_port_0_cmd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_port_0_cmd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_port_0_cmd_payload_roundMode_string = "RMM";
       default : io_port_0_cmd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_port_0_commit_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_commit_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_commit_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_commit_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_commit_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_commit_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_commit_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_commit_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_commit_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_commit_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_commit_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_commit_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_commit_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_commit_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_commit_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_commit_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_commit_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_port_0_commit_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_port_0_commit_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_port_0_commit_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_port_0_commit_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_port_0_commit_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_port_0_commit_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_port_0_commit_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_port_0_commit_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_port_0_commit_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_port_0_commit_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_port_0_commit_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_port_0_commit_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_port_0_commit_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_port_0_commit_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_port_0_commit_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_port_0_commit_payload_opcode_string = "FCVT_X_X";
       default : io_port_0_commit_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(commitFork_load_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : commitFork_load_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : commitFork_load_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : commitFork_load_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : commitFork_load_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : commitFork_load_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : commitFork_load_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : commitFork_load_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : commitFork_load_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : commitFork_load_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : commitFork_load_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : commitFork_load_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : commitFork_load_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : commitFork_load_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : commitFork_load_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : commitFork_load_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : commitFork_load_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : commitFork_load_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : commitFork_load_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : commitFork_load_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : commitFork_load_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : commitFork_load_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : commitFork_load_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : commitFork_load_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : commitFork_load_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : commitFork_load_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : commitFork_load_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : commitFork_load_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : commitFork_load_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : commitFork_load_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : commitFork_load_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : commitFork_load_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : commitFork_load_0_payload_opcode_string = "FCVT_X_X";
       default : commitFork_load_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(commitFork_commit_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : commitFork_commit_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : commitFork_commit_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : commitFork_commit_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : commitFork_commit_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : commitFork_commit_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : commitFork_commit_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : commitFork_commit_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : commitFork_commit_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : commitFork_commit_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : commitFork_commit_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : commitFork_commit_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : commitFork_commit_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : commitFork_commit_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : commitFork_commit_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : commitFork_commit_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : commitFork_commit_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : commitFork_commit_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : commitFork_commit_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : commitFork_commit_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : commitFork_commit_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : commitFork_commit_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : commitFork_commit_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : commitFork_commit_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : commitFork_commit_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : commitFork_commit_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : commitFork_commit_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : commitFork_commit_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : commitFork_commit_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : commitFork_commit_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : commitFork_commit_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : commitFork_commit_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : commitFork_commit_0_payload_opcode_string = "FCVT_X_X";
       default : commitFork_commit_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(streamFork_1_io_outputs_1_s2mPipe_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCVT_X_X";
       default : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(streamFork_1_io_outputs_1_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : streamFork_1_io_outputs_1_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : streamFork_1_io_outputs_1_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : streamFork_1_io_outputs_1_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : streamFork_1_io_outputs_1_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : streamFork_1_io_outputs_1_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : streamFork_1_io_outputs_1_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : streamFork_1_io_outputs_1_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : streamFork_1_io_outputs_1_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : streamFork_1_io_outputs_1_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : streamFork_1_io_outputs_1_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : streamFork_1_io_outputs_1_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : streamFork_1_io_outputs_1_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : streamFork_1_io_outputs_1_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : streamFork_1_io_outputs_1_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : streamFork_1_io_outputs_1_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : streamFork_1_io_outputs_1_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : streamFork_1_io_outputs_1_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : streamFork_1_io_outputs_1_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : streamFork_1_io_outputs_1_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : streamFork_1_io_outputs_1_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : streamFork_1_io_outputs_1_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : streamFork_1_io_outputs_1_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : streamFork_1_io_outputs_1_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : streamFork_1_io_outputs_1_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : streamFork_1_io_outputs_1_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : streamFork_1_io_outputs_1_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : streamFork_1_io_outputs_1_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : streamFork_1_io_outputs_1_rData_opcode_string = "FCVT_X_X";
       default : streamFork_1_io_outputs_1_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_payload_opcode_string = "FCVT_X_X";
       default : _zz_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_commitLogic_0_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_commitLogic_0_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_commitLogic_0_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_commitLogic_0_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_commitLogic_0_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_commitLogic_0_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_commitLogic_0_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_commitLogic_0_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_commitLogic_0_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_commitLogic_0_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_commitLogic_0_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_commitLogic_0_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_commitLogic_0_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_commitLogic_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_commitLogic_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_commitLogic_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_commitLogic_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_commitLogic_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_commitLogic_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_commitLogic_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_commitLogic_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_commitLogic_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_commitLogic_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_commitLogic_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_commitLogic_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
       default : _zz_commitLogic_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(commitLogic_0_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : commitLogic_0_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : commitLogic_0_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : commitLogic_0_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : commitLogic_0_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : commitLogic_0_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : commitLogic_0_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : commitLogic_0_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : commitLogic_0_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : commitLogic_0_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : commitLogic_0_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : commitLogic_0_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : commitLogic_0_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : commitLogic_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : commitLogic_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : commitLogic_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : commitLogic_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : commitLogic_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : commitLogic_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : commitLogic_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : commitLogic_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : commitLogic_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : commitLogic_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : commitLogic_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : commitLogic_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
       default : commitLogic_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_cmd_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_cmd_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_cmd_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_cmd_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_cmd_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_cmd_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_cmd_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_cmd_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_cmd_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_cmd_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_cmd_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_cmd_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_cmd_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_cmd_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_cmd_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_cmd_input_payload_opcode_string = "FCVT_X_X";
-      default : io_port_0_cmd_input_payload_opcode_string = "????????";
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : scheduler_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : scheduler_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : scheduler_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : scheduler_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : scheduler_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : scheduler_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : scheduler_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : scheduler_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : scheduler_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : scheduler_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : scheduler_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : scheduler_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : scheduler_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : scheduler_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : scheduler_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : scheduler_0_input_payload_opcode_string = "FCVT_X_X";
+      default : scheduler_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(io_port_0_cmd_input_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_port_0_cmd_input_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_port_0_cmd_input_payload_format_string = "DOUBLE";
-      default : io_port_0_cmd_input_payload_format_string = "??????";
+    case(scheduler_0_input_payload_format)
+      FpuFormat_FLOAT : scheduler_0_input_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : scheduler_0_input_payload_format_string = "DOUBLE";
+      default : scheduler_0_input_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
-    case(io_port_0_cmd_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_port_0_cmd_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_port_0_cmd_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_port_0_cmd_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_port_0_cmd_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_port_0_cmd_input_payload_roundMode_string = "RMM";
-      default : io_port_0_cmd_input_payload_roundMode_string = "???";
+    case(scheduler_0_input_payload_roundMode)
+      FpuRoundMode_RNE : scheduler_0_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : scheduler_0_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : scheduler_0_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : scheduler_0_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : scheduler_0_input_payload_roundMode_string = "RMM";
+      default : scheduler_0_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_cmd_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_cmd_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_cmd_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_cmd_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_cmd_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_cmd_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_cmd_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_cmd_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_cmd_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_cmd_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_cmd_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_cmd_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_cmd_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_cmd_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_cmd_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_cmd_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_port_0_cmd_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_port_0_cmd_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_port_0_cmd_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_port_0_cmd_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_port_0_cmd_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_port_0_cmd_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_port_0_cmd_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_port_0_cmd_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_port_0_cmd_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_port_0_cmd_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_port_0_cmd_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_port_0_cmd_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_port_0_cmd_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_port_0_cmd_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_port_0_cmd_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_port_0_cmd_rData_opcode_string = "FCVT_X_X";
       default : io_port_0_cmd_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_rData_format)
-      `FpuFormat_binary_sequential_FLOAT : io_port_0_cmd_rData_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_port_0_cmd_rData_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_port_0_cmd_rData_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_port_0_cmd_rData_format_string = "DOUBLE";
       default : io_port_0_cmd_rData_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_rData_roundMode)
-      `FpuRoundMode_opt_RNE : io_port_0_cmd_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_port_0_cmd_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_port_0_cmd_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_port_0_cmd_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_port_0_cmd_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_port_0_cmd_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_port_0_cmd_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_port_0_cmd_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_port_0_cmd_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_port_0_cmd_rData_roundMode_string = "RMM";
       default : io_port_0_cmd_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_io_port_0_cmd_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_io_port_0_cmd_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_io_port_0_cmd_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_io_port_0_cmd_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_io_port_0_cmd_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_io_port_0_cmd_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_io_port_0_cmd_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_io_port_0_cmd_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_io_port_0_cmd_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_io_port_0_cmd_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_io_port_0_cmd_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_io_port_0_cmd_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_io_port_0_cmd_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_io_port_0_cmd_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_io_port_0_cmd_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_io_port_0_cmd_input_payload_opcode_string = "FCVT_X_X";
-      default : _zz_io_port_0_cmd_input_payload_opcode_string = "????????";
+    case(_zz_scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : _zz_scheduler_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_scheduler_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_scheduler_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_scheduler_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_scheduler_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_scheduler_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_scheduler_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_scheduler_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_scheduler_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_scheduler_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_scheduler_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_scheduler_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_scheduler_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_scheduler_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_scheduler_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_scheduler_0_input_payload_opcode_string = "FCVT_X_X";
+      default : _zz_scheduler_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_io_port_0_cmd_input_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : _zz_io_port_0_cmd_input_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : _zz_io_port_0_cmd_input_payload_format_string = "DOUBLE";
-      default : _zz_io_port_0_cmd_input_payload_format_string = "??????";
+    case(_zz_scheduler_0_input_payload_format)
+      FpuFormat_FLOAT : _zz_scheduler_0_input_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : _zz_scheduler_0_input_payload_format_string = "DOUBLE";
+      default : _zz_scheduler_0_input_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
-    case(_zz_io_port_0_cmd_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_port_0_cmd_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_port_0_cmd_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_port_0_cmd_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_port_0_cmd_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_port_0_cmd_input_payload_roundMode_string = "RMM";
-      default : _zz_io_port_0_cmd_input_payload_roundMode_string = "???";
+    case(_zz_scheduler_0_input_payload_roundMode)
+      FpuRoundMode_RNE : _zz_scheduler_0_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_scheduler_0_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_scheduler_0_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_scheduler_0_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_scheduler_0_input_payload_roundMode_string = "RMM";
+      default : _zz_scheduler_0_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(scheduler_0_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : scheduler_0_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : scheduler_0_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : scheduler_0_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : scheduler_0_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : scheduler_0_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : scheduler_0_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : scheduler_0_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : scheduler_0_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : scheduler_0_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : scheduler_0_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : scheduler_0_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : scheduler_0_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : scheduler_0_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : scheduler_0_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : scheduler_0_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : scheduler_0_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : scheduler_0_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : scheduler_0_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : scheduler_0_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : scheduler_0_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : scheduler_0_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : scheduler_0_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : scheduler_0_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : scheduler_0_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : scheduler_0_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : scheduler_0_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : scheduler_0_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : scheduler_0_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : scheduler_0_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : scheduler_0_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : scheduler_0_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : scheduler_0_output_payload_opcode_string = "FCVT_X_X";
       default : scheduler_0_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(scheduler_0_output_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : scheduler_0_output_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : scheduler_0_output_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : scheduler_0_output_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : scheduler_0_output_payload_format_string = "DOUBLE";
       default : scheduler_0_output_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(scheduler_0_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : scheduler_0_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : scheduler_0_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : scheduler_0_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : scheduler_0_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : scheduler_0_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : scheduler_0_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : scheduler_0_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : scheduler_0_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : scheduler_0_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : scheduler_0_output_payload_roundMode_string = "RMM";
       default : scheduler_0_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_io_inputs_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_io_inputs_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_io_inputs_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_io_inputs_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_io_inputs_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_io_inputs_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_io_inputs_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_io_inputs_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_io_inputs_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_io_inputs_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_io_inputs_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_io_inputs_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_io_inputs_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_io_inputs_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_io_inputs_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_io_inputs_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_io_inputs_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_io_inputs_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_io_inputs_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_io_inputs_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_io_inputs_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_io_inputs_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_io_inputs_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_io_inputs_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_io_inputs_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_io_inputs_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_io_inputs_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_io_inputs_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_io_inputs_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_io_inputs_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_io_inputs_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_io_inputs_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_io_inputs_0_payload_opcode_string = "FCVT_X_X";
       default : _zz_io_inputs_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_io_inputs_0_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : _zz_io_inputs_0_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : _zz_io_inputs_0_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : _zz_io_inputs_0_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : _zz_io_inputs_0_payload_format_string = "DOUBLE";
       default : _zz_io_inputs_0_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(_zz_io_inputs_0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_inputs_0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_inputs_0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_inputs_0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_inputs_0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_inputs_0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_io_inputs_0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_io_inputs_0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_io_inputs_0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_io_inputs_0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_io_inputs_0_payload_roundMode_string = "RMM";
       default : _zz_io_inputs_0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(cmdArbiter_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : cmdArbiter_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : cmdArbiter_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : cmdArbiter_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : cmdArbiter_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : cmdArbiter_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : cmdArbiter_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : cmdArbiter_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : cmdArbiter_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : cmdArbiter_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : cmdArbiter_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : cmdArbiter_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : cmdArbiter_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : cmdArbiter_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : cmdArbiter_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : cmdArbiter_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : cmdArbiter_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : cmdArbiter_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : cmdArbiter_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : cmdArbiter_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : cmdArbiter_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : cmdArbiter_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : cmdArbiter_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : cmdArbiter_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : cmdArbiter_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : cmdArbiter_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : cmdArbiter_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : cmdArbiter_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : cmdArbiter_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : cmdArbiter_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : cmdArbiter_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : cmdArbiter_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : cmdArbiter_output_payload_opcode_string = "FCVT_X_X";
       default : cmdArbiter_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(cmdArbiter_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : cmdArbiter_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : cmdArbiter_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : cmdArbiter_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : cmdArbiter_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : cmdArbiter_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : cmdArbiter_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : cmdArbiter_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : cmdArbiter_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : cmdArbiter_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : cmdArbiter_output_payload_roundMode_string = "RMM";
       default : cmdArbiter_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(read_s0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_s0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_s0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_s0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_s0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_s0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_s0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_s0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_s0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_s0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_s0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_s0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_s0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_s0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_s0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_s0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_s0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : read_s0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_s0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_s0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_s0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_s0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_s0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_s0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_s0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_s0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_s0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_s0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_s0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_s0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_s0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_s0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_s0_payload_opcode_string = "FCVT_X_X";
       default : read_s0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(read_s0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : read_s0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_s0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_s0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_s0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_s0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : read_s0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_s0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_s0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_s0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_s0_payload_roundMode_string = "RMM";
       default : read_s0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(read_s0_s1_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_s0_s1_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_s0_s1_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_s0_s1_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_s0_s1_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_s0_s1_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_s0_s1_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_s0_s1_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_s0_s1_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_s0_s1_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_s0_s1_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_s0_s1_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_s0_s1_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_s0_s1_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_s0_s1_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_s0_s1_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_s0_s1_payload_opcode_string = "FCVT_X_X";
-      default : read_s0_s1_payload_opcode_string = "????????";
+    case(read_s1_payload_opcode)
+      FpuOpcode_LOAD : read_s1_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_s1_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_s1_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_s1_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_s1_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_s1_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_s1_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_s1_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_s1_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_s1_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_s1_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_s1_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_s1_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_s1_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_s1_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_s1_payload_opcode_string = "FCVT_X_X";
+      default : read_s1_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(read_s0_s1_payload_roundMode)
-      `FpuRoundMode_opt_RNE : read_s0_s1_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_s0_s1_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_s0_s1_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_s0_s1_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_s0_s1_payload_roundMode_string = "RMM";
-      default : read_s0_s1_payload_roundMode_string = "???";
+    case(read_s1_payload_roundMode)
+      FpuRoundMode_RNE : read_s1_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_s1_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_s1_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_s1_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_s1_payload_roundMode_string = "RMM";
+      default : read_s1_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(read_s0_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_s0_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_s0_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_s0_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_s0_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_s0_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_s0_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_s0_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_s0_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_s0_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_s0_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_s0_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_s0_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_s0_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_s0_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_s0_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_s0_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : read_s0_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_s0_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_s0_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_s0_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_s0_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_s0_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_s0_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_s0_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_s0_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_s0_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_s0_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_s0_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_s0_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_s0_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_s0_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_s0_rData_opcode_string = "FCVT_X_X";
       default : read_s0_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(read_s0_rData_roundMode)
-      `FpuRoundMode_opt_RNE : read_s0_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_s0_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_s0_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_s0_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_s0_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : read_s0_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_s0_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_s0_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_s0_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_s0_rData_roundMode_string = "RMM";
       default : read_s0_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(read_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : read_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_output_payload_opcode_string = "FCVT_X_X";
       default : read_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(read_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : read_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : read_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_output_payload_roundMode_string = "RMM";
       default : read_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : decode_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : decode_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : decode_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : decode_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : decode_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : decode_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : decode_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : decode_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : decode_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_input_payload_opcode_string = "FCVT_X_X";
       default : decode_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_input_payload_roundMode_string = "RMM";
       default : decode_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_payload_roundMode_string = "RMM";
       default : decode_load_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_shortPip_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_shortPip_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_shortPip_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_shortPip_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_shortPip_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_shortPip_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_shortPip_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_shortPip_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_shortPip_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_shortPip_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_shortPip_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_shortPip_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_shortPip_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_shortPip_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_shortPip_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_shortPip_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_shortPip_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : decode_shortPip_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : decode_shortPip_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : decode_shortPip_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : decode_shortPip_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : decode_shortPip_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : decode_shortPip_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : decode_shortPip_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : decode_shortPip_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : decode_shortPip_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_shortPip_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_shortPip_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_shortPip_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_shortPip_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_shortPip_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_shortPip_payload_opcode_string = "FCVT_X_X";
       default : decode_shortPip_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_shortPip_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_shortPip_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_shortPip_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_shortPip_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_shortPip_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_shortPip_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_shortPip_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_shortPip_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_shortPip_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_shortPip_payload_roundMode_string = "RMM";
       default : decode_shortPip_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_divSqrt_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_divSqrt_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_divSqrt_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_divSqrt_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_divSqrt_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_divSqrt_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_divSqrt_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_divSqrt_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_divSqrt_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_divSqrt_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_divSqrt_payload_roundMode_string = "RMM";
       default : decode_divSqrt_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_div_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_div_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_div_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_div_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_div_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_div_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_div_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_div_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_div_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_div_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_div_payload_roundMode_string = "RMM";
       default : decode_div_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_sqrt_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_sqrt_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_sqrt_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_sqrt_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_sqrt_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_sqrt_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_sqrt_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_sqrt_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_sqrt_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_sqrt_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_sqrt_payload_roundMode_string = "RMM";
       default : decode_sqrt_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_mul_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mul_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mul_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mul_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mul_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mul_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_mul_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_mul_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_mul_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_mul_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_mul_payload_roundMode_string = "RMM";
       default : decode_mul_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_divSqrtToMul_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_divSqrtToMul_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_divSqrtToMul_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_divSqrtToMul_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_divSqrtToMul_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_divSqrtToMul_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_divSqrtToMul_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_divSqrtToMul_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_divSqrtToMul_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_divSqrtToMul_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_divSqrtToMul_payload_roundMode_string = "RMM";
       default : decode_divSqrtToMul_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_add_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_add_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_add_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_add_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_add_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_add_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_add_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_add_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_add_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_add_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_add_payload_roundMode_string = "RMM";
       default : decode_add_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_mulToAdd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mulToAdd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mulToAdd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mulToAdd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mulToAdd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mulToAdd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_mulToAdd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_mulToAdd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_mulToAdd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_mulToAdd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_mulToAdd_payload_roundMode_string = "RMM";
       default : decode_mulToAdd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_payload_roundMode_string = "RMM";
       default : decode_load_s2mPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_rData_roundMode_string = "RMM";
       default : decode_load_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_load_s2mPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_decode_load_s2mPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_decode_load_s2mPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_decode_load_s2mPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_decode_load_s2mPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_decode_load_s2mPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_decode_load_s2mPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_decode_load_s2mPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_decode_load_s2mPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_decode_load_s2mPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_decode_load_s2mPipe_payload_roundMode_string = "RMM";
       default : _zz_decode_load_s2mPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RMM";
       default : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_rData_roundMode_string = "RMM";
       default : decode_load_s2mPipe_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_load_s2mPipe_m2sPipe_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RMM";
-      default : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "???";
+    case(load_s0_input_payload_roundMode)
+      FpuRoundMode_RNE : load_s0_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s0_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s0_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s0_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s0_input_payload_roundMode_string = "RMM";
+      default : load_s0_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_m2sPipe_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RMM";
       default : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s0_filtred_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : load_s0_filtred_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : load_s0_filtred_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : load_s0_filtred_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : load_s0_filtred_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : load_s0_filtred_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : load_s0_filtred_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : load_s0_filtred_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : load_s0_filtred_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : load_s0_filtred_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : load_s0_filtred_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : load_s0_filtred_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : load_s0_filtred_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : load_s0_filtred_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : load_s0_filtred_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : load_s0_filtred_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : load_s0_filtred_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : load_s0_filtred_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : load_s0_filtred_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : load_s0_filtred_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : load_s0_filtred_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : load_s0_filtred_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : load_s0_filtred_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : load_s0_filtred_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : load_s0_filtred_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : load_s0_filtred_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : load_s0_filtred_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : load_s0_filtred_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : load_s0_filtred_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : load_s0_filtred_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : load_s0_filtred_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : load_s0_filtred_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : load_s0_filtred_0_payload_opcode_string = "FCVT_X_X";
       default : load_s0_filtred_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(load_s0_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s0_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s0_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s0_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s0_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s0_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s0_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s0_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s0_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s0_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s0_output_payload_roundMode_string = "RMM";
       default : load_s0_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(load_s0_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s0_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s0_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s0_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s0_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s0_output_input_payload_roundMode_string = "RMM";
-      default : load_s0_output_input_payload_roundMode_string = "???";
+    case(load_s1_input_payload_roundMode)
+      FpuRoundMode_RNE : load_s1_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_input_payload_roundMode_string = "RMM";
+      default : load_s1_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s0_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : load_s0_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s0_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s0_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s0_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s0_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s0_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s0_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s0_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s0_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s0_output_rData_roundMode_string = "RMM";
       default : load_s0_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s1_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s1_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s1_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s1_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s1_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s1_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s1_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_output_payload_roundMode_string = "RMM";
       default : load_s1_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_shortPip_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_shortPip_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_shortPip_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_shortPip_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_shortPip_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_shortPip_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_shortPip_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_shortPip_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_shortPip_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_shortPip_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_shortPip_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_shortPip_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_shortPip_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_shortPip_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_shortPip_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_shortPip_input_payload_opcode_string = "FCVT_X_X";
-      default : decode_shortPip_input_payload_opcode_string = "????????";
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_LOAD : shortPip_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : shortPip_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : shortPip_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : shortPip_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : shortPip_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : shortPip_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : shortPip_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : shortPip_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : shortPip_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : shortPip_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : shortPip_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : shortPip_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : shortPip_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : shortPip_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : shortPip_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : shortPip_input_payload_opcode_string = "FCVT_X_X";
+      default : shortPip_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(decode_shortPip_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_shortPip_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_shortPip_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_shortPip_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_shortPip_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_shortPip_input_payload_roundMode_string = "RMM";
-      default : decode_shortPip_input_payload_roundMode_string = "???";
+    case(shortPip_input_payload_roundMode)
+      FpuRoundMode_RNE : shortPip_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_input_payload_roundMode_string = "RMM";
+      default : shortPip_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_shortPip_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_shortPip_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_shortPip_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_shortPip_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_shortPip_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_shortPip_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_shortPip_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_shortPip_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_shortPip_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_shortPip_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_shortPip_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_shortPip_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_shortPip_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_shortPip_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_shortPip_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_shortPip_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_shortPip_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : decode_shortPip_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : decode_shortPip_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : decode_shortPip_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : decode_shortPip_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : decode_shortPip_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : decode_shortPip_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : decode_shortPip_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : decode_shortPip_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : decode_shortPip_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_shortPip_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_shortPip_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_shortPip_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_shortPip_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_shortPip_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_shortPip_rData_opcode_string = "FCVT_X_X";
       default : decode_shortPip_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_shortPip_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_shortPip_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_shortPip_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_shortPip_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_shortPip_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_shortPip_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_shortPip_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_shortPip_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_shortPip_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_shortPip_rData_roundMode_string = "RMM";
       default : decode_shortPip_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_rfOutput_payload_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_rfOutput_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_rfOutput_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_rfOutput_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_rfOutput_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_rfOutput_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_rfOutput_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_rfOutput_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_rfOutput_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_rfOutput_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_rfOutput_payload_roundMode_string = "RMM";
       default : shortPip_rfOutput_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_output_payload_roundMode_string = "RMM";
       default : shortPip_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_mul_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mul_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mul_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mul_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mul_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mul_input_payload_roundMode_string = "RMM";
-      default : decode_mul_input_payload_roundMode_string = "???";
+    case(mul_preMul_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_preMul_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_preMul_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_preMul_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_preMul_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_preMul_input_payload_roundMode_string = "RMM";
+      default : mul_preMul_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_mul_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mul_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mul_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mul_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mul_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mul_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_mul_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_mul_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_mul_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_mul_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_mul_rData_roundMode_string = "RMM";
       default : decode_mul_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_preMul_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_preMul_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_preMul_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_preMul_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_preMul_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_preMul_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_preMul_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_preMul_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_preMul_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_preMul_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_preMul_output_payload_roundMode_string = "RMM";
       default : mul_preMul_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_preMul_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_preMul_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_preMul_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_preMul_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_preMul_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_preMul_output_input_payload_roundMode_string = "RMM";
-      default : mul_preMul_output_input_payload_roundMode_string = "???";
+    case(mul_mul_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_mul_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_mul_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_mul_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_mul_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_mul_input_payload_roundMode_string = "RMM";
+      default : mul_mul_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_preMul_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_preMul_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_preMul_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_preMul_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_preMul_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_preMul_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_preMul_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_preMul_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_preMul_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_preMul_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_preMul_output_rData_roundMode_string = "RMM";
       default : mul_preMul_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_mul_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_mul_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_mul_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_mul_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_mul_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_mul_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_mul_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_mul_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_mul_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_mul_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_mul_output_payload_roundMode_string = "RMM";
       default : mul_mul_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_mul_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_mul_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_mul_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_mul_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_mul_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_mul_output_input_payload_roundMode_string = "RMM";
-      default : mul_mul_output_input_payload_roundMode_string = "???";
+    case(mul_sum1_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_sum1_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum1_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum1_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum1_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum1_input_payload_roundMode_string = "RMM";
+      default : mul_sum1_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_mul_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_mul_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_mul_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_mul_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_mul_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_mul_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_mul_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_mul_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_mul_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_mul_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_mul_output_rData_roundMode_string = "RMM";
       default : mul_mul_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum1_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum1_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum1_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum1_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum1_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum1_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum1_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum1_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum1_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum1_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum1_output_payload_roundMode_string = "RMM";
       default : mul_sum1_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_sum1_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum1_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum1_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum1_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum1_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum1_output_input_payload_roundMode_string = "RMM";
-      default : mul_sum1_output_input_payload_roundMode_string = "???";
+    case(mul_sum2_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_sum2_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum2_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum2_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum2_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum2_input_payload_roundMode_string = "RMM";
+      default : mul_sum2_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum1_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum1_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum1_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum1_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum1_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum1_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum1_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum1_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum1_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum1_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum1_output_rData_roundMode_string = "RMM";
       default : mul_sum1_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum2_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum2_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum2_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum2_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum2_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum2_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum2_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum2_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum2_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum2_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum2_output_payload_roundMode_string = "RMM";
       default : mul_sum2_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_sum2_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum2_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum2_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum2_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum2_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum2_output_input_payload_roundMode_string = "RMM";
-      default : mul_sum2_output_input_payload_roundMode_string = "???";
+    case(mul_norm_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_norm_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_norm_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_norm_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_norm_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_norm_input_payload_roundMode_string = "RMM";
+      default : mul_norm_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum2_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum2_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum2_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum2_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum2_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum2_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum2_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum2_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum2_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum2_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum2_output_rData_roundMode_string = "RMM";
       default : mul_sum2_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_output_payload_roundMode_string = "RMM";
       default : mul_result_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_mulToAdd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_mulToAdd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_mulToAdd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_mulToAdd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_mulToAdd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_mulToAdd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_mulToAdd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_mulToAdd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_mulToAdd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_mulToAdd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_mulToAdd_payload_roundMode_string = "RMM";
       default : mul_result_mulToAdd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_mulToAdd_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RMM";
       default : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_mulToAdd_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_mulToAdd_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_mulToAdd_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_mulToAdd_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_mulToAdd_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_mulToAdd_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_mulToAdd_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_mulToAdd_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_mulToAdd_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_mulToAdd_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_mulToAdd_rData_roundMode_string = "RMM";
       default : mul_result_mulToAdd_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_div_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_div_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_div_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_div_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_div_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_div_input_payload_roundMode_string = "RMM";
-      default : decode_div_input_payload_roundMode_string = "???";
+    case(div_input_payload_roundMode)
+      FpuRoundMode_RNE : div_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : div_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : div_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : div_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : div_input_payload_roundMode_string = "RMM";
+      default : div_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_div_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_div_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_div_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_div_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_div_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_div_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_div_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_div_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_div_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_div_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_div_rData_roundMode_string = "RMM";
       default : decode_div_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(div_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : div_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : div_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : div_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : div_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : div_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : div_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : div_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : div_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : div_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : div_output_payload_roundMode_string = "RMM";
       default : div_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_sqrt_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_sqrt_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_sqrt_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_sqrt_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_sqrt_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_sqrt_input_payload_roundMode_string = "RMM";
-      default : decode_sqrt_input_payload_roundMode_string = "???";
+    case(sqrt_input_payload_roundMode)
+      FpuRoundMode_RNE : sqrt_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : sqrt_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : sqrt_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : sqrt_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : sqrt_input_payload_roundMode_string = "RMM";
+      default : sqrt_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_sqrt_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_sqrt_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_sqrt_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_sqrt_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_sqrt_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_sqrt_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_sqrt_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_sqrt_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_sqrt_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_sqrt_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_sqrt_rData_roundMode_string = "RMM";
       default : decode_sqrt_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(sqrt_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : sqrt_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : sqrt_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : sqrt_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : sqrt_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : sqrt_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : sqrt_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : sqrt_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : sqrt_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : sqrt_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : sqrt_output_payload_roundMode_string = "RMM";
       default : sqrt_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_preShifter_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_preShifter_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_preShifter_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_preShifter_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_preShifter_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_preShifter_input_payload_roundMode_string = "RMM";
       default : add_preShifter_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_preShifter_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_preShifter_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_preShifter_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_preShifter_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_preShifter_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_preShifter_output_payload_roundMode_string = "RMM";
       default : add_preShifter_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_preShifter_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_output_input_payload_roundMode_string = "RMM";
-      default : add_preShifter_output_input_payload_roundMode_string = "???";
+    case(add_shifter_input_payload_roundMode)
+      FpuRoundMode_RNE : add_shifter_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_shifter_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_shifter_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_shifter_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_shifter_input_payload_roundMode_string = "RMM";
+      default : add_shifter_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_preShifter_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_preShifter_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_preShifter_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_preShifter_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_preShifter_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_preShifter_output_rData_roundMode_string = "RMM";
       default : add_preShifter_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_shifter_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_shifter_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_shifter_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_shifter_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_shifter_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_shifter_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_shifter_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_shifter_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_shifter_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_shifter_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_shifter_output_payload_roundMode_string = "RMM";
       default : add_shifter_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_shifter_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_shifter_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_shifter_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_shifter_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_shifter_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_shifter_output_input_payload_roundMode_string = "RMM";
-      default : add_shifter_output_input_payload_roundMode_string = "???";
+    case(add_math_input_payload_roundMode)
+      FpuRoundMode_RNE : add_math_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_math_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_math_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_math_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_math_input_payload_roundMode_string = "RMM";
+      default : add_math_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_shifter_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_shifter_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_shifter_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_shifter_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_shifter_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_shifter_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_shifter_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_shifter_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_shifter_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_shifter_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_shifter_output_rData_roundMode_string = "RMM";
       default : add_shifter_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_math_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_math_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_math_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_math_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_math_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_math_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_math_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_math_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_math_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_math_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_math_output_payload_roundMode_string = "RMM";
       default : add_math_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_math_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_math_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_math_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_math_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_math_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_math_output_input_payload_roundMode_string = "RMM";
-      default : add_math_output_input_payload_roundMode_string = "???";
+    case(add_oh_input_payload_roundMode)
+      FpuRoundMode_RNE : add_oh_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_oh_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_oh_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_oh_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_oh_input_payload_roundMode_string = "RMM";
+      default : add_oh_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_math_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_math_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_math_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_math_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_math_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_math_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_math_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_math_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_math_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_math_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_math_output_rData_roundMode_string = "RMM";
       default : add_math_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_oh_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_oh_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_oh_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_oh_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_oh_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_oh_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_oh_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_oh_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_oh_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_oh_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_oh_output_payload_roundMode_string = "RMM";
       default : add_oh_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_oh_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_oh_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_oh_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_oh_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_oh_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_oh_output_input_payload_roundMode_string = "RMM";
-      default : add_oh_output_input_payload_roundMode_string = "???";
+    case(add_norm_input_payload_roundMode)
+      FpuRoundMode_RNE : add_norm_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_norm_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_norm_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_norm_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_norm_input_payload_roundMode_string = "RMM";
+      default : add_norm_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_oh_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_oh_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_oh_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_oh_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_oh_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_oh_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_oh_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_oh_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_oh_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_oh_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_oh_output_rData_roundMode_string = "RMM";
       default : add_oh_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_norm_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_norm_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_norm_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_norm_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_norm_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_norm_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_norm_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_norm_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_norm_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_norm_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_norm_output_payload_roundMode_string = "RMM";
       default : add_norm_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_result_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_result_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_result_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_result_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_result_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_result_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_result_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_result_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_result_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_result_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_result_input_payload_roundMode_string = "RMM";
       default : add_result_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_result_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_result_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_result_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_result_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_result_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_result_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_result_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_result_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_result_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_result_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_result_output_payload_roundMode_string = "RMM";
       default : add_result_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s1_output_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s1_output_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s1_output_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s1_output_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s1_output_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s1_output_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s1_output_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_output_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_output_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_output_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_output_m2sPipe_payload_roundMode_string = "RMM";
       default : load_s1_output_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s1_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : load_s1_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s1_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s1_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s1_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s1_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s1_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_output_rData_roundMode_string = "RMM";
       default : load_s1_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_output_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_output_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_output_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_output_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_output_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_output_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_output_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_output_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_output_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_output_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_output_m2sPipe_payload_roundMode_string = "RMM";
       default : shortPip_output_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_output_rData_roundMode_string = "RMM";
       default : shortPip_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(merge_arbitrated_payload_roundMode)
-      `FpuRoundMode_opt_RNE : merge_arbitrated_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : merge_arbitrated_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : merge_arbitrated_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : merge_arbitrated_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : merge_arbitrated_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : merge_arbitrated_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : merge_arbitrated_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : merge_arbitrated_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : merge_arbitrated_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : merge_arbitrated_payload_roundMode_string = "RMM";
       default : merge_arbitrated_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(roundFront_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : roundFront_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : roundFront_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : roundFront_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : roundFront_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : roundFront_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : roundFront_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : roundFront_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : roundFront_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : roundFront_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : roundFront_input_payload_roundMode_string = "RMM";
       default : roundFront_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(roundFront_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : roundFront_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : roundFront_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : roundFront_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : roundFront_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : roundFront_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : roundFront_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : roundFront_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : roundFront_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : roundFront_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : roundFront_output_payload_roundMode_string = "RMM";
       default : roundFront_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : roundBack_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : roundBack_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : roundBack_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : roundBack_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : roundBack_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : roundBack_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : roundBack_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : roundBack_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : roundBack_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : roundBack_input_payload_roundMode_string = "RMM";
       default : roundBack_input_payload_roundMode_string = "???";
     endcase
   end
@@ -10999,7 +10959,7 @@ module FpuCore (
   always @(*) begin
     rf_scoreboards_0_targetWrite_payload_address = rf_init_counter[4:0];
     if(when_FpuCore_l261) begin
-      rf_scoreboards_0_targetWrite_payload_address = io_port_0_cmd_input_payload_rd;
+      rf_scoreboards_0_targetWrite_payload_address = scheduler_0_input_payload_rd;
     end
   end
 
@@ -11052,8 +11012,8 @@ module FpuCore (
   assign commitFork_commit_0_payload_rd = streamFork_1_io_outputs_1_s2mPipe_payload_rd;
   assign commitFork_commit_0_payload_write = streamFork_1_io_outputs_1_s2mPipe_payload_write;
   assign commitFork_commit_0_payload_value = streamFork_1_io_outputs_1_s2mPipe_payload_value;
-  assign commitLogic_0_pending_full = (commitLogic_0_pending_counter == 4'b1111);
-  assign commitLogic_0_pending_notEmpty = (commitLogic_0_pending_counter != 4'b0000);
+  assign commitLogic_0_pending_full = (&commitLogic_0_pending_counter);
+  assign commitLogic_0_pending_notEmpty = (|commitLogic_0_pending_counter);
   always @(*) begin
     commitLogic_0_pending_inc = 1'b0;
     if(when_FpuCore_l265) begin
@@ -11068,8 +11028,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_add_full = (commitLogic_0_add_counter == 4'b1111);
-  assign commitLogic_0_add_notEmpty = (commitLogic_0_add_counter != 4'b0000);
+  assign commitLogic_0_add_full = (&commitLogic_0_add_counter);
+  assign commitLogic_0_add_notEmpty = (|commitLogic_0_add_counter);
   always @(*) begin
     commitLogic_0_add_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11086,8 +11046,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_mul_full = (commitLogic_0_mul_counter == 4'b1111);
-  assign commitLogic_0_mul_notEmpty = (commitLogic_0_mul_counter != 4'b0000);
+  assign commitLogic_0_mul_full = (&commitLogic_0_mul_counter);
+  assign commitLogic_0_mul_notEmpty = (|commitLogic_0_mul_counter);
   always @(*) begin
     commitLogic_0_mul_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11104,8 +11064,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_div_full = (commitLogic_0_div_counter == 4'b1111);
-  assign commitLogic_0_div_notEmpty = (commitLogic_0_div_counter != 4'b0000);
+  assign commitLogic_0_div_full = (&commitLogic_0_div_counter);
+  assign commitLogic_0_div_notEmpty = (|commitLogic_0_div_counter);
   always @(*) begin
     commitLogic_0_div_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11122,8 +11082,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_sqrt_full = (commitLogic_0_sqrt_counter == 4'b1111);
-  assign commitLogic_0_sqrt_notEmpty = (commitLogic_0_sqrt_counter != 4'b0000);
+  assign commitLogic_0_sqrt_full = (&commitLogic_0_sqrt_counter);
+  assign commitLogic_0_sqrt_notEmpty = (|commitLogic_0_sqrt_counter);
   always @(*) begin
     commitLogic_0_sqrt_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11140,8 +11100,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_short_full = (commitLogic_0_short_counter == 4'b1111);
-  assign commitLogic_0_short_notEmpty = (commitLogic_0_short_counter != 4'b0000);
+  assign commitLogic_0_short_full = (&commitLogic_0_short_counter);
+  assign commitLogic_0_short_notEmpty = (|commitLogic_0_short_counter);
   always @(*) begin
     commitLogic_0_short_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11166,66 +11126,66 @@ module FpuCore (
   assign commitLogic_0_input_payload_rd = commitFork_commit_0_payload_rd;
   assign commitLogic_0_input_payload_write = commitFork_commit_0_payload_write;
   assign commitLogic_0_input_payload_value = commitFork_commit_0_payload_value;
-  assign when_FpuCore_l208 = ((commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_ADD) != 1'b0);
-  assign when_FpuCore_l209 = ({(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_FMA),(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_MUL)} != 2'b00);
-  assign when_FpuCore_l210 = ((commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_DIV) != 1'b0);
-  assign when_FpuCore_l211 = ((commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_SQRT) != 1'b0);
-  assign when_FpuCore_l212 = ({(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX),(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_SGNJ)}} != 3'b000);
+  assign when_FpuCore_l208 = ((commitLogic_0_input_payload_opcode == FpuOpcode_ADD) != 1'b0);
+  assign when_FpuCore_l209 = ({(commitLogic_0_input_payload_opcode == FpuOpcode_FMA),(commitLogic_0_input_payload_opcode == FpuOpcode_MUL)} != 2'b00);
+  assign when_FpuCore_l210 = ((commitLogic_0_input_payload_opcode == FpuOpcode_DIV) != 1'b0);
+  assign when_FpuCore_l211 = ((commitLogic_0_input_payload_opcode == FpuOpcode_SQRT) != 1'b0);
+  assign when_FpuCore_l212 = ({(commitLogic_0_input_payload_opcode == FpuOpcode_FCVT_X_X),{(commitLogic_0_input_payload_opcode == FpuOpcode_MIN_MAX),(commitLogic_0_input_payload_opcode == FpuOpcode_SGNJ)}} != 3'b000);
   assign io_port_0_cmd_ready = (! io_port_0_cmd_rValid);
-  assign io_port_0_cmd_input_valid = (io_port_0_cmd_valid || io_port_0_cmd_rValid);
-  assign _zz_io_port_0_cmd_input_payload_opcode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_opcode : io_port_0_cmd_payload_opcode);
-  assign _zz_io_port_0_cmd_input_payload_format = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_format : io_port_0_cmd_payload_format);
-  assign _zz_io_port_0_cmd_input_payload_roundMode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_roundMode : io_port_0_cmd_payload_roundMode);
-  assign io_port_0_cmd_input_payload_opcode = _zz_io_port_0_cmd_input_payload_opcode;
-  assign io_port_0_cmd_input_payload_arg = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_arg : io_port_0_cmd_payload_arg);
-  assign io_port_0_cmd_input_payload_rs1 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs1 : io_port_0_cmd_payload_rs1);
-  assign io_port_0_cmd_input_payload_rs2 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs2 : io_port_0_cmd_payload_rs2);
-  assign io_port_0_cmd_input_payload_rs3 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs3 : io_port_0_cmd_payload_rs3);
-  assign io_port_0_cmd_input_payload_rd = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rd : io_port_0_cmd_payload_rd);
-  assign io_port_0_cmd_input_payload_format = _zz_io_port_0_cmd_input_payload_format;
-  assign io_port_0_cmd_input_payload_roundMode = _zz_io_port_0_cmd_input_payload_roundMode;
+  assign scheduler_0_input_valid = (io_port_0_cmd_valid || io_port_0_cmd_rValid);
+  assign _zz_scheduler_0_input_payload_opcode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_opcode : io_port_0_cmd_payload_opcode);
+  assign _zz_scheduler_0_input_payload_format = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_format : io_port_0_cmd_payload_format);
+  assign _zz_scheduler_0_input_payload_roundMode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_roundMode : io_port_0_cmd_payload_roundMode);
+  assign scheduler_0_input_payload_opcode = _zz_scheduler_0_input_payload_opcode;
+  assign scheduler_0_input_payload_arg = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_arg : io_port_0_cmd_payload_arg);
+  assign scheduler_0_input_payload_rs1 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs1 : io_port_0_cmd_payload_rs1);
+  assign scheduler_0_input_payload_rs2 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs2 : io_port_0_cmd_payload_rs2);
+  assign scheduler_0_input_payload_rs3 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs3 : io_port_0_cmd_payload_rs3);
+  assign scheduler_0_input_payload_rd = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rd : io_port_0_cmd_payload_rd);
+  assign scheduler_0_input_payload_format = _zz_scheduler_0_input_payload_format;
+  assign scheduler_0_input_payload_roundMode = _zz_scheduler_0_input_payload_roundMode;
   always @(*) begin
     scheduler_0_useRs1 = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
         scheduler_0_useRs1 = 1'b1;
       end
       default : begin
@@ -11236,44 +11196,44 @@ module FpuCore (
 
   always @(*) begin
     scheduler_0_useRs2 = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
       end
       default : begin
       end
@@ -11282,37 +11242,37 @@ module FpuCore (
 
   always @(*) begin
     scheduler_0_useRs3 = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRs3 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
       end
       default : begin
       end
@@ -11321,46 +11281,46 @@ module FpuCore (
 
   always @(*) begin
     scheduler_0_useRd = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
       end
       default : begin
         scheduler_0_useRd = 1'b1;
@@ -11385,25 +11345,25 @@ module FpuCore (
   assign scheduler_0_hits_2 = (scheduler_0_useRs3 && scheduler_0_rfBusy_2);
   assign scheduler_0_hits_3 = (scheduler_0_useRd && scheduler_0_rfBusy_3);
   assign scheduler_0_hazard = ((({scheduler_0_hits_3,{scheduler_0_hits_2,{scheduler_0_hits_1,scheduler_0_hits_0}}} != 4'b0000) || (! rf_init_done)) || commitLogic_0_pending_full);
-  assign _zz_io_port_0_cmd_input_ready = (! scheduler_0_hazard);
-  assign scheduler_0_output_valid = (io_port_0_cmd_input_valid && _zz_io_port_0_cmd_input_ready);
-  assign io_port_0_cmd_input_ready = (scheduler_0_output_ready && _zz_io_port_0_cmd_input_ready);
-  assign scheduler_0_output_payload_opcode = io_port_0_cmd_input_payload_opcode;
-  assign scheduler_0_output_payload_arg = io_port_0_cmd_input_payload_arg;
+  assign _zz_scheduler_0_input_ready = (! scheduler_0_hazard);
+  assign scheduler_0_output_valid = (scheduler_0_input_valid && _zz_scheduler_0_input_ready);
+  assign scheduler_0_input_ready = (scheduler_0_output_ready && _zz_scheduler_0_input_ready);
+  assign scheduler_0_output_payload_opcode = scheduler_0_input_payload_opcode;
+  assign scheduler_0_output_payload_arg = scheduler_0_input_payload_arg;
   always @(*) begin
-    scheduler_0_output_payload_rs1 = io_port_0_cmd_input_payload_rs1;
+    scheduler_0_output_payload_rs1 = scheduler_0_input_payload_rs1;
     if(when_FpuCore_l258) begin
-      scheduler_0_output_payload_rs1 = io_port_0_cmd_input_payload_rs2;
+      scheduler_0_output_payload_rs1 = scheduler_0_input_payload_rs2;
     end
   end
 
-  assign scheduler_0_output_payload_rs2 = io_port_0_cmd_input_payload_rs2;
-  assign scheduler_0_output_payload_rs3 = io_port_0_cmd_input_payload_rs3;
-  assign scheduler_0_output_payload_rd = io_port_0_cmd_input_payload_rd;
-  assign scheduler_0_output_payload_format = io_port_0_cmd_input_payload_format;
-  assign scheduler_0_output_payload_roundMode = io_port_0_cmd_input_payload_roundMode;
-  assign when_FpuCore_l258 = (io_port_0_cmd_input_payload_opcode == `FpuOpcode_binary_sequential_STORE);
-  assign when_FpuCore_l261 = (io_port_0_cmd_input_valid && rf_init_done);
+  assign scheduler_0_output_payload_rs2 = scheduler_0_input_payload_rs2;
+  assign scheduler_0_output_payload_rs3 = scheduler_0_input_payload_rs3;
+  assign scheduler_0_output_payload_rd = scheduler_0_input_payload_rd;
+  assign scheduler_0_output_payload_format = scheduler_0_input_payload_format;
+  assign scheduler_0_output_payload_roundMode = scheduler_0_input_payload_roundMode;
+  assign when_FpuCore_l258 = (scheduler_0_input_payload_opcode == FpuOpcode_STORE);
+  assign when_FpuCore_l261 = (scheduler_0_input_valid && rf_init_done);
   assign scheduler_0_output_fire = (scheduler_0_output_valid && scheduler_0_output_ready);
   assign when_FpuCore_l265 = (scheduler_0_output_fire && scheduler_0_useRd);
   assign scheduler_0_output_ready = cmdArbiter_arbiter_io_inputs_0_ready;
@@ -11428,23 +11388,23 @@ module FpuCore (
   assign read_s0_payload_arg = cmdArbiter_output_payload_arg;
   assign read_s0_payload_roundMode = cmdArbiter_output_payload_roundMode;
   always @(*) begin
-    read_s0_ready = read_s0_s1_ready;
-    if(when_Stream_l342) begin
+    read_s0_ready = read_s1_ready;
+    if(when_Stream_l368) begin
       read_s0_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! read_s0_s1_valid);
-  assign read_s0_s1_valid = read_s0_rValid;
-  assign read_s0_s1_payload_opcode = read_s0_rData_opcode;
-  assign read_s0_s1_payload_rs1 = read_s0_rData_rs1;
-  assign read_s0_s1_payload_rs2 = read_s0_rData_rs2;
-  assign read_s0_s1_payload_rs3 = read_s0_rData_rs3;
-  assign read_s0_s1_payload_rd = read_s0_rData_rd;
-  assign read_s0_s1_payload_arg = read_s0_rData_arg;
-  assign read_s0_s1_payload_roundMode = read_s0_rData_roundMode;
-  assign read_output_valid = read_s0_s1_valid;
-  assign read_s0_s1_ready = read_output_ready;
+  assign when_Stream_l368 = (! read_s1_valid);
+  assign read_s1_valid = read_s0_rValid;
+  assign read_s1_payload_opcode = read_s0_rData_opcode;
+  assign read_s1_payload_rs1 = read_s0_rData_rs1;
+  assign read_s1_payload_rs2 = read_s0_rData_rs2;
+  assign read_s1_payload_rs3 = read_s0_rData_rs3;
+  assign read_s1_payload_rd = read_s0_rData_rd;
+  assign read_s1_payload_arg = read_s0_rData_arg;
+  assign read_s1_payload_roundMode = read_s0_rData_roundMode;
+  assign read_output_valid = read_s1_valid;
+  assign read_s1_ready = read_output_ready;
   assign _zz_read_rs_0_value_mantissa = read_s0_payload_rs1;
   assign read_output_isStall = (read_output_valid && (! read_output_ready));
   assign _zz_read_rs_0_value_mantissa_1 = (! read_output_isStall);
@@ -11469,10 +11429,10 @@ module FpuCore (
   assign read_rs_2_value_exponent = _zz_read_rs_2_value_mantissa_2[31 : 23];
   assign read_rs_2_value_sign = _zz_read_rs_2_value_mantissa_2[32];
   assign read_rs_2_value_special = _zz_read_rs_2_value_mantissa_2[33];
-  assign read_output_payload_opcode = read_s0_s1_payload_opcode;
-  assign read_output_payload_arg = read_s0_s1_payload_arg;
-  assign read_output_payload_roundMode = read_s0_s1_payload_roundMode;
-  assign read_output_payload_rd = read_s0_s1_payload_rd;
+  assign read_output_payload_opcode = read_s1_payload_opcode;
+  assign read_output_payload_arg = read_s1_payload_arg;
+  assign read_output_payload_roundMode = read_s1_payload_roundMode;
+  assign read_output_payload_rd = read_s1_payload_rd;
   assign read_output_payload_rs1_mantissa = read_rs_0_value_mantissa;
   assign read_output_payload_rs1_exponent = read_rs_0_value_exponent;
   assign read_output_payload_rs1_sign = read_rs_0_value_sign;
@@ -11525,14 +11485,14 @@ module FpuCore (
     end
   end
 
-  assign decode_loadHit = ({(decode_input_payload_opcode == `FpuOpcode_binary_sequential_I2F),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FMV_W_X),(decode_input_payload_opcode == `FpuOpcode_binary_sequential_LOAD)}} != 3'b000);
+  assign decode_loadHit = ({(decode_input_payload_opcode == FpuOpcode_I2F),{(decode_input_payload_opcode == FpuOpcode_FMV_W_X),(decode_input_payload_opcode == FpuOpcode_LOAD)}} != 3'b000);
   assign decode_load_valid = (decode_input_valid && decode_loadHit);
   assign when_FpuCore_l329 = (decode_loadHit && decode_load_ready);
   assign decode_load_payload_rd = decode_input_payload_rd;
   assign decode_load_payload_arg = decode_input_payload_arg;
   assign decode_load_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_load_payload_i2f = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_I2F);
-  assign decode_shortPipHit = ({(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FCLASS),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FMV_X_W),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_SGNJ),{(decode_input_payload_opcode == _zz_decode_shortPipHit),{_zz_decode_shortPipHit_1,{_zz_decode_shortPipHit_2,_zz_decode_shortPipHit_3}}}}}}} != 8'h0);
+  assign decode_load_payload_i2f = (decode_input_payload_opcode == FpuOpcode_I2F);
+  assign decode_shortPipHit = ({(decode_input_payload_opcode == FpuOpcode_FCVT_X_X),{(decode_input_payload_opcode == FpuOpcode_FCLASS),{(decode_input_payload_opcode == FpuOpcode_FMV_X_W),{(decode_input_payload_opcode == FpuOpcode_SGNJ),{(decode_input_payload_opcode == _zz_decode_shortPipHit),{_zz_decode_shortPipHit_1,{_zz_decode_shortPipHit_2,_zz_decode_shortPipHit_3}}}}}}} != 8'h0);
   assign when_FpuCore_l335 = (decode_shortPipHit && decode_shortPip_ready);
   assign decode_shortPip_valid = (decode_input_valid && decode_shortPipHit);
   assign decode_shortPip_payload_opcode = decode_input_payload_opcode;
@@ -11547,8 +11507,8 @@ module FpuCore (
   assign decode_shortPip_payload_rd = decode_input_payload_rd;
   assign decode_shortPip_payload_arg = decode_input_payload_arg;
   assign decode_shortPip_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_divSqrtHit = ((decode_input_payload_opcode == `FpuOpcode_binary_sequential_DIV) || (decode_input_payload_opcode == `FpuOpcode_binary_sequential_SQRT));
-  assign decode_divHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_DIV);
+  assign decode_divSqrtHit = ((decode_input_payload_opcode == FpuOpcode_DIV) || (decode_input_payload_opcode == FpuOpcode_SQRT));
+  assign decode_divHit = (decode_input_payload_opcode == FpuOpcode_DIV);
   assign when_FpuCore_l351 = (decode_divHit && decode_div_ready);
   assign decode_div_valid = (decode_input_valid && decode_divHit);
   assign decode_div_payload_rs1_mantissa = decode_input_payload_rs1_mantissa;
@@ -11561,7 +11521,7 @@ module FpuCore (
   assign decode_div_payload_rs2_special = decode_input_payload_rs2_special;
   assign decode_div_payload_rd = decode_input_payload_rd;
   assign decode_div_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_sqrtHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_SQRT);
+  assign decode_sqrtHit = (decode_input_payload_opcode == FpuOpcode_SQRT);
   assign when_FpuCore_l359 = (decode_sqrtHit && decode_sqrt_ready);
   assign decode_sqrt_valid = (decode_input_valid && decode_sqrtHit);
   assign decode_sqrt_payload_rs1_mantissa = decode_input_payload_rs1_mantissa;
@@ -11570,8 +11530,8 @@ module FpuCore (
   assign decode_sqrt_payload_rs1_special = decode_input_payload_rs1_special;
   assign decode_sqrt_payload_rd = decode_input_payload_rd;
   assign decode_sqrt_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_fmaHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_FMA);
-  assign decode_mulHit = ((decode_input_payload_opcode == `FpuOpcode_binary_sequential_MUL) || decode_fmaHit);
+  assign decode_fmaHit = (decode_input_payload_opcode == FpuOpcode_FMA);
+  assign decode_mulHit = ((decode_input_payload_opcode == FpuOpcode_MUL) || decode_fmaHit);
   assign decode_divSqrtToMul_valid = 1'b0;
   assign decode_divSqrtToMul_payload_rs1_mantissa = 23'bxxxxxxxxxxxxxxxxxxxxxxx;
   assign decode_divSqrtToMul_payload_rs1_exponent = 9'bxxxxxxxxx;
@@ -11723,7 +11683,7 @@ module FpuCore (
   end
 
   assign when_FpuCore_l380 = (! decode_divSqrtToMul_valid);
-  assign decode_addHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_ADD);
+  assign decode_addHit = (decode_input_payload_opcode == FpuOpcode_ADD);
   assign when_FpuCore_l399 = ((decode_addHit && decode_add_ready) && (! decode_mulToAdd_valid));
   assign decode_add_valid = ((decode_input_valid && decode_addHit) || decode_mulToAdd_valid);
   assign decode_mulToAdd_ready = decode_add_ready;
@@ -11814,41 +11774,41 @@ module FpuCore (
   assign decode_load_s2mPipe_payload_roundMode = _zz_decode_load_s2mPipe_payload_roundMode;
   always @(*) begin
     decode_load_s2mPipe_ready = decode_load_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342_1) begin
+    if(when_Stream_l368_1) begin
       decode_load_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_1 = (! decode_load_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368_1 = (! decode_load_s2mPipe_m2sPipe_valid);
   assign decode_load_s2mPipe_m2sPipe_valid = decode_load_s2mPipe_rValid;
   assign decode_load_s2mPipe_m2sPipe_payload_rd = decode_load_s2mPipe_rData_rd;
   assign decode_load_s2mPipe_m2sPipe_payload_i2f = decode_load_s2mPipe_rData_i2f;
   assign decode_load_s2mPipe_m2sPipe_payload_arg = decode_load_s2mPipe_rData_arg;
   assign decode_load_s2mPipe_m2sPipe_payload_roundMode = decode_load_s2mPipe_rData_roundMode;
   always @(*) begin
-    decode_load_s2mPipe_m2sPipe_ready = decode_load_s2mPipe_m2sPipe_input_ready;
-    if(when_Stream_l342_2) begin
+    decode_load_s2mPipe_m2sPipe_ready = load_s0_input_ready;
+    if(when_Stream_l368_2) begin
       decode_load_s2mPipe_m2sPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_2 = (! decode_load_s2mPipe_m2sPipe_input_valid);
-  assign decode_load_s2mPipe_m2sPipe_input_valid = decode_load_s2mPipe_m2sPipe_rValid;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_rd = decode_load_s2mPipe_m2sPipe_rData_rd;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_i2f = decode_load_s2mPipe_m2sPipe_rData_i2f;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_arg = decode_load_s2mPipe_m2sPipe_rData_arg;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_roundMode = decode_load_s2mPipe_m2sPipe_rData_roundMode;
-  assign when_Stream_l408 = (! ({(commitFork_load_0_payload_opcode == `FpuOpcode_binary_sequential_I2F),{(commitFork_load_0_payload_opcode == `FpuOpcode_binary_sequential_FMV_W_X),(commitFork_load_0_payload_opcode == `FpuOpcode_binary_sequential_LOAD)}} != 3'b000));
+  assign when_Stream_l368_2 = (! load_s0_input_valid);
+  assign load_s0_input_valid = decode_load_s2mPipe_m2sPipe_rValid;
+  assign load_s0_input_payload_rd = decode_load_s2mPipe_m2sPipe_rData_rd;
+  assign load_s0_input_payload_i2f = decode_load_s2mPipe_m2sPipe_rData_i2f;
+  assign load_s0_input_payload_arg = decode_load_s2mPipe_m2sPipe_rData_arg;
+  assign load_s0_input_payload_roundMode = decode_load_s2mPipe_m2sPipe_rData_roundMode;
+  assign when_Stream_l438 = (! ({(commitFork_load_0_payload_opcode == FpuOpcode_I2F),{(commitFork_load_0_payload_opcode == FpuOpcode_FMV_W_X),(commitFork_load_0_payload_opcode == FpuOpcode_LOAD)}} != 3'b000));
   always @(*) begin
     load_s0_filtred_0_valid = commitFork_load_0_valid;
-    if(when_Stream_l408) begin
+    if(when_Stream_l438) begin
       load_s0_filtred_0_valid = 1'b0;
     end
   end
 
   always @(*) begin
     commitFork_load_0_ready = load_s0_filtred_0_ready;
-    if(when_Stream_l408) begin
+    if(when_Stream_l438) begin
       commitFork_load_0_ready = 1'b1;
     end
   end
@@ -11858,35 +11818,35 @@ module FpuCore (
   assign load_s0_filtred_0_payload_write = commitFork_load_0_payload_write;
   assign load_s0_filtred_0_payload_value = commitFork_load_0_payload_value;
   assign load_s0_hazard = (! load_s0_filtred_0_valid);
-  assign _zz_decode_load_s2mPipe_m2sPipe_input_ready = (! load_s0_hazard);
-  assign decode_load_s2mPipe_m2sPipe_input_ready = (load_s0_output_ready && _zz_decode_load_s2mPipe_m2sPipe_input_ready);
-  assign load_s0_output_valid = (decode_load_s2mPipe_m2sPipe_input_valid && _zz_decode_load_s2mPipe_m2sPipe_input_ready);
+  assign _zz_load_s0_input_ready = (! load_s0_hazard);
+  assign load_s0_input_ready = (load_s0_output_ready && _zz_load_s0_input_ready);
+  assign load_s0_output_valid = (load_s0_input_valid && _zz_load_s0_input_ready);
   always @(*) begin
     load_s0_filtred_0_ready = 1'b0;
     if(_zz_when[0]) begin
-      load_s0_filtred_0_ready = (decode_load_s2mPipe_m2sPipe_input_valid && load_s0_output_ready);
+      load_s0_filtred_0_ready = (load_s0_input_valid && load_s0_output_ready);
     end
   end
 
-  assign load_s0_output_payload_rd = decode_load_s2mPipe_m2sPipe_input_payload_rd;
+  assign load_s0_output_payload_rd = load_s0_input_payload_rd;
   assign load_s0_output_payload_value = load_s0_filtred_0_payload_value;
-  assign load_s0_output_payload_i2f = decode_load_s2mPipe_m2sPipe_input_payload_i2f;
-  assign load_s0_output_payload_arg = decode_load_s2mPipe_m2sPipe_input_payload_arg;
-  assign load_s0_output_payload_roundMode = decode_load_s2mPipe_m2sPipe_input_payload_roundMode;
+  assign load_s0_output_payload_i2f = load_s0_input_payload_i2f;
+  assign load_s0_output_payload_arg = load_s0_input_payload_arg;
+  assign load_s0_output_payload_roundMode = load_s0_input_payload_roundMode;
   always @(*) begin
-    load_s0_output_ready = load_s0_output_input_ready;
-    if(when_Stream_l342_3) begin
+    load_s0_output_ready = load_s1_input_ready;
+    if(when_Stream_l368_3) begin
       load_s0_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_3 = (! load_s0_output_input_valid);
-  assign load_s0_output_input_valid = load_s0_output_rValid;
-  assign load_s0_output_input_payload_rd = load_s0_output_rData_rd;
-  assign load_s0_output_input_payload_value = load_s0_output_rData_value;
-  assign load_s0_output_input_payload_i2f = load_s0_output_rData_i2f;
-  assign load_s0_output_input_payload_arg = load_s0_output_rData_arg;
-  assign load_s0_output_input_payload_roundMode = load_s0_output_rData_roundMode;
+  assign when_Stream_l368_3 = (! load_s1_input_valid);
+  assign load_s1_input_valid = load_s0_output_rValid;
+  assign load_s1_input_payload_rd = load_s0_output_rData_rd;
+  assign load_s1_input_payload_value = load_s0_output_rData_value;
+  assign load_s1_input_payload_i2f = load_s0_output_rData_i2f;
+  assign load_s1_input_payload_arg = load_s0_output_rData_arg;
+  assign load_s1_input_payload_roundMode = load_s0_output_rData_roundMode;
   always @(*) begin
     load_s1_busy = 1'b0;
     if(when_FpuCore_l529) begin
@@ -11894,9 +11854,9 @@ module FpuCore (
     end
   end
 
-  assign load_s1_f32_mantissa = load_s0_output_input_payload_value[22 : 0];
-  assign load_s1_f32_exponent = load_s0_output_input_payload_value[30 : 23];
-  assign load_s1_f32_sign = load_s0_output_input_payload_value[31];
+  assign load_s1_f32_mantissa = load_s1_input_payload_value[22 : 0];
+  assign load_s1_f32_exponent = load_s1_input_payload_value[30 : 23];
+  assign load_s1_f32_sign = load_s1_input_payload_value[31];
   assign load_s1_passThroughFloat_special = 1'b0;
   assign load_s1_passThroughFloat_sign = load_s1_f32_sign;
   assign load_s1_passThroughFloat_exponent = {1'd0, load_s1_f32_exponent};
@@ -11904,7 +11864,7 @@ module FpuCore (
   assign load_s1_recodedExpOffset = 9'h080;
   assign load_s1_manZero = (load_s1_passThroughFloat_mantissa == 23'h0);
   assign load_s1_expZero = (load_s1_passThroughFloat_exponent == 9'h0);
-  assign load_s1_expOne = (load_s1_passThroughFloat_exponent[7 : 0] == 8'hff);
+  assign load_s1_expOne = (&load_s1_passThroughFloat_exponent[7 : 0]);
   assign load_s1_isZero = (load_s1_expZero && load_s1_manZero);
   assign load_s1_isSubnormal = (load_s1_expZero && (! load_s1_manZero));
   assign load_s1_isInfinity = (load_s1_expOne && load_s1_manZero);
@@ -11912,22 +11872,22 @@ module FpuCore (
   always @(*) begin
     load_s1_fsm_ohInput = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     if(when_FpuCore_l508) begin
-      load_s1_fsm_ohInput = ({9'd0,load_s0_output_input_payload_value[22 : 0]} <<< 9);
+      load_s1_fsm_ohInput = ({9'd0,load_s1_input_payload_value[22 : 0]} <<< 9);
     end else begin
-      load_s1_fsm_ohInput[31 : 0] = load_s0_output_input_payload_value[31 : 0];
+      load_s1_fsm_ohInput[31 : 0] = load_s1_input_payload_value[31 : 0];
     end
   end
 
-  assign when_FpuCore_l508 = (! load_s0_output_input_payload_i2f);
+  assign when_FpuCore_l508 = (! load_s1_input_payload_i2f);
   always @(*) begin
     load_s1_fsm_shift_input = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     load_s1_fsm_shift_input = (load_s1_fsm_ohInput <<< 1);
   end
 
   assign when_FpuCore_l525 = (! load_s1_fsm_done);
-  assign when_FpuCore_l529 = ((load_s0_output_input_valid && (load_s0_output_input_payload_i2f || load_s1_isSubnormal)) && (! load_s1_fsm_done));
-  assign when_FpuCore_l532 = (((load_s0_output_input_payload_i2f && (! load_s1_fsm_patched)) && load_s0_output_input_payload_value[31]) && load_s0_output_input_payload_arg[0]);
-  assign _zz_load_s0_output_rData_value = load_s0_output_input_payload_value;
+  assign when_FpuCore_l529 = ((load_s1_input_valid && (load_s1_input_payload_i2f || load_s1_isSubnormal)) && (! load_s1_fsm_done));
+  assign when_FpuCore_l532 = (((load_s1_input_payload_i2f && (! load_s1_fsm_patched)) && load_s1_input_payload_value[31]) && load_s1_input_payload_arg[0]);
+  assign _zz_load_s0_output_rData_value = load_s1_input_payload_value;
   assign _zz_load_s0_output_rData_value_1 = 1'b1;
   assign _zz_load_s1_fsm_shift_by = {load_s1_fsm_ohInput[0],{load_s1_fsm_ohInput[1],{load_s1_fsm_ohInput[2],{load_s1_fsm_ohInput[3],{load_s1_fsm_ohInput[4],{load_s1_fsm_ohInput[5],{load_s1_fsm_ohInput[6],{load_s1_fsm_ohInput[7],{load_s1_fsm_ohInput[8],{_zz__zz_load_s1_fsm_shift_by,{_zz__zz_load_s1_fsm_shift_by_1,_zz__zz_load_s1_fsm_shift_by_2}}}}}}}}}}};
   assign _zz_load_s1_fsm_shift_by_1 = (_zz_load_s1_fsm_shift_by & (~ _zz__zz_load_s1_fsm_shift_by_1_1));
@@ -11969,8 +11929,8 @@ module FpuCore (
     end
   end
 
-  assign load_s0_output_input_isStall = (load_s0_output_input_valid && (! load_s0_output_input_ready));
-  assign when_FpuCore_l551 = (! load_s0_output_input_isStall);
+  assign load_s1_input_isStall = (load_s1_input_valid && (! load_s1_input_ready));
+  assign when_FpuCore_l551 = (! load_s1_input_isStall);
   assign load_s1_i2fHigh = load_s1_fsm_shift_output[31 : 8];
   assign load_s1_i2fLow = load_s1_fsm_shift_output[7 : 0];
   assign load_s1_scrap = (load_s1_i2fLow != 8'h0);
@@ -12003,21 +11963,21 @@ module FpuCore (
     end
   end
 
-  assign _zz_load_s0_output_input_ready = (! load_s1_busy);
-  assign load_s0_output_input_ready = (load_s1_output_ready && _zz_load_s0_output_input_ready);
-  assign load_s1_output_valid = (load_s0_output_input_valid && _zz_load_s0_output_input_ready);
-  assign load_s1_output_payload_roundMode = load_s0_output_input_payload_roundMode;
-  assign load_s1_output_payload_rd = load_s0_output_input_payload_rd;
+  assign _zz_load_s1_input_ready = (! load_s1_busy);
+  assign load_s1_input_ready = (load_s1_output_ready && _zz_load_s1_input_ready);
+  assign load_s1_output_valid = (load_s1_input_valid && _zz_load_s1_input_ready);
+  assign load_s1_output_payload_roundMode = load_s1_input_payload_roundMode;
+  assign load_s1_output_payload_rd = load_s1_input_payload_rd;
   always @(*) begin
     load_s1_output_payload_value_sign = load_s1_recoded_sign;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_value_sign = load_s1_fsm_patched;
     end
   end
 
   always @(*) begin
     load_s1_output_payload_value_exponent = load_s1_recoded_exponent;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_value_exponent = (9'h11e - _zz_load_s1_output_payload_value_exponent);
       if(load_s1_fsm_i2fZero) begin
         load_s1_output_payload_value_exponent[1 : 0] = 2'b00;
@@ -12034,7 +11994,7 @@ module FpuCore (
 
   always @(*) begin
     load_s1_output_payload_value_special = load_s1_recoded_special;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_value_special = 1'b0;
       if(load_s1_fsm_i2fZero) begin
         load_s1_output_payload_value_special = 1'b1;
@@ -12044,39 +12004,39 @@ module FpuCore (
 
   always @(*) begin
     load_s1_output_payload_scrap = 1'b0;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_scrap = load_s1_scrap;
     end
   end
 
   assign load_s1_output_payload_NV = 1'b0;
   assign load_s1_output_payload_DZ = 1'b0;
-  assign when_FpuCore_l594 = (load_s0_output_input_payload_i2f || load_s1_isSubnormal);
+  assign when_FpuCore_l594 = (load_s1_input_payload_i2f || load_s1_isSubnormal);
   always @(*) begin
-    decode_shortPip_ready = decode_shortPip_input_ready;
-    if(when_Stream_l342_4) begin
+    decode_shortPip_ready = shortPip_input_ready;
+    if(when_Stream_l368_4) begin
       decode_shortPip_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_4 = (! decode_shortPip_input_valid);
-  assign decode_shortPip_input_valid = decode_shortPip_rValid;
-  assign decode_shortPip_input_payload_opcode = decode_shortPip_rData_opcode;
-  assign decode_shortPip_input_payload_rs1_mantissa = decode_shortPip_rData_rs1_mantissa;
-  assign decode_shortPip_input_payload_rs1_exponent = decode_shortPip_rData_rs1_exponent;
-  assign decode_shortPip_input_payload_rs1_sign = decode_shortPip_rData_rs1_sign;
-  assign decode_shortPip_input_payload_rs1_special = decode_shortPip_rData_rs1_special;
-  assign decode_shortPip_input_payload_rs2_mantissa = decode_shortPip_rData_rs2_mantissa;
-  assign decode_shortPip_input_payload_rs2_exponent = decode_shortPip_rData_rs2_exponent;
-  assign decode_shortPip_input_payload_rs2_sign = decode_shortPip_rData_rs2_sign;
-  assign decode_shortPip_input_payload_rs2_special = decode_shortPip_rData_rs2_special;
-  assign decode_shortPip_input_payload_rd = decode_shortPip_rData_rd;
-  assign decode_shortPip_input_payload_value = decode_shortPip_rData_value;
-  assign decode_shortPip_input_payload_arg = decode_shortPip_rData_arg;
-  assign decode_shortPip_input_payload_roundMode = decode_shortPip_rData_roundMode;
-  assign shortPip_toFpuRf = ({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_SGNJ),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX)}} != 3'b000);
-  assign decode_shortPip_input_fire = (decode_shortPip_input_valid && decode_shortPip_input_ready);
-  assign when_FpuCore_l221 = ((decode_shortPip_input_fire && shortPip_toFpuRf) && 1'b1);
+  assign when_Stream_l368_4 = (! shortPip_input_valid);
+  assign shortPip_input_valid = decode_shortPip_rValid;
+  assign shortPip_input_payload_opcode = decode_shortPip_rData_opcode;
+  assign shortPip_input_payload_rs1_mantissa = decode_shortPip_rData_rs1_mantissa;
+  assign shortPip_input_payload_rs1_exponent = decode_shortPip_rData_rs1_exponent;
+  assign shortPip_input_payload_rs1_sign = decode_shortPip_rData_rs1_sign;
+  assign shortPip_input_payload_rs1_special = decode_shortPip_rData_rs1_special;
+  assign shortPip_input_payload_rs2_mantissa = decode_shortPip_rData_rs2_mantissa;
+  assign shortPip_input_payload_rs2_exponent = decode_shortPip_rData_rs2_exponent;
+  assign shortPip_input_payload_rs2_sign = decode_shortPip_rData_rs2_sign;
+  assign shortPip_input_payload_rs2_special = decode_shortPip_rData_rs2_special;
+  assign shortPip_input_payload_rd = decode_shortPip_rData_rd;
+  assign shortPip_input_payload_value = decode_shortPip_rData_value;
+  assign shortPip_input_payload_arg = decode_shortPip_rData_arg;
+  assign shortPip_input_payload_roundMode = decode_shortPip_rData_roundMode;
+  assign shortPip_toFpuRf = ({(shortPip_input_payload_opcode == FpuOpcode_FCVT_X_X),{(shortPip_input_payload_opcode == FpuOpcode_SGNJ),(shortPip_input_payload_opcode == FpuOpcode_MIN_MAX)}} != 3'b000);
+  assign shortPip_input_fire = (shortPip_input_valid && shortPip_input_ready);
+  assign when_FpuCore_l221 = ((shortPip_input_fire && shortPip_toFpuRf) && 1'b1);
   assign shortPip_isCommited = commitLogic_0_short_notEmpty;
   assign _zz_shortPip_rfOutput_ready = (! (! shortPip_isCommited));
   assign shortPip_output_valid = (shortPip_rfOutput_valid && _zz_shortPip_rfOutput_ready);
@@ -12092,20 +12052,20 @@ module FpuCore (
   assign shortPip_output_payload_DZ = shortPip_rfOutput_payload_DZ;
   always @(*) begin
     shortPip_result = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_STORE : begin
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_STORE : begin
         shortPip_result = shortPip_recodedResult;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
         shortPip_result = shortPip_recodedResult;
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
         shortPip_result[31 : 0] = shortPip_f2i_result;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
         shortPip_result[31 : 0] = {31'd0, shortPip_cmpResult};
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
         shortPip_result[31 : 0] = shortPip_fclassResult;
       end
       default : begin
@@ -12121,9 +12081,9 @@ module FpuCore (
   end
 
   assign shortPip_f32_exp = _zz_shortPip_f32_exp[7:0];
-  assign shortPip_f32_man = decode_shortPip_input_payload_rs1_mantissa[22 : 0];
+  assign shortPip_f32_man = shortPip_input_payload_rs1_mantissa[22 : 0];
   always @(*) begin
-    shortPip_recodedResult = {{decode_shortPip_input_payload_rs1_sign,shortPip_f32_exp},shortPip_f32_man};
+    shortPip_recodedResult = {{shortPip_input_payload_rs1_sign,shortPip_f32_exp},shortPip_f32_man};
     if(shortPip_isSubnormal) begin
       shortPip_recodedResult[22 : 0] = shortPip_fsm_shift_output[22 : 0];
     end
@@ -12140,16 +12100,16 @@ module FpuCore (
   end
 
   assign shortPip_expSubnormalThreshold = 8'h80;
-  assign shortPip_expInSubnormalRange = (decode_shortPip_input_payload_rs1_exponent <= _zz_shortPip_expInSubnormalRange);
-  assign shortPip_isSubnormal = ((! decode_shortPip_input_payload_rs1_special) && shortPip_expInSubnormalRange);
-  assign shortPip_isNormal = ((! decode_shortPip_input_payload_rs1_special) && (! shortPip_expInSubnormalRange));
-  assign shortPip_fsm_f2iShift = (decode_shortPip_input_payload_rs1_exponent - 9'h0ff);
-  assign shortPip_fsm_isF2i = (decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_F2I);
-  assign shortPip_fsm_needRecoding = (({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_STORE),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_FMV_X_W)} != 2'b00) && shortPip_isSubnormal);
-  assign shortPip_fsm_isZero = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign shortPip_expInSubnormalRange = (shortPip_input_payload_rs1_exponent <= _zz_shortPip_expInSubnormalRange);
+  assign shortPip_isSubnormal = ((! shortPip_input_payload_rs1_special) && shortPip_expInSubnormalRange);
+  assign shortPip_isNormal = ((! shortPip_input_payload_rs1_special) && (! shortPip_expInSubnormalRange));
+  assign shortPip_fsm_f2iShift = (shortPip_input_payload_rs1_exponent - 9'h0ff);
+  assign shortPip_fsm_isF2i = (shortPip_input_payload_opcode == FpuOpcode_F2I);
+  assign shortPip_fsm_needRecoding = (({(shortPip_input_payload_opcode == FpuOpcode_STORE),(shortPip_input_payload_opcode == FpuOpcode_FMV_X_W)} != 2'b00) && shortPip_isSubnormal);
+  assign shortPip_fsm_isZero = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
   always @(*) begin
     shortPip_fsm_shift_input = 33'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    shortPip_fsm_shift_input = ({9'd0,{(! shortPip_fsm_isZero),decode_shortPip_input_payload_rs1_mantissa}} <<< 9);
+    shortPip_fsm_shift_input = ({9'd0,{(! shortPip_fsm_isZero),shortPip_input_payload_rs1_mantissa}} <<< 9);
   end
 
   assign when_FpuCore_l646 = (shortPip_fsm_shift_by[5] && (shortPip_fsm_shift_input[31 : 0] != 32'h0));
@@ -12160,14 +12120,14 @@ module FpuCore (
   assign when_FpuCore_l646_5 = (shortPip_fsm_shift_by[0] && (shortPip_fsm_shift_input_5[0 : 0] != 1'b0));
   assign when_FpuCore_l652 = (! shortPip_fsm_done);
   assign shortPip_fsm_formatShiftOffset = 8'h8a;
-  assign when_FpuCore_l658 = ((decode_shortPip_input_valid && (shortPip_fsm_needRecoding || shortPip_fsm_isF2i)) && (! shortPip_fsm_done));
-  assign _zz_shortPip_fsm_shift_by = (9'h11e - decode_shortPip_input_payload_rs1_exponent);
+  assign when_FpuCore_l658 = ((shortPip_input_valid && (shortPip_fsm_needRecoding || shortPip_fsm_isF2i)) && (! shortPip_fsm_done));
+  assign _zz_shortPip_fsm_shift_by = (9'h11e - shortPip_input_payload_rs1_exponent);
   assign _zz_shortPip_fsm_shift_by_1 = 6'h21;
-  assign decode_shortPip_input_isStall = (decode_shortPip_input_valid && (! decode_shortPip_input_ready));
-  assign when_FpuCore_l672 = (! decode_shortPip_input_isStall);
+  assign shortPip_input_isStall = (shortPip_input_valid && (! shortPip_input_ready));
+  assign when_FpuCore_l672 = (! shortPip_input_isStall);
   always @(*) begin
     shortPip_mantissaForced = 1'b0;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_mantissaForced = 1'b1;
@@ -12188,7 +12148,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_exponentForced = 1'b0;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_exponentForced = 1'b1;
@@ -12210,7 +12170,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_mantissaForcedValue = 1'bx;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_mantissaForcedValue = 1'b0;
@@ -12231,7 +12191,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_exponentForcedValue = 1'bx;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_exponentForcedValue = 1'b0;
@@ -12253,7 +12213,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_cononicalForced = 1'b0;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b10 : begin
           if(when_FpuCore_l702) begin
@@ -12266,13 +12226,13 @@ module FpuCore (
     end
   end
 
-  assign switch_FpuCore_l686 = decode_shortPip_input_payload_rs1_exponent[1 : 0];
-  assign when_FpuCore_l702 = decode_shortPip_input_payload_rs1_exponent[2];
+  assign switch_FpuCore_l686 = shortPip_input_payload_rs1_exponent[1 : 0];
+  assign when_FpuCore_l702 = shortPip_input_payload_rs1_exponent[2];
   always @(*) begin
     shortPip_rspNv = 1'b0;
     if(!shortPip_f2i_isZero) begin
       if(when_FpuCore_l767) begin
-        shortPip_rspNv = (((decode_shortPip_input_valid && (decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_F2I)) && shortPip_fsm_done) && (! shortPip_f2i_isZero));
+        shortPip_rspNv = (((shortPip_input_valid && (shortPip_input_payload_opcode == FpuOpcode_F2I)) && shortPip_fsm_done) && (! shortPip_f2i_isZero));
       end
     end
     if(shortPip_NV) begin
@@ -12284,27 +12244,27 @@ module FpuCore (
     shortPip_rspNx = 1'b0;
     if(!shortPip_f2i_isZero) begin
       if(!when_FpuCore_l767) begin
-        shortPip_rspNx = (((decode_shortPip_input_valid && (decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_F2I)) && shortPip_fsm_done) && (shortPip_f2i_round != 2'b00));
+        shortPip_rspNx = (((shortPip_input_valid && (shortPip_input_payload_opcode == FpuOpcode_F2I)) && shortPip_fsm_done) && (shortPip_f2i_round != 2'b00));
       end
     end
   end
 
   assign shortPip_f2i_unsigned = (shortPip_fsm_shift_output[32 : 0] >>> 1);
-  assign shortPip_f2i_resign = (decode_shortPip_input_payload_arg[0] && decode_shortPip_input_payload_rs1_sign);
+  assign shortPip_f2i_resign = (shortPip_input_payload_arg[0] && shortPip_input_payload_rs1_sign);
   assign shortPip_f2i_round = {shortPip_fsm_shift_output[0],shortPip_fsm_shift_scrap};
   always @(*) begin
-    case(decode_shortPip_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+    case(shortPip_input_payload_roundMode)
+      FpuRoundMode_RNE : begin
         shortPip_f2i_increment = (shortPip_f2i_round[1] && (shortPip_f2i_round[0] || shortPip_f2i_unsigned[0]));
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         shortPip_f2i_increment = 1'b0;
       end
-      `FpuRoundMode_opt_RDN : begin
-        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && decode_shortPip_input_payload_rs1_sign);
+      FpuRoundMode_RDN : begin
+        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && shortPip_input_payload_rs1_sign);
       end
-      `FpuRoundMode_opt_RUP : begin
-        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && (! decode_shortPip_input_payload_rs1_sign));
+      FpuRoundMode_RUP : begin
+        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && (! shortPip_input_payload_rs1_sign));
       end
       default : begin
         shortPip_f2i_increment = shortPip_f2i_round[1];
@@ -12319,25 +12279,25 @@ module FpuCore (
     end else begin
       if(when_FpuCore_l767) begin
         shortPip_f2i_result = (shortPip_f2i_overflow ? 32'hffffffff : 32'h0);
-        shortPip_f2i_result[31] = (decode_shortPip_input_payload_arg[0] ^ shortPip_f2i_overflow);
+        shortPip_f2i_result[31] = (shortPip_input_payload_arg[0] ^ shortPip_f2i_overflow);
       end
     end
   end
 
-  assign shortPip_f2i_overflow = (((((decode_shortPip_input_payload_arg[0] ? 9'h11d : 9'h11e) < decode_shortPip_input_payload_rs1_exponent) || (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (! decode_shortPip_input_payload_rs1_sign)) || (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
-  assign shortPip_f2i_underflow = (((((9'h11e < decode_shortPip_input_payload_rs1_exponent) || ((decode_shortPip_input_payload_arg[0] && shortPip_f2i_unsigned[31]) && ((shortPip_f2i_unsigned[30 : 0] != 31'h0) || shortPip_f2i_increment))) || ((! decode_shortPip_input_payload_arg[0]) && ((shortPip_f2i_unsigned != 32'h0) || shortPip_f2i_increment))) || (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && decode_shortPip_input_payload_rs1_sign);
-  assign shortPip_f2i_isZero = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign shortPip_f2i_overflow = (((((shortPip_input_payload_arg[0] ? 9'h11d : 9'h11e) < shortPip_input_payload_rs1_exponent) || (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (! shortPip_input_payload_rs1_sign)) || (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
+  assign shortPip_f2i_underflow = (((((9'h11e < shortPip_input_payload_rs1_exponent) || ((shortPip_input_payload_arg[0] && shortPip_f2i_unsigned[31]) && ((shortPip_f2i_unsigned[30 : 0] != 31'h0) || shortPip_f2i_increment))) || ((! shortPip_input_payload_arg[0]) && ((shortPip_f2i_unsigned != 32'h0) || shortPip_f2i_increment))) || (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && shortPip_input_payload_rs1_sign);
+  assign shortPip_f2i_isZero = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
   assign when_FpuCore_l767 = (shortPip_f2i_underflow || shortPip_f2i_overflow);
-  assign shortPip_bothZero = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign shortPip_bothZero = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00)));
   always @(*) begin
-    shortPip_rs1Equal = ((((decode_shortPip_input_payload_rs1_mantissa == decode_shortPip_input_payload_rs2_mantissa) && (decode_shortPip_input_payload_rs1_exponent == decode_shortPip_input_payload_rs2_exponent)) && (decode_shortPip_input_payload_rs1_sign == decode_shortPip_input_payload_rs2_sign)) && (decode_shortPip_input_payload_rs1_special == decode_shortPip_input_payload_rs2_special));
+    shortPip_rs1Equal = ((((shortPip_input_payload_rs1_mantissa == shortPip_input_payload_rs2_mantissa) && (shortPip_input_payload_rs1_exponent == shortPip_input_payload_rs2_exponent)) && (shortPip_input_payload_rs1_sign == shortPip_input_payload_rs2_sign)) && (shortPip_input_payload_rs1_special == shortPip_input_payload_rs2_special));
     if(when_FpuCore_l784) begin
       shortPip_rs1Equal = 1'b1;
     end
   end
 
   always @(*) begin
-    shortPip_rs1AbsSmaller = ({decode_shortPip_input_payload_rs1_exponent,decode_shortPip_input_payload_rs1_mantissa} < {decode_shortPip_input_payload_rs2_exponent,decode_shortPip_input_payload_rs2_mantissa});
+    shortPip_rs1AbsSmaller = ({shortPip_input_payload_rs1_exponent,shortPip_input_payload_rs1_mantissa} < {shortPip_input_payload_rs2_exponent,shortPip_input_payload_rs2_mantissa});
     if(when_FpuCore_l780) begin
       shortPip_rs1AbsSmaller = 1'b1;
     end
@@ -12352,14 +12312,14 @@ module FpuCore (
     end
   end
 
-  assign when_FpuCore_l780 = (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01));
-  assign when_FpuCore_l781 = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
-  assign when_FpuCore_l782 = (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00));
-  assign when_FpuCore_l783 = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
-  assign when_FpuCore_l784 = (((decode_shortPip_input_payload_rs1_sign == decode_shortPip_input_payload_rs2_sign) && (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01)));
-  assign switch_Misc_l200 = {decode_shortPip_input_payload_rs1_sign,decode_shortPip_input_payload_rs2_sign};
+  assign when_FpuCore_l780 = (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01));
+  assign when_FpuCore_l781 = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign when_FpuCore_l782 = (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00));
+  assign when_FpuCore_l783 = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
+  assign when_FpuCore_l784 = (((shortPip_input_payload_rs1_sign == shortPip_input_payload_rs2_sign) && (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign switch_Misc_l210 = {shortPip_input_payload_rs1_sign,shortPip_input_payload_rs2_sign};
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         shortPip_rs1Smaller = shortPip_rs1AbsSmaller;
       end
@@ -12375,51 +12335,51 @@ module FpuCore (
     endcase
   end
 
-  assign shortPip_minMaxSelectRs2 = (! (((shortPip_rs1Smaller ^ decode_shortPip_input_payload_arg[0]) && (! (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)))) || (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10))));
-  assign shortPip_minMaxSelectNanQuiet = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
+  assign shortPip_minMaxSelectRs2 = (! (((shortPip_rs1Smaller ^ shortPip_input_payload_arg[0]) && (! (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)))) || (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10))));
+  assign shortPip_minMaxSelectNanQuiet = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
   always @(*) begin
-    shortPip_cmpResult = (((shortPip_rs1Smaller && (! shortPip_bothZero)) && (! decode_shortPip_input_payload_arg[1])) || ((shortPip_rs1Equal || shortPip_bothZero) && (! decode_shortPip_input_payload_arg[0])));
+    shortPip_cmpResult = (((shortPip_rs1Smaller && (! shortPip_bothZero)) && (! shortPip_input_payload_arg[1])) || ((shortPip_rs1Equal || shortPip_bothZero) && (! shortPip_input_payload_arg[0])));
     if(when_FpuCore_l796) begin
       shortPip_cmpResult = 1'b0;
     end
   end
 
-  assign when_FpuCore_l796 = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
-  assign shortPip_sgnjRs1Sign = decode_shortPip_input_payload_rs1_sign;
-  assign shortPip_sgnjRs2Sign = decode_shortPip_input_payload_rs2_sign;
-  assign shortPip_sgnjResult = (((shortPip_sgnjRs1Sign && decode_shortPip_input_payload_arg[1]) ^ shortPip_sgnjRs2Sign) ^ decode_shortPip_input_payload_arg[0]);
+  assign when_FpuCore_l796 = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
+  assign shortPip_sgnjRs1Sign = shortPip_input_payload_rs1_sign;
+  assign shortPip_sgnjRs2Sign = shortPip_input_payload_rs2_sign;
+  assign shortPip_sgnjResult = (((shortPip_sgnjRs1Sign && shortPip_input_payload_arg[1]) ^ shortPip_sgnjRs2Sign) ^ shortPip_input_payload_arg[0]);
   always @(*) begin
     shortPip_fclassResult = 32'h0;
-    shortPip_fclassResult[0] = (decode_shortPip_input_payload_rs1_sign && shortPip_decoded_isInfinity);
-    shortPip_fclassResult[1] = (decode_shortPip_input_payload_rs1_sign && shortPip_isNormal);
-    shortPip_fclassResult[2] = (decode_shortPip_input_payload_rs1_sign && shortPip_isSubnormal);
-    shortPip_fclassResult[3] = (decode_shortPip_input_payload_rs1_sign && shortPip_decoded_isZero);
-    shortPip_fclassResult[4] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_decoded_isZero);
-    shortPip_fclassResult[5] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_isSubnormal);
-    shortPip_fclassResult[6] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_isNormal);
-    shortPip_fclassResult[7] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_decoded_isInfinity);
+    shortPip_fclassResult[0] = (shortPip_input_payload_rs1_sign && shortPip_decoded_isInfinity);
+    shortPip_fclassResult[1] = (shortPip_input_payload_rs1_sign && shortPip_isNormal);
+    shortPip_fclassResult[2] = (shortPip_input_payload_rs1_sign && shortPip_isSubnormal);
+    shortPip_fclassResult[3] = (shortPip_input_payload_rs1_sign && shortPip_decoded_isZero);
+    shortPip_fclassResult[4] = ((! shortPip_input_payload_rs1_sign) && shortPip_decoded_isZero);
+    shortPip_fclassResult[5] = ((! shortPip_input_payload_rs1_sign) && shortPip_isSubnormal);
+    shortPip_fclassResult[6] = ((! shortPip_input_payload_rs1_sign) && shortPip_isNormal);
+    shortPip_fclassResult[7] = ((! shortPip_input_payload_rs1_sign) && shortPip_decoded_isInfinity);
     shortPip_fclassResult[8] = (shortPip_decoded_isNan && (! shortPip_decoded_isQuiet));
     shortPip_fclassResult[9] = (shortPip_decoded_isNan && shortPip_decoded_isQuiet);
   end
 
-  assign shortPip_decoded_isZero = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
-  assign shortPip_decoded_isNormal = (! decode_shortPip_input_payload_rs1_special);
-  assign shortPip_decoded_isInfinity = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
-  assign shortPip_decoded_isNan = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
-  assign shortPip_decoded_isQuiet = decode_shortPip_input_payload_rs1_mantissa[22];
-  assign shortPip_rfOutput_valid = ((decode_shortPip_input_valid && shortPip_toFpuRf) && (! shortPip_halt));
-  assign shortPip_rfOutput_payload_rd = decode_shortPip_input_payload_rd;
-  assign shortPip_rfOutput_payload_roundMode = decode_shortPip_input_payload_roundMode;
+  assign shortPip_decoded_isZero = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign shortPip_decoded_isNormal = (! shortPip_input_payload_rs1_special);
+  assign shortPip_decoded_isInfinity = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
+  assign shortPip_decoded_isNan = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
+  assign shortPip_decoded_isQuiet = shortPip_input_payload_rs1_mantissa[22];
+  assign shortPip_rfOutput_valid = ((shortPip_input_valid && shortPip_toFpuRf) && (! shortPip_halt));
+  assign shortPip_rfOutput_payload_rd = shortPip_input_payload_rd;
+  assign shortPip_rfOutput_payload_roundMode = shortPip_input_payload_roundMode;
   assign shortPip_rfOutput_payload_scrap = 1'b0;
   always @(*) begin
-    shortPip_rfOutput_payload_value_sign = decode_shortPip_input_payload_rs1_sign;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_sign = shortPip_input_payload_rs1_sign;
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_sign = decode_shortPip_input_payload_rs2_sign;
+          shortPip_rfOutput_payload_value_sign = shortPip_input_payload_rs2_sign;
         end
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         if(when_FpuCore_l850) begin
           shortPip_rfOutput_payload_value_sign = shortPip_sgnjResult;
         end
@@ -12430,11 +12390,11 @@ module FpuCore (
   end
 
   always @(*) begin
-    shortPip_rfOutput_payload_value_exponent = decode_shortPip_input_payload_rs1_exponent;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_exponent = shortPip_input_payload_rs1_exponent;
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_exponent = decode_shortPip_input_payload_rs2_exponent;
+          shortPip_rfOutput_payload_value_exponent = shortPip_input_payload_rs2_exponent;
         end
         if(shortPip_minMaxSelectNanQuiet) begin
           shortPip_rfOutput_payload_value_exponent[1 : 0] = 2'b10;
@@ -12447,11 +12407,11 @@ module FpuCore (
   end
 
   always @(*) begin
-    shortPip_rfOutput_payload_value_mantissa = {decode_shortPip_input_payload_rs1_mantissa,1'b0};
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_mantissa = {shortPip_input_payload_rs1_mantissa,1'b0};
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_mantissa = {decode_shortPip_input_payload_rs2_mantissa,1'b0};
+          shortPip_rfOutput_payload_value_mantissa = {shortPip_input_payload_rs2_mantissa,1'b0};
         end
         if(shortPip_minMaxSelectNanQuiet) begin
           shortPip_rfOutput_payload_value_mantissa[23] = 1'b1;
@@ -12463,11 +12423,11 @@ module FpuCore (
   end
 
   always @(*) begin
-    shortPip_rfOutput_payload_value_special = decode_shortPip_input_payload_rs1_special;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_special = shortPip_input_payload_rs1_special;
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_special = decode_shortPip_input_payload_rs2_special;
+          shortPip_rfOutput_payload_value_special = shortPip_input_payload_rs2_special;
         end
         if(shortPip_minMaxSelectNanQuiet) begin
           shortPip_rfOutput_payload_value_special = 1'b1;
@@ -12478,26 +12438,26 @@ module FpuCore (
     endcase
   end
 
-  assign when_FpuCore_l850 = (! (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
-  assign shortPip_signalQuiet = ((decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_CMP) && (decode_shortPip_input_payload_arg != 2'b10));
-  assign shortPip_rs1Nan = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
-  assign shortPip_rs2Nan = (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10));
-  assign shortPip_rs1NanNv = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && ((! decode_shortPip_input_payload_rs1_mantissa[22]) || shortPip_signalQuiet));
-  assign shortPip_rs2NanNv = ((decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)) && ((! decode_shortPip_input_payload_rs2_mantissa[22]) || shortPip_signalQuiet));
-  assign shortPip_NV = ((({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_CMP)}} != 3'b000) && shortPip_rs1NanNv) || (({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_CMP)} != 2'b00) && shortPip_rs2NanNv));
-  assign decode_shortPip_input_ready = ((! shortPip_halt) && (shortPip_toFpuRf ? shortPip_rfOutput_ready : shortPip_rspStreams_0_ready));
-  assign shortPip_rspStreams_0_valid = (((decode_shortPip_input_valid && 1'b1) && (! shortPip_toFpuRf)) && (! shortPip_halt));
+  assign when_FpuCore_l850 = (! (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
+  assign shortPip_signalQuiet = ((shortPip_input_payload_opcode == FpuOpcode_CMP) && (shortPip_input_payload_arg != 2'b10));
+  assign shortPip_rs1Nan = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
+  assign shortPip_rs2Nan = (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10));
+  assign shortPip_rs1NanNv = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && ((! shortPip_input_payload_rs1_mantissa[22]) || shortPip_signalQuiet));
+  assign shortPip_rs2NanNv = ((shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)) && ((! shortPip_input_payload_rs2_mantissa[22]) || shortPip_signalQuiet));
+  assign shortPip_NV = ((({(shortPip_input_payload_opcode == FpuOpcode_FCVT_X_X),{(shortPip_input_payload_opcode == FpuOpcode_MIN_MAX),(shortPip_input_payload_opcode == FpuOpcode_CMP)}} != 3'b000) && shortPip_rs1NanNv) || (({(shortPip_input_payload_opcode == FpuOpcode_MIN_MAX),(shortPip_input_payload_opcode == FpuOpcode_CMP)} != 2'b00) && shortPip_rs2NanNv));
+  assign shortPip_input_ready = ((! shortPip_halt) && (shortPip_toFpuRf ? shortPip_rfOutput_ready : shortPip_rspStreams_0_ready));
+  assign shortPip_rspStreams_0_valid = (((shortPip_input_valid && 1'b1) && (! shortPip_toFpuRf)) && (! shortPip_halt));
   assign shortPip_rspStreams_0_payload_value = shortPip_result;
   assign shortPip_rspStreams_0_payload_NV = shortPip_rspNv;
   assign shortPip_rspStreams_0_payload_NX = shortPip_rspNx;
   always @(*) begin
     shortPip_rspStreams_0_ready = shortPip_rspStreams_0_m2sPipe_ready;
-    if(when_Stream_l342_5) begin
+    if(when_Stream_l368_5) begin
       shortPip_rspStreams_0_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_5 = (! shortPip_rspStreams_0_m2sPipe_valid);
+  assign when_Stream_l368_5 = (! shortPip_rspStreams_0_m2sPipe_valid);
   assign shortPip_rspStreams_0_m2sPipe_valid = shortPip_rspStreams_0_rValid;
   assign shortPip_rspStreams_0_m2sPipe_payload_value = shortPip_rspStreams_0_rData_value;
   assign shortPip_rspStreams_0_m2sPipe_payload_NV = shortPip_rspStreams_0_rData_NV;
@@ -12510,254 +12470,254 @@ module FpuCore (
   assign shortPip_rfOutput_payload_NV = shortPip_NV;
   assign shortPip_rfOutput_payload_DZ = 1'b0;
   always @(*) begin
-    decode_mul_ready = decode_mul_input_ready;
-    if(when_Stream_l342_6) begin
+    decode_mul_ready = mul_preMul_input_ready;
+    if(when_Stream_l368_6) begin
       decode_mul_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_6 = (! decode_mul_input_valid);
-  assign decode_mul_input_valid = decode_mul_rValid;
-  assign decode_mul_input_payload_rs1_mantissa = decode_mul_rData_rs1_mantissa;
-  assign decode_mul_input_payload_rs1_exponent = decode_mul_rData_rs1_exponent;
-  assign decode_mul_input_payload_rs1_sign = decode_mul_rData_rs1_sign;
-  assign decode_mul_input_payload_rs1_special = decode_mul_rData_rs1_special;
-  assign decode_mul_input_payload_rs2_mantissa = decode_mul_rData_rs2_mantissa;
-  assign decode_mul_input_payload_rs2_exponent = decode_mul_rData_rs2_exponent;
-  assign decode_mul_input_payload_rs2_sign = decode_mul_rData_rs2_sign;
-  assign decode_mul_input_payload_rs2_special = decode_mul_rData_rs2_special;
-  assign decode_mul_input_payload_rs3_mantissa = decode_mul_rData_rs3_mantissa;
-  assign decode_mul_input_payload_rs3_exponent = decode_mul_rData_rs3_exponent;
-  assign decode_mul_input_payload_rs3_sign = decode_mul_rData_rs3_sign;
-  assign decode_mul_input_payload_rs3_special = decode_mul_rData_rs3_special;
-  assign decode_mul_input_payload_rd = decode_mul_rData_rd;
-  assign decode_mul_input_payload_add = decode_mul_rData_add;
-  assign decode_mul_input_payload_divSqrt = decode_mul_rData_divSqrt;
-  assign decode_mul_input_payload_msb1 = decode_mul_rData_msb1;
-  assign decode_mul_input_payload_msb2 = decode_mul_rData_msb2;
-  assign decode_mul_input_payload_roundMode = decode_mul_rData_roundMode;
-  assign mul_preMul_output_valid = decode_mul_input_valid;
-  assign decode_mul_input_ready = mul_preMul_output_ready;
-  assign mul_preMul_output_payload_rs1_mantissa = decode_mul_input_payload_rs1_mantissa;
-  assign mul_preMul_output_payload_rs1_exponent = decode_mul_input_payload_rs1_exponent;
-  assign mul_preMul_output_payload_rs1_sign = decode_mul_input_payload_rs1_sign;
-  assign mul_preMul_output_payload_rs1_special = decode_mul_input_payload_rs1_special;
-  assign mul_preMul_output_payload_rs2_mantissa = decode_mul_input_payload_rs2_mantissa;
-  assign mul_preMul_output_payload_rs2_exponent = decode_mul_input_payload_rs2_exponent;
-  assign mul_preMul_output_payload_rs2_sign = decode_mul_input_payload_rs2_sign;
-  assign mul_preMul_output_payload_rs2_special = decode_mul_input_payload_rs2_special;
-  assign mul_preMul_output_payload_rs3_mantissa = decode_mul_input_payload_rs3_mantissa;
-  assign mul_preMul_output_payload_rs3_exponent = decode_mul_input_payload_rs3_exponent;
-  assign mul_preMul_output_payload_rs3_sign = decode_mul_input_payload_rs3_sign;
-  assign mul_preMul_output_payload_rs3_special = decode_mul_input_payload_rs3_special;
-  assign mul_preMul_output_payload_rd = decode_mul_input_payload_rd;
-  assign mul_preMul_output_payload_add = decode_mul_input_payload_add;
-  assign mul_preMul_output_payload_divSqrt = decode_mul_input_payload_divSqrt;
-  assign mul_preMul_output_payload_msb1 = decode_mul_input_payload_msb1;
-  assign mul_preMul_output_payload_msb2 = decode_mul_input_payload_msb2;
-  assign mul_preMul_output_payload_roundMode = decode_mul_input_payload_roundMode;
-  assign mul_preMul_output_payload_exp = ({1'b0,decode_mul_input_payload_rs1_exponent} + {1'b0,decode_mul_input_payload_rs2_exponent});
+  assign when_Stream_l368_6 = (! mul_preMul_input_valid);
+  assign mul_preMul_input_valid = decode_mul_rValid;
+  assign mul_preMul_input_payload_rs1_mantissa = decode_mul_rData_rs1_mantissa;
+  assign mul_preMul_input_payload_rs1_exponent = decode_mul_rData_rs1_exponent;
+  assign mul_preMul_input_payload_rs1_sign = decode_mul_rData_rs1_sign;
+  assign mul_preMul_input_payload_rs1_special = decode_mul_rData_rs1_special;
+  assign mul_preMul_input_payload_rs2_mantissa = decode_mul_rData_rs2_mantissa;
+  assign mul_preMul_input_payload_rs2_exponent = decode_mul_rData_rs2_exponent;
+  assign mul_preMul_input_payload_rs2_sign = decode_mul_rData_rs2_sign;
+  assign mul_preMul_input_payload_rs2_special = decode_mul_rData_rs2_special;
+  assign mul_preMul_input_payload_rs3_mantissa = decode_mul_rData_rs3_mantissa;
+  assign mul_preMul_input_payload_rs3_exponent = decode_mul_rData_rs3_exponent;
+  assign mul_preMul_input_payload_rs3_sign = decode_mul_rData_rs3_sign;
+  assign mul_preMul_input_payload_rs3_special = decode_mul_rData_rs3_special;
+  assign mul_preMul_input_payload_rd = decode_mul_rData_rd;
+  assign mul_preMul_input_payload_add = decode_mul_rData_add;
+  assign mul_preMul_input_payload_divSqrt = decode_mul_rData_divSqrt;
+  assign mul_preMul_input_payload_msb1 = decode_mul_rData_msb1;
+  assign mul_preMul_input_payload_msb2 = decode_mul_rData_msb2;
+  assign mul_preMul_input_payload_roundMode = decode_mul_rData_roundMode;
+  assign mul_preMul_output_valid = mul_preMul_input_valid;
+  assign mul_preMul_input_ready = mul_preMul_output_ready;
+  assign mul_preMul_output_payload_rs1_mantissa = mul_preMul_input_payload_rs1_mantissa;
+  assign mul_preMul_output_payload_rs1_exponent = mul_preMul_input_payload_rs1_exponent;
+  assign mul_preMul_output_payload_rs1_sign = mul_preMul_input_payload_rs1_sign;
+  assign mul_preMul_output_payload_rs1_special = mul_preMul_input_payload_rs1_special;
+  assign mul_preMul_output_payload_rs2_mantissa = mul_preMul_input_payload_rs2_mantissa;
+  assign mul_preMul_output_payload_rs2_exponent = mul_preMul_input_payload_rs2_exponent;
+  assign mul_preMul_output_payload_rs2_sign = mul_preMul_input_payload_rs2_sign;
+  assign mul_preMul_output_payload_rs2_special = mul_preMul_input_payload_rs2_special;
+  assign mul_preMul_output_payload_rs3_mantissa = mul_preMul_input_payload_rs3_mantissa;
+  assign mul_preMul_output_payload_rs3_exponent = mul_preMul_input_payload_rs3_exponent;
+  assign mul_preMul_output_payload_rs3_sign = mul_preMul_input_payload_rs3_sign;
+  assign mul_preMul_output_payload_rs3_special = mul_preMul_input_payload_rs3_special;
+  assign mul_preMul_output_payload_rd = mul_preMul_input_payload_rd;
+  assign mul_preMul_output_payload_add = mul_preMul_input_payload_add;
+  assign mul_preMul_output_payload_divSqrt = mul_preMul_input_payload_divSqrt;
+  assign mul_preMul_output_payload_msb1 = mul_preMul_input_payload_msb1;
+  assign mul_preMul_output_payload_msb2 = mul_preMul_input_payload_msb2;
+  assign mul_preMul_output_payload_roundMode = mul_preMul_input_payload_roundMode;
+  assign mul_preMul_output_payload_exp = ({1'b0,mul_preMul_input_payload_rs1_exponent} + {1'b0,mul_preMul_input_payload_rs2_exponent});
   always @(*) begin
-    mul_preMul_output_ready = mul_preMul_output_input_ready;
-    if(when_Stream_l342_7) begin
+    mul_preMul_output_ready = mul_mul_input_ready;
+    if(when_Stream_l368_7) begin
       mul_preMul_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_7 = (! mul_preMul_output_input_valid);
-  assign mul_preMul_output_input_valid = mul_preMul_output_rValid;
-  assign mul_preMul_output_input_payload_rs1_mantissa = mul_preMul_output_rData_rs1_mantissa;
-  assign mul_preMul_output_input_payload_rs1_exponent = mul_preMul_output_rData_rs1_exponent;
-  assign mul_preMul_output_input_payload_rs1_sign = mul_preMul_output_rData_rs1_sign;
-  assign mul_preMul_output_input_payload_rs1_special = mul_preMul_output_rData_rs1_special;
-  assign mul_preMul_output_input_payload_rs2_mantissa = mul_preMul_output_rData_rs2_mantissa;
-  assign mul_preMul_output_input_payload_rs2_exponent = mul_preMul_output_rData_rs2_exponent;
-  assign mul_preMul_output_input_payload_rs2_sign = mul_preMul_output_rData_rs2_sign;
-  assign mul_preMul_output_input_payload_rs2_special = mul_preMul_output_rData_rs2_special;
-  assign mul_preMul_output_input_payload_rs3_mantissa = mul_preMul_output_rData_rs3_mantissa;
-  assign mul_preMul_output_input_payload_rs3_exponent = mul_preMul_output_rData_rs3_exponent;
-  assign mul_preMul_output_input_payload_rs3_sign = mul_preMul_output_rData_rs3_sign;
-  assign mul_preMul_output_input_payload_rs3_special = mul_preMul_output_rData_rs3_special;
-  assign mul_preMul_output_input_payload_rd = mul_preMul_output_rData_rd;
-  assign mul_preMul_output_input_payload_add = mul_preMul_output_rData_add;
-  assign mul_preMul_output_input_payload_divSqrt = mul_preMul_output_rData_divSqrt;
-  assign mul_preMul_output_input_payload_msb1 = mul_preMul_output_rData_msb1;
-  assign mul_preMul_output_input_payload_msb2 = mul_preMul_output_rData_msb2;
-  assign mul_preMul_output_input_payload_roundMode = mul_preMul_output_rData_roundMode;
-  assign mul_preMul_output_input_payload_exp = mul_preMul_output_rData_exp;
-  assign mul_mul_output_valid = mul_preMul_output_input_valid;
-  assign mul_preMul_output_input_ready = mul_mul_output_ready;
-  assign mul_mul_mulA = {mul_preMul_output_input_payload_msb1,mul_preMul_output_input_payload_rs1_mantissa};
-  assign mul_mul_mulB = {mul_preMul_output_input_payload_msb2,mul_preMul_output_input_payload_rs2_mantissa};
-  assign mul_mul_output_payload_rs1_mantissa = mul_preMul_output_input_payload_rs1_mantissa;
-  assign mul_mul_output_payload_rs1_exponent = mul_preMul_output_input_payload_rs1_exponent;
-  assign mul_mul_output_payload_rs1_sign = mul_preMul_output_input_payload_rs1_sign;
-  assign mul_mul_output_payload_rs1_special = mul_preMul_output_input_payload_rs1_special;
-  assign mul_mul_output_payload_rs2_mantissa = mul_preMul_output_input_payload_rs2_mantissa;
-  assign mul_mul_output_payload_rs2_exponent = mul_preMul_output_input_payload_rs2_exponent;
-  assign mul_mul_output_payload_rs2_sign = mul_preMul_output_input_payload_rs2_sign;
-  assign mul_mul_output_payload_rs2_special = mul_preMul_output_input_payload_rs2_special;
-  assign mul_mul_output_payload_rs3_mantissa = mul_preMul_output_input_payload_rs3_mantissa;
-  assign mul_mul_output_payload_rs3_exponent = mul_preMul_output_input_payload_rs3_exponent;
-  assign mul_mul_output_payload_rs3_sign = mul_preMul_output_input_payload_rs3_sign;
-  assign mul_mul_output_payload_rs3_special = mul_preMul_output_input_payload_rs3_special;
-  assign mul_mul_output_payload_rd = mul_preMul_output_input_payload_rd;
-  assign mul_mul_output_payload_add = mul_preMul_output_input_payload_add;
-  assign mul_mul_output_payload_divSqrt = mul_preMul_output_input_payload_divSqrt;
-  assign mul_mul_output_payload_msb1 = mul_preMul_output_input_payload_msb1;
-  assign mul_mul_output_payload_msb2 = mul_preMul_output_input_payload_msb2;
-  assign mul_mul_output_payload_roundMode = mul_preMul_output_input_payload_roundMode;
-  assign mul_mul_output_payload_exp = mul_preMul_output_input_payload_exp;
+  assign when_Stream_l368_7 = (! mul_mul_input_valid);
+  assign mul_mul_input_valid = mul_preMul_output_rValid;
+  assign mul_mul_input_payload_rs1_mantissa = mul_preMul_output_rData_rs1_mantissa;
+  assign mul_mul_input_payload_rs1_exponent = mul_preMul_output_rData_rs1_exponent;
+  assign mul_mul_input_payload_rs1_sign = mul_preMul_output_rData_rs1_sign;
+  assign mul_mul_input_payload_rs1_special = mul_preMul_output_rData_rs1_special;
+  assign mul_mul_input_payload_rs2_mantissa = mul_preMul_output_rData_rs2_mantissa;
+  assign mul_mul_input_payload_rs2_exponent = mul_preMul_output_rData_rs2_exponent;
+  assign mul_mul_input_payload_rs2_sign = mul_preMul_output_rData_rs2_sign;
+  assign mul_mul_input_payload_rs2_special = mul_preMul_output_rData_rs2_special;
+  assign mul_mul_input_payload_rs3_mantissa = mul_preMul_output_rData_rs3_mantissa;
+  assign mul_mul_input_payload_rs3_exponent = mul_preMul_output_rData_rs3_exponent;
+  assign mul_mul_input_payload_rs3_sign = mul_preMul_output_rData_rs3_sign;
+  assign mul_mul_input_payload_rs3_special = mul_preMul_output_rData_rs3_special;
+  assign mul_mul_input_payload_rd = mul_preMul_output_rData_rd;
+  assign mul_mul_input_payload_add = mul_preMul_output_rData_add;
+  assign mul_mul_input_payload_divSqrt = mul_preMul_output_rData_divSqrt;
+  assign mul_mul_input_payload_msb1 = mul_preMul_output_rData_msb1;
+  assign mul_mul_input_payload_msb2 = mul_preMul_output_rData_msb2;
+  assign mul_mul_input_payload_roundMode = mul_preMul_output_rData_roundMode;
+  assign mul_mul_input_payload_exp = mul_preMul_output_rData_exp;
+  assign mul_mul_output_valid = mul_mul_input_valid;
+  assign mul_mul_input_ready = mul_mul_output_ready;
+  assign mul_mul_mulA = {mul_mul_input_payload_msb1,mul_mul_input_payload_rs1_mantissa};
+  assign mul_mul_mulB = {mul_mul_input_payload_msb2,mul_mul_input_payload_rs2_mantissa};
+  assign mul_mul_output_payload_rs1_mantissa = mul_mul_input_payload_rs1_mantissa;
+  assign mul_mul_output_payload_rs1_exponent = mul_mul_input_payload_rs1_exponent;
+  assign mul_mul_output_payload_rs1_sign = mul_mul_input_payload_rs1_sign;
+  assign mul_mul_output_payload_rs1_special = mul_mul_input_payload_rs1_special;
+  assign mul_mul_output_payload_rs2_mantissa = mul_mul_input_payload_rs2_mantissa;
+  assign mul_mul_output_payload_rs2_exponent = mul_mul_input_payload_rs2_exponent;
+  assign mul_mul_output_payload_rs2_sign = mul_mul_input_payload_rs2_sign;
+  assign mul_mul_output_payload_rs2_special = mul_mul_input_payload_rs2_special;
+  assign mul_mul_output_payload_rs3_mantissa = mul_mul_input_payload_rs3_mantissa;
+  assign mul_mul_output_payload_rs3_exponent = mul_mul_input_payload_rs3_exponent;
+  assign mul_mul_output_payload_rs3_sign = mul_mul_input_payload_rs3_sign;
+  assign mul_mul_output_payload_rs3_special = mul_mul_input_payload_rs3_special;
+  assign mul_mul_output_payload_rd = mul_mul_input_payload_rd;
+  assign mul_mul_output_payload_add = mul_mul_input_payload_add;
+  assign mul_mul_output_payload_divSqrt = mul_mul_input_payload_divSqrt;
+  assign mul_mul_output_payload_msb1 = mul_mul_input_payload_msb1;
+  assign mul_mul_output_payload_msb2 = mul_mul_input_payload_msb2;
+  assign mul_mul_output_payload_roundMode = mul_mul_input_payload_roundMode;
+  assign mul_mul_output_payload_exp = mul_mul_input_payload_exp;
   assign mul_mul_output_payload_muls_0 = (mul_mul_mulA[17 : 0] * mul_mul_mulB[17 : 0]);
   assign mul_mul_output_payload_muls_1 = (mul_mul_mulA[17 : 0] * mul_mul_mulB[23 : 18]);
   assign mul_mul_output_payload_muls_2 = (mul_mul_mulA[23 : 18] * mul_mul_mulB[17 : 0]);
   assign mul_mul_output_payload_muls_3 = (mul_mul_mulA[23 : 18] * mul_mul_mulB[23 : 18]);
   always @(*) begin
-    mul_mul_output_ready = mul_mul_output_input_ready;
-    if(when_Stream_l342_8) begin
+    mul_mul_output_ready = mul_sum1_input_ready;
+    if(when_Stream_l368_8) begin
       mul_mul_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_8 = (! mul_mul_output_input_valid);
-  assign mul_mul_output_input_valid = mul_mul_output_rValid;
-  assign mul_mul_output_input_payload_rs1_mantissa = mul_mul_output_rData_rs1_mantissa;
-  assign mul_mul_output_input_payload_rs1_exponent = mul_mul_output_rData_rs1_exponent;
-  assign mul_mul_output_input_payload_rs1_sign = mul_mul_output_rData_rs1_sign;
-  assign mul_mul_output_input_payload_rs1_special = mul_mul_output_rData_rs1_special;
-  assign mul_mul_output_input_payload_rs2_mantissa = mul_mul_output_rData_rs2_mantissa;
-  assign mul_mul_output_input_payload_rs2_exponent = mul_mul_output_rData_rs2_exponent;
-  assign mul_mul_output_input_payload_rs2_sign = mul_mul_output_rData_rs2_sign;
-  assign mul_mul_output_input_payload_rs2_special = mul_mul_output_rData_rs2_special;
-  assign mul_mul_output_input_payload_rs3_mantissa = mul_mul_output_rData_rs3_mantissa;
-  assign mul_mul_output_input_payload_rs3_exponent = mul_mul_output_rData_rs3_exponent;
-  assign mul_mul_output_input_payload_rs3_sign = mul_mul_output_rData_rs3_sign;
-  assign mul_mul_output_input_payload_rs3_special = mul_mul_output_rData_rs3_special;
-  assign mul_mul_output_input_payload_rd = mul_mul_output_rData_rd;
-  assign mul_mul_output_input_payload_add = mul_mul_output_rData_add;
-  assign mul_mul_output_input_payload_divSqrt = mul_mul_output_rData_divSqrt;
-  assign mul_mul_output_input_payload_msb1 = mul_mul_output_rData_msb1;
-  assign mul_mul_output_input_payload_msb2 = mul_mul_output_rData_msb2;
-  assign mul_mul_output_input_payload_roundMode = mul_mul_output_rData_roundMode;
-  assign mul_mul_output_input_payload_exp = mul_mul_output_rData_exp;
-  assign mul_mul_output_input_payload_muls_0 = mul_mul_output_rData_muls_0;
-  assign mul_mul_output_input_payload_muls_1 = mul_mul_output_rData_muls_1;
-  assign mul_mul_output_input_payload_muls_2 = mul_mul_output_rData_muls_2;
-  assign mul_mul_output_input_payload_muls_3 = mul_mul_output_rData_muls_3;
+  assign when_Stream_l368_8 = (! mul_sum1_input_valid);
+  assign mul_sum1_input_valid = mul_mul_output_rValid;
+  assign mul_sum1_input_payload_rs1_mantissa = mul_mul_output_rData_rs1_mantissa;
+  assign mul_sum1_input_payload_rs1_exponent = mul_mul_output_rData_rs1_exponent;
+  assign mul_sum1_input_payload_rs1_sign = mul_mul_output_rData_rs1_sign;
+  assign mul_sum1_input_payload_rs1_special = mul_mul_output_rData_rs1_special;
+  assign mul_sum1_input_payload_rs2_mantissa = mul_mul_output_rData_rs2_mantissa;
+  assign mul_sum1_input_payload_rs2_exponent = mul_mul_output_rData_rs2_exponent;
+  assign mul_sum1_input_payload_rs2_sign = mul_mul_output_rData_rs2_sign;
+  assign mul_sum1_input_payload_rs2_special = mul_mul_output_rData_rs2_special;
+  assign mul_sum1_input_payload_rs3_mantissa = mul_mul_output_rData_rs3_mantissa;
+  assign mul_sum1_input_payload_rs3_exponent = mul_mul_output_rData_rs3_exponent;
+  assign mul_sum1_input_payload_rs3_sign = mul_mul_output_rData_rs3_sign;
+  assign mul_sum1_input_payload_rs3_special = mul_mul_output_rData_rs3_special;
+  assign mul_sum1_input_payload_rd = mul_mul_output_rData_rd;
+  assign mul_sum1_input_payload_add = mul_mul_output_rData_add;
+  assign mul_sum1_input_payload_divSqrt = mul_mul_output_rData_divSqrt;
+  assign mul_sum1_input_payload_msb1 = mul_mul_output_rData_msb1;
+  assign mul_sum1_input_payload_msb2 = mul_mul_output_rData_msb2;
+  assign mul_sum1_input_payload_roundMode = mul_mul_output_rData_roundMode;
+  assign mul_sum1_input_payload_exp = mul_mul_output_rData_exp;
+  assign mul_sum1_input_payload_muls_0 = mul_mul_output_rData_muls_0;
+  assign mul_sum1_input_payload_muls_1 = mul_mul_output_rData_muls_1;
+  assign mul_sum1_input_payload_muls_2 = mul_mul_output_rData_muls_2;
+  assign mul_sum1_input_payload_muls_3 = mul_mul_output_rData_muls_3;
   assign mul_sum1_sum = (_zz_mul_sum1_sum + _zz_mul_sum1_sum_1);
-  assign mul_sum1_output_valid = mul_mul_output_input_valid;
-  assign mul_mul_output_input_ready = mul_sum1_output_ready;
-  assign mul_sum1_output_payload_rs1_mantissa = mul_mul_output_input_payload_rs1_mantissa;
-  assign mul_sum1_output_payload_rs1_exponent = mul_mul_output_input_payload_rs1_exponent;
-  assign mul_sum1_output_payload_rs1_sign = mul_mul_output_input_payload_rs1_sign;
-  assign mul_sum1_output_payload_rs1_special = mul_mul_output_input_payload_rs1_special;
-  assign mul_sum1_output_payload_rs2_mantissa = mul_mul_output_input_payload_rs2_mantissa;
-  assign mul_sum1_output_payload_rs2_exponent = mul_mul_output_input_payload_rs2_exponent;
-  assign mul_sum1_output_payload_rs2_sign = mul_mul_output_input_payload_rs2_sign;
-  assign mul_sum1_output_payload_rs2_special = mul_mul_output_input_payload_rs2_special;
-  assign mul_sum1_output_payload_rs3_mantissa = mul_mul_output_input_payload_rs3_mantissa;
-  assign mul_sum1_output_payload_rs3_exponent = mul_mul_output_input_payload_rs3_exponent;
-  assign mul_sum1_output_payload_rs3_sign = mul_mul_output_input_payload_rs3_sign;
-  assign mul_sum1_output_payload_rs3_special = mul_mul_output_input_payload_rs3_special;
-  assign mul_sum1_output_payload_rd = mul_mul_output_input_payload_rd;
-  assign mul_sum1_output_payload_add = mul_mul_output_input_payload_add;
-  assign mul_sum1_output_payload_divSqrt = mul_mul_output_input_payload_divSqrt;
-  assign mul_sum1_output_payload_msb1 = mul_mul_output_input_payload_msb1;
-  assign mul_sum1_output_payload_msb2 = mul_mul_output_input_payload_msb2;
-  assign mul_sum1_output_payload_roundMode = mul_mul_output_input_payload_roundMode;
-  assign mul_sum1_output_payload_exp = mul_mul_output_input_payload_exp;
+  assign mul_sum1_output_valid = mul_sum1_input_valid;
+  assign mul_sum1_input_ready = mul_sum1_output_ready;
+  assign mul_sum1_output_payload_rs1_mantissa = mul_sum1_input_payload_rs1_mantissa;
+  assign mul_sum1_output_payload_rs1_exponent = mul_sum1_input_payload_rs1_exponent;
+  assign mul_sum1_output_payload_rs1_sign = mul_sum1_input_payload_rs1_sign;
+  assign mul_sum1_output_payload_rs1_special = mul_sum1_input_payload_rs1_special;
+  assign mul_sum1_output_payload_rs2_mantissa = mul_sum1_input_payload_rs2_mantissa;
+  assign mul_sum1_output_payload_rs2_exponent = mul_sum1_input_payload_rs2_exponent;
+  assign mul_sum1_output_payload_rs2_sign = mul_sum1_input_payload_rs2_sign;
+  assign mul_sum1_output_payload_rs2_special = mul_sum1_input_payload_rs2_special;
+  assign mul_sum1_output_payload_rs3_mantissa = mul_sum1_input_payload_rs3_mantissa;
+  assign mul_sum1_output_payload_rs3_exponent = mul_sum1_input_payload_rs3_exponent;
+  assign mul_sum1_output_payload_rs3_sign = mul_sum1_input_payload_rs3_sign;
+  assign mul_sum1_output_payload_rs3_special = mul_sum1_input_payload_rs3_special;
+  assign mul_sum1_output_payload_rd = mul_sum1_input_payload_rd;
+  assign mul_sum1_output_payload_add = mul_sum1_input_payload_add;
+  assign mul_sum1_output_payload_divSqrt = mul_sum1_input_payload_divSqrt;
+  assign mul_sum1_output_payload_msb1 = mul_sum1_input_payload_msb1;
+  assign mul_sum1_output_payload_msb2 = mul_sum1_input_payload_msb2;
+  assign mul_sum1_output_payload_roundMode = mul_sum1_input_payload_roundMode;
+  assign mul_sum1_output_payload_exp = mul_sum1_input_payload_exp;
   assign mul_sum1_output_payload_mulC2 = mul_sum1_sum;
-  assign mul_sum1_output_payload_muls2_0 = mul_mul_output_input_payload_muls_2;
-  assign mul_sum1_output_payload_muls2_1 = mul_mul_output_input_payload_muls_3;
+  assign mul_sum1_output_payload_muls2_0 = mul_sum1_input_payload_muls_2;
+  assign mul_sum1_output_payload_muls2_1 = mul_sum1_input_payload_muls_3;
   always @(*) begin
-    mul_sum1_output_ready = mul_sum1_output_input_ready;
-    if(when_Stream_l342_9) begin
+    mul_sum1_output_ready = mul_sum2_input_ready;
+    if(when_Stream_l368_9) begin
       mul_sum1_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_9 = (! mul_sum1_output_input_valid);
-  assign mul_sum1_output_input_valid = mul_sum1_output_rValid;
-  assign mul_sum1_output_input_payload_rs1_mantissa = mul_sum1_output_rData_rs1_mantissa;
-  assign mul_sum1_output_input_payload_rs1_exponent = mul_sum1_output_rData_rs1_exponent;
-  assign mul_sum1_output_input_payload_rs1_sign = mul_sum1_output_rData_rs1_sign;
-  assign mul_sum1_output_input_payload_rs1_special = mul_sum1_output_rData_rs1_special;
-  assign mul_sum1_output_input_payload_rs2_mantissa = mul_sum1_output_rData_rs2_mantissa;
-  assign mul_sum1_output_input_payload_rs2_exponent = mul_sum1_output_rData_rs2_exponent;
-  assign mul_sum1_output_input_payload_rs2_sign = mul_sum1_output_rData_rs2_sign;
-  assign mul_sum1_output_input_payload_rs2_special = mul_sum1_output_rData_rs2_special;
-  assign mul_sum1_output_input_payload_rs3_mantissa = mul_sum1_output_rData_rs3_mantissa;
-  assign mul_sum1_output_input_payload_rs3_exponent = mul_sum1_output_rData_rs3_exponent;
-  assign mul_sum1_output_input_payload_rs3_sign = mul_sum1_output_rData_rs3_sign;
-  assign mul_sum1_output_input_payload_rs3_special = mul_sum1_output_rData_rs3_special;
-  assign mul_sum1_output_input_payload_rd = mul_sum1_output_rData_rd;
-  assign mul_sum1_output_input_payload_add = mul_sum1_output_rData_add;
-  assign mul_sum1_output_input_payload_divSqrt = mul_sum1_output_rData_divSqrt;
-  assign mul_sum1_output_input_payload_msb1 = mul_sum1_output_rData_msb1;
-  assign mul_sum1_output_input_payload_msb2 = mul_sum1_output_rData_msb2;
-  assign mul_sum1_output_input_payload_roundMode = mul_sum1_output_rData_roundMode;
-  assign mul_sum1_output_input_payload_exp = mul_sum1_output_rData_exp;
-  assign mul_sum1_output_input_payload_muls2_0 = mul_sum1_output_rData_muls2_0;
-  assign mul_sum1_output_input_payload_muls2_1 = mul_sum1_output_rData_muls2_1;
-  assign mul_sum1_output_input_payload_mulC2 = mul_sum1_output_rData_mulC2;
-  assign mul_sum2_sum = (mul_sum1_output_input_payload_mulC2 + _zz_mul_sum2_sum);
-  assign mul_sum1_output_input_fire = (mul_sum1_output_input_valid && mul_sum1_output_input_ready);
-  assign when_FpuCore_l221_1 = (mul_sum1_output_input_fire && 1'b1);
+  assign when_Stream_l368_9 = (! mul_sum2_input_valid);
+  assign mul_sum2_input_valid = mul_sum1_output_rValid;
+  assign mul_sum2_input_payload_rs1_mantissa = mul_sum1_output_rData_rs1_mantissa;
+  assign mul_sum2_input_payload_rs1_exponent = mul_sum1_output_rData_rs1_exponent;
+  assign mul_sum2_input_payload_rs1_sign = mul_sum1_output_rData_rs1_sign;
+  assign mul_sum2_input_payload_rs1_special = mul_sum1_output_rData_rs1_special;
+  assign mul_sum2_input_payload_rs2_mantissa = mul_sum1_output_rData_rs2_mantissa;
+  assign mul_sum2_input_payload_rs2_exponent = mul_sum1_output_rData_rs2_exponent;
+  assign mul_sum2_input_payload_rs2_sign = mul_sum1_output_rData_rs2_sign;
+  assign mul_sum2_input_payload_rs2_special = mul_sum1_output_rData_rs2_special;
+  assign mul_sum2_input_payload_rs3_mantissa = mul_sum1_output_rData_rs3_mantissa;
+  assign mul_sum2_input_payload_rs3_exponent = mul_sum1_output_rData_rs3_exponent;
+  assign mul_sum2_input_payload_rs3_sign = mul_sum1_output_rData_rs3_sign;
+  assign mul_sum2_input_payload_rs3_special = mul_sum1_output_rData_rs3_special;
+  assign mul_sum2_input_payload_rd = mul_sum1_output_rData_rd;
+  assign mul_sum2_input_payload_add = mul_sum1_output_rData_add;
+  assign mul_sum2_input_payload_divSqrt = mul_sum1_output_rData_divSqrt;
+  assign mul_sum2_input_payload_msb1 = mul_sum1_output_rData_msb1;
+  assign mul_sum2_input_payload_msb2 = mul_sum1_output_rData_msb2;
+  assign mul_sum2_input_payload_roundMode = mul_sum1_output_rData_roundMode;
+  assign mul_sum2_input_payload_exp = mul_sum1_output_rData_exp;
+  assign mul_sum2_input_payload_muls2_0 = mul_sum1_output_rData_muls2_0;
+  assign mul_sum2_input_payload_muls2_1 = mul_sum1_output_rData_muls2_1;
+  assign mul_sum2_input_payload_mulC2 = mul_sum1_output_rData_mulC2;
+  assign mul_sum2_sum = (mul_sum2_input_payload_mulC2 + _zz_mul_sum2_sum);
+  assign mul_sum2_input_fire = (mul_sum2_input_valid && mul_sum2_input_ready);
+  assign when_FpuCore_l221_1 = (mul_sum2_input_fire && 1'b1);
   assign mul_sum2_isCommited = commitLogic_0_mul_notEmpty;
-  assign _zz_mul_sum1_output_input_ready = (! (! mul_sum2_isCommited));
-  assign mul_sum1_output_input_ready = (mul_sum2_output_ready && _zz_mul_sum1_output_input_ready);
-  assign mul_sum2_output_valid = (mul_sum1_output_input_valid && _zz_mul_sum1_output_input_ready);
-  assign mul_sum2_output_payload_rs1_mantissa = mul_sum1_output_input_payload_rs1_mantissa;
-  assign mul_sum2_output_payload_rs1_exponent = mul_sum1_output_input_payload_rs1_exponent;
-  assign mul_sum2_output_payload_rs1_sign = mul_sum1_output_input_payload_rs1_sign;
-  assign mul_sum2_output_payload_rs1_special = mul_sum1_output_input_payload_rs1_special;
-  assign mul_sum2_output_payload_rs2_mantissa = mul_sum1_output_input_payload_rs2_mantissa;
-  assign mul_sum2_output_payload_rs2_exponent = mul_sum1_output_input_payload_rs2_exponent;
-  assign mul_sum2_output_payload_rs2_sign = mul_sum1_output_input_payload_rs2_sign;
-  assign mul_sum2_output_payload_rs2_special = mul_sum1_output_input_payload_rs2_special;
-  assign mul_sum2_output_payload_rs3_mantissa = mul_sum1_output_input_payload_rs3_mantissa;
-  assign mul_sum2_output_payload_rs3_exponent = mul_sum1_output_input_payload_rs3_exponent;
-  assign mul_sum2_output_payload_rs3_sign = mul_sum1_output_input_payload_rs3_sign;
-  assign mul_sum2_output_payload_rs3_special = mul_sum1_output_input_payload_rs3_special;
-  assign mul_sum2_output_payload_rd = mul_sum1_output_input_payload_rd;
-  assign mul_sum2_output_payload_add = mul_sum1_output_input_payload_add;
-  assign mul_sum2_output_payload_divSqrt = mul_sum1_output_input_payload_divSqrt;
-  assign mul_sum2_output_payload_msb1 = mul_sum1_output_input_payload_msb1;
-  assign mul_sum2_output_payload_msb2 = mul_sum1_output_input_payload_msb2;
-  assign mul_sum2_output_payload_roundMode = mul_sum1_output_input_payload_roundMode;
-  assign mul_sum2_output_payload_exp = mul_sum1_output_input_payload_exp;
+  assign _zz_mul_sum2_input_ready = (! (! mul_sum2_isCommited));
+  assign mul_sum2_input_ready = (mul_sum2_output_ready && _zz_mul_sum2_input_ready);
+  assign mul_sum2_output_valid = (mul_sum2_input_valid && _zz_mul_sum2_input_ready);
+  assign mul_sum2_output_payload_rs1_mantissa = mul_sum2_input_payload_rs1_mantissa;
+  assign mul_sum2_output_payload_rs1_exponent = mul_sum2_input_payload_rs1_exponent;
+  assign mul_sum2_output_payload_rs1_sign = mul_sum2_input_payload_rs1_sign;
+  assign mul_sum2_output_payload_rs1_special = mul_sum2_input_payload_rs1_special;
+  assign mul_sum2_output_payload_rs2_mantissa = mul_sum2_input_payload_rs2_mantissa;
+  assign mul_sum2_output_payload_rs2_exponent = mul_sum2_input_payload_rs2_exponent;
+  assign mul_sum2_output_payload_rs2_sign = mul_sum2_input_payload_rs2_sign;
+  assign mul_sum2_output_payload_rs2_special = mul_sum2_input_payload_rs2_special;
+  assign mul_sum2_output_payload_rs3_mantissa = mul_sum2_input_payload_rs3_mantissa;
+  assign mul_sum2_output_payload_rs3_exponent = mul_sum2_input_payload_rs3_exponent;
+  assign mul_sum2_output_payload_rs3_sign = mul_sum2_input_payload_rs3_sign;
+  assign mul_sum2_output_payload_rs3_special = mul_sum2_input_payload_rs3_special;
+  assign mul_sum2_output_payload_rd = mul_sum2_input_payload_rd;
+  assign mul_sum2_output_payload_add = mul_sum2_input_payload_add;
+  assign mul_sum2_output_payload_divSqrt = mul_sum2_input_payload_divSqrt;
+  assign mul_sum2_output_payload_msb1 = mul_sum2_input_payload_msb1;
+  assign mul_sum2_output_payload_msb2 = mul_sum2_input_payload_msb2;
+  assign mul_sum2_output_payload_roundMode = mul_sum2_input_payload_roundMode;
+  assign mul_sum2_output_payload_exp = mul_sum2_input_payload_exp;
   assign mul_sum2_output_payload_mulC = mul_sum2_sum;
   always @(*) begin
-    mul_sum2_output_ready = mul_sum2_output_input_ready;
-    if(when_Stream_l342_10) begin
+    mul_sum2_output_ready = mul_norm_input_ready;
+    if(when_Stream_l368_10) begin
       mul_sum2_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_10 = (! mul_sum2_output_input_valid);
-  assign mul_sum2_output_input_valid = mul_sum2_output_rValid;
-  assign mul_sum2_output_input_payload_rs1_mantissa = mul_sum2_output_rData_rs1_mantissa;
-  assign mul_sum2_output_input_payload_rs1_exponent = mul_sum2_output_rData_rs1_exponent;
-  assign mul_sum2_output_input_payload_rs1_sign = mul_sum2_output_rData_rs1_sign;
-  assign mul_sum2_output_input_payload_rs1_special = mul_sum2_output_rData_rs1_special;
-  assign mul_sum2_output_input_payload_rs2_mantissa = mul_sum2_output_rData_rs2_mantissa;
-  assign mul_sum2_output_input_payload_rs2_exponent = mul_sum2_output_rData_rs2_exponent;
-  assign mul_sum2_output_input_payload_rs2_sign = mul_sum2_output_rData_rs2_sign;
-  assign mul_sum2_output_input_payload_rs2_special = mul_sum2_output_rData_rs2_special;
-  assign mul_sum2_output_input_payload_rs3_mantissa = mul_sum2_output_rData_rs3_mantissa;
-  assign mul_sum2_output_input_payload_rs3_exponent = mul_sum2_output_rData_rs3_exponent;
-  assign mul_sum2_output_input_payload_rs3_sign = mul_sum2_output_rData_rs3_sign;
-  assign mul_sum2_output_input_payload_rs3_special = mul_sum2_output_rData_rs3_special;
-  assign mul_sum2_output_input_payload_rd = mul_sum2_output_rData_rd;
-  assign mul_sum2_output_input_payload_add = mul_sum2_output_rData_add;
-  assign mul_sum2_output_input_payload_divSqrt = mul_sum2_output_rData_divSqrt;
-  assign mul_sum2_output_input_payload_msb1 = mul_sum2_output_rData_msb1;
-  assign mul_sum2_output_input_payload_msb2 = mul_sum2_output_rData_msb2;
-  assign mul_sum2_output_input_payload_roundMode = mul_sum2_output_rData_roundMode;
-  assign mul_sum2_output_input_payload_exp = mul_sum2_output_rData_exp;
-  assign mul_sum2_output_input_payload_mulC = mul_sum2_output_rData_mulC;
-  assign mul_norm_mulHigh = mul_sum2_output_input_payload_mulC[47 : 22];
-  assign mul_norm_mulLow = mul_sum2_output_input_payload_mulC[21 : 0];
+  assign when_Stream_l368_10 = (! mul_norm_input_valid);
+  assign mul_norm_input_valid = mul_sum2_output_rValid;
+  assign mul_norm_input_payload_rs1_mantissa = mul_sum2_output_rData_rs1_mantissa;
+  assign mul_norm_input_payload_rs1_exponent = mul_sum2_output_rData_rs1_exponent;
+  assign mul_norm_input_payload_rs1_sign = mul_sum2_output_rData_rs1_sign;
+  assign mul_norm_input_payload_rs1_special = mul_sum2_output_rData_rs1_special;
+  assign mul_norm_input_payload_rs2_mantissa = mul_sum2_output_rData_rs2_mantissa;
+  assign mul_norm_input_payload_rs2_exponent = mul_sum2_output_rData_rs2_exponent;
+  assign mul_norm_input_payload_rs2_sign = mul_sum2_output_rData_rs2_sign;
+  assign mul_norm_input_payload_rs2_special = mul_sum2_output_rData_rs2_special;
+  assign mul_norm_input_payload_rs3_mantissa = mul_sum2_output_rData_rs3_mantissa;
+  assign mul_norm_input_payload_rs3_exponent = mul_sum2_output_rData_rs3_exponent;
+  assign mul_norm_input_payload_rs3_sign = mul_sum2_output_rData_rs3_sign;
+  assign mul_norm_input_payload_rs3_special = mul_sum2_output_rData_rs3_special;
+  assign mul_norm_input_payload_rd = mul_sum2_output_rData_rd;
+  assign mul_norm_input_payload_add = mul_sum2_output_rData_add;
+  assign mul_norm_input_payload_divSqrt = mul_sum2_output_rData_divSqrt;
+  assign mul_norm_input_payload_msb1 = mul_sum2_output_rData_msb1;
+  assign mul_norm_input_payload_msb2 = mul_sum2_output_rData_msb2;
+  assign mul_norm_input_payload_roundMode = mul_sum2_output_rData_roundMode;
+  assign mul_norm_input_payload_exp = mul_sum2_output_rData_exp;
+  assign mul_norm_input_payload_mulC = mul_sum2_output_rData_mulC;
+  assign mul_norm_mulHigh = mul_norm_input_payload_mulC[47 : 22];
+  assign mul_norm_mulLow = mul_norm_input_payload_mulC[21 : 0];
   always @(*) begin
     mul_norm_scrap = (mul_norm_mulLow != 22'h0);
     if(when_FpuCore_l967) begin
@@ -12766,17 +12726,17 @@ module FpuCore (
   end
 
   assign mul_norm_needShift = mul_norm_mulHigh[25];
-  assign mul_norm_exp = (mul_sum2_output_input_payload_exp + _zz_mul_norm_exp);
+  assign mul_norm_exp = (mul_norm_input_payload_exp + _zz_mul_norm_exp);
   assign mul_norm_man = (mul_norm_needShift ? mul_norm_mulHigh[24 : 1] : mul_norm_mulHigh[23 : 0]);
   assign when_FpuCore_l967 = (mul_norm_needShift && mul_norm_mulHigh[0]);
-  assign mul_norm_forceZero = ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign mul_norm_forceZero = ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b00)));
   assign mul_norm_underflowThreshold = 9'h167;
   assign mul_norm_underflowExp = 7'h67;
   assign mul_norm_forceUnderflow = (mul_norm_exp < _zz_mul_norm_forceUnderflow);
-  assign mul_norm_forceOverflow = ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b01)));
-  assign mul_norm_infinitynan = (((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b01))) && ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b00))));
-  assign mul_norm_forceNan = (((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b10))) || mul_norm_infinitynan);
-  assign mul_norm_output_sign = (mul_sum2_output_input_payload_rs1_sign ^ mul_sum2_output_input_payload_rs2_sign);
+  assign mul_norm_forceOverflow = ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign mul_norm_infinitynan = (((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b01))) && ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b00))));
+  assign mul_norm_forceNan = (((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b10))) || mul_norm_infinitynan);
+  assign mul_norm_output_sign = (mul_norm_input_payload_rs1_sign ^ mul_norm_input_payload_rs2_sign);
   always @(*) begin
     mul_norm_output_exponent = _zz_mul_norm_output_exponent[8:0];
     if(when_FpuCore_l983) begin
@@ -12832,12 +12792,12 @@ module FpuCore (
   end
 
   assign when_FpuCore_l983 = (3'b101 <= mul_norm_exp[9 : 7]);
-  assign when_FpuCore_l987 = ((mul_norm_infinitynan || ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! mul_sum2_output_input_payload_rs1_mantissa[22]))) || ((mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! mul_sum2_output_input_payload_rs2_mantissa[22])));
-  assign mul_result_notMul_output_valid = (mul_sum2_output_input_valid && mul_sum2_output_input_payload_divSqrt);
-  assign mul_result_notMul_output_payload = mul_sum2_output_input_payload_mulC[46 : 23];
-  assign mul_result_output_valid = ((mul_sum2_output_input_valid && (! mul_sum2_output_input_payload_add)) && (! mul_sum2_output_input_payload_divSqrt));
-  assign mul_result_output_payload_rd = mul_sum2_output_input_payload_rd;
-  assign mul_result_output_payload_roundMode = mul_sum2_output_input_payload_roundMode;
+  assign when_FpuCore_l987 = ((mul_norm_infinitynan || ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! mul_norm_input_payload_rs1_mantissa[22]))) || ((mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! mul_norm_input_payload_rs2_mantissa[22])));
+  assign mul_result_notMul_output_valid = (mul_norm_input_valid && mul_norm_input_payload_divSqrt);
+  assign mul_result_notMul_output_payload = mul_norm_input_payload_mulC[46 : 23];
+  assign mul_result_output_valid = ((mul_norm_input_valid && (! mul_norm_input_payload_add)) && (! mul_norm_input_payload_divSqrt));
+  assign mul_result_output_payload_rd = mul_norm_input_payload_rd;
+  assign mul_result_output_payload_roundMode = mul_norm_input_payload_roundMode;
   assign mul_result_output_payload_scrap = mul_norm_scrap;
   assign mul_result_output_payload_value_mantissa = mul_norm_output_mantissa;
   assign mul_result_output_payload_value_exponent = mul_norm_output_exponent;
@@ -12847,12 +12807,12 @@ module FpuCore (
   assign mul_result_output_payload_DZ = 1'b0;
   always @(*) begin
     mul_result_mulToAdd_ready = mul_result_mulToAdd_m2sPipe_ready;
-    if(when_Stream_l342_11) begin
+    if(when_Stream_l368_11) begin
       mul_result_mulToAdd_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_11 = (! mul_result_mulToAdd_m2sPipe_valid);
+  assign when_Stream_l368_11 = (! mul_result_mulToAdd_m2sPipe_valid);
   assign mul_result_mulToAdd_m2sPipe_valid = mul_result_mulToAdd_rValid;
   assign mul_result_mulToAdd_m2sPipe_payload_rs1_mantissa = mul_result_mulToAdd_rData_rs1_mantissa;
   assign mul_result_mulToAdd_m2sPipe_payload_rs1_exponent = mul_result_mulToAdd_rData_rs1_exponent;
@@ -12878,7 +12838,7 @@ module FpuCore (
   assign decode_mulToAdd_payload_rd = mul_result_mulToAdd_m2sPipe_payload_rd;
   assign decode_mulToAdd_payload_roundMode = mul_result_mulToAdd_m2sPipe_payload_roundMode;
   assign decode_mulToAdd_payload_needCommit = mul_result_mulToAdd_m2sPipe_payload_needCommit;
-  assign mul_result_mulToAdd_valid = (mul_sum2_output_input_valid && mul_sum2_output_input_payload_add);
+  assign mul_result_mulToAdd_valid = (mul_norm_input_valid && mul_norm_input_payload_add);
   always @(*) begin
     mul_result_mulToAdd_payload_rs1_mantissa = {mul_norm_output_mantissa,mul_norm_scrap};
     if(mul_norm_NV) begin
@@ -12889,27 +12849,27 @@ module FpuCore (
   assign mul_result_mulToAdd_payload_rs1_exponent = mul_norm_output_exponent;
   assign mul_result_mulToAdd_payload_rs1_sign = mul_norm_output_sign;
   assign mul_result_mulToAdd_payload_rs1_special = mul_norm_output_special;
-  assign mul_result_mulToAdd_payload_rs2_exponent = mul_sum2_output_input_payload_rs3_exponent;
-  assign mul_result_mulToAdd_payload_rs2_sign = mul_sum2_output_input_payload_rs3_sign;
-  assign mul_result_mulToAdd_payload_rs2_special = mul_sum2_output_input_payload_rs3_special;
-  assign mul_result_mulToAdd_payload_rs2_mantissa = ({2'd0,mul_sum2_output_input_payload_rs3_mantissa} <<< 2);
-  assign mul_result_mulToAdd_payload_rd = mul_sum2_output_input_payload_rd;
-  assign mul_result_mulToAdd_payload_roundMode = mul_sum2_output_input_payload_roundMode;
+  assign mul_result_mulToAdd_payload_rs2_exponent = mul_norm_input_payload_rs3_exponent;
+  assign mul_result_mulToAdd_payload_rs2_sign = mul_norm_input_payload_rs3_sign;
+  assign mul_result_mulToAdd_payload_rs2_special = mul_norm_input_payload_rs3_special;
+  assign mul_result_mulToAdd_payload_rs2_mantissa = ({2'd0,mul_norm_input_payload_rs3_mantissa} <<< 2);
+  assign mul_result_mulToAdd_payload_rd = mul_norm_input_payload_rd;
+  assign mul_result_mulToAdd_payload_roundMode = mul_norm_input_payload_roundMode;
   assign mul_result_mulToAdd_payload_needCommit = 1'b0;
-  assign mul_sum2_output_input_ready = ((mul_sum2_output_input_payload_add ? mul_result_mulToAdd_ready : mul_result_output_ready) || mul_sum2_output_input_payload_divSqrt);
-  assign decode_div_input_fire = (decode_div_input_valid && decode_div_input_ready);
+  assign mul_norm_input_ready = ((mul_norm_input_payload_add ? mul_result_mulToAdd_ready : mul_result_output_ready) || mul_norm_input_payload_divSqrt);
+  assign div_input_fire = (div_input_valid && div_input_ready);
   assign decode_div_ready = (! decode_div_rValid);
-  assign decode_div_input_valid = decode_div_rValid;
-  assign decode_div_input_payload_rs1_mantissa = decode_div_rData_rs1_mantissa;
-  assign decode_div_input_payload_rs1_exponent = decode_div_rData_rs1_exponent;
-  assign decode_div_input_payload_rs1_sign = decode_div_rData_rs1_sign;
-  assign decode_div_input_payload_rs1_special = decode_div_rData_rs1_special;
-  assign decode_div_input_payload_rs2_mantissa = decode_div_rData_rs2_mantissa;
-  assign decode_div_input_payload_rs2_exponent = decode_div_rData_rs2_exponent;
-  assign decode_div_input_payload_rs2_sign = decode_div_rData_rs2_sign;
-  assign decode_div_input_payload_rs2_special = decode_div_rData_rs2_special;
-  assign decode_div_input_payload_rd = decode_div_rData_rd;
-  assign decode_div_input_payload_roundMode = decode_div_rData_roundMode;
+  assign div_input_valid = decode_div_rValid;
+  assign div_input_payload_rs1_mantissa = decode_div_rData_rs1_mantissa;
+  assign div_input_payload_rs1_exponent = decode_div_rData_rs1_exponent;
+  assign div_input_payload_rs1_sign = decode_div_rData_rs1_sign;
+  assign div_input_payload_rs1_special = decode_div_rData_rs1_special;
+  assign div_input_payload_rs2_mantissa = decode_div_rData_rs2_mantissa;
+  assign div_input_payload_rs2_exponent = decode_div_rData_rs2_exponent;
+  assign div_input_payload_rs2_sign = decode_div_rData_rs2_sign;
+  assign div_input_payload_rs2_special = decode_div_rData_rs2_special;
+  assign div_input_payload_rd = decode_div_rData_rd;
+  assign div_input_payload_roundMode = decode_div_rData_roundMode;
   always @(*) begin
     div_haltIt = 1'b1;
     if(div_divider_io_output_valid) begin
@@ -12917,20 +12877,20 @@ module FpuCore (
     end
   end
 
-  assign decode_div_input_fire_1 = (decode_div_input_valid && decode_div_input_ready);
-  assign when_FpuCore_l221_2 = (decode_div_input_fire_1 && 1'b1);
-  assign _zz_decode_div_input_ready = (! (div_haltIt || (! div_isCommited)));
-  assign decode_div_input_ready = (div_output_ready && _zz_decode_div_input_ready);
-  assign div_output_valid = (decode_div_input_valid && _zz_decode_div_input_ready);
-  assign div_divider_io_input_payload_a = ({1'd0,decode_div_input_payload_rs1_mantissa} <<< 1);
-  assign div_divider_io_input_payload_b = ({1'd0,decode_div_input_payload_rs2_mantissa} <<< 1);
+  assign div_input_fire_1 = (div_input_valid && div_input_ready);
+  assign when_FpuCore_l221_2 = (div_input_fire_1 && 1'b1);
+  assign _zz_div_input_ready = (! (div_haltIt || (! div_isCommited)));
+  assign div_input_ready = (div_output_ready && _zz_div_input_ready);
+  assign div_output_valid = (div_input_valid && _zz_div_input_ready);
+  assign div_divider_io_input_payload_a = ({1'd0,div_input_payload_rs1_mantissa} <<< 1);
+  assign div_divider_io_input_payload_b = ({1'd0,div_input_payload_rs2_mantissa} <<< 1);
   assign div_dividerResult = (div_divider_io_output_payload_result >>> 1);
   assign div_dividerScrap = ((div_divider_io_output_payload_remain != 25'h0) || (div_divider_io_output_payload_result[0 : 0] != 1'b0));
   assign div_divider_io_input_fire = (div_divider_io_input_valid && div_divider_io_input_ready);
   assign when_FpuCore_l1056 = (! div_haltIt);
-  assign div_divider_io_input_valid = (decode_div_input_valid && (! div_cmdSent));
-  assign div_output_payload_rd = decode_div_input_payload_rd;
-  assign div_output_payload_roundMode = decode_div_input_payload_roundMode;
+  assign div_divider_io_input_valid = (div_input_valid && (! div_cmdSent));
+  assign div_output_payload_rd = div_input_payload_rd;
+  assign div_output_payload_roundMode = div_input_payload_roundMode;
   assign div_needShift = (! div_dividerResult[25]);
   assign div_mantissa = (div_needShift ? div_dividerResult[23 : 0] : div_dividerResult[24 : 1]);
   assign div_scrap = (div_dividerScrap || ((! div_needShift) && div_dividerResult[0]));
@@ -12950,7 +12910,7 @@ module FpuCore (
     end
   end
 
-  assign div_output_payload_value_sign = (decode_div_input_payload_rs1_sign ^ decode_div_input_payload_rs2_sign);
+  assign div_output_payload_value_sign = (div_input_payload_rs1_sign ^ div_input_payload_rs2_sign);
   always @(*) begin
     div_output_payload_value_exponent = div_exponent[8:0];
     if(when_FpuCore_l1072) begin
@@ -12989,10 +12949,10 @@ module FpuCore (
   assign div_underflowThreshold = 11'h468;
   assign div_underflowExp = 11'h467;
   assign div_forceUnderflow = (div_exponent < div_underflowThreshold);
-  assign div_forceOverflow = ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
-  assign div_infinitynan = (((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b00))) || ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b01))));
-  assign div_forceNan = (((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b10))) || div_infinitynan);
-  assign div_forceZero = ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign div_forceOverflow = ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign div_infinitynan = (((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b00))) || ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b01))));
+  assign div_forceNan = (((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b10))) || div_infinitynan);
+  assign div_forceZero = ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b01)));
   always @(*) begin
     div_output_payload_NV = 1'b0;
     if(div_forceNan) begin
@@ -13002,18 +12962,18 @@ module FpuCore (
     end
   end
 
-  assign div_output_payload_DZ = (((! div_forceNan) && (! (decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b01)))) && (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign div_output_payload_DZ = (((! div_forceNan) && (! (div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b01)))) && (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
   assign when_FpuCore_l1089 = (div_exponent[10 : 8] == 3'b111);
-  assign when_FpuCore_l1093 = ((div_infinitynan || ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! decode_div_input_payload_rs1_mantissa[22]))) || ((decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! decode_div_input_payload_rs2_mantissa[22])));
-  assign decode_sqrt_input_fire = (decode_sqrt_input_valid && decode_sqrt_input_ready);
+  assign when_FpuCore_l1093 = ((div_infinitynan || ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! div_input_payload_rs1_mantissa[22]))) || ((div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! div_input_payload_rs2_mantissa[22])));
+  assign sqrt_input_fire = (sqrt_input_valid && sqrt_input_ready);
   assign decode_sqrt_ready = (! decode_sqrt_rValid);
-  assign decode_sqrt_input_valid = decode_sqrt_rValid;
-  assign decode_sqrt_input_payload_rs1_mantissa = decode_sqrt_rData_rs1_mantissa;
-  assign decode_sqrt_input_payload_rs1_exponent = decode_sqrt_rData_rs1_exponent;
-  assign decode_sqrt_input_payload_rs1_sign = decode_sqrt_rData_rs1_sign;
-  assign decode_sqrt_input_payload_rs1_special = decode_sqrt_rData_rs1_special;
-  assign decode_sqrt_input_payload_rd = decode_sqrt_rData_rd;
-  assign decode_sqrt_input_payload_roundMode = decode_sqrt_rData_roundMode;
+  assign sqrt_input_valid = decode_sqrt_rValid;
+  assign sqrt_input_payload_rs1_mantissa = decode_sqrt_rData_rs1_mantissa;
+  assign sqrt_input_payload_rs1_exponent = decode_sqrt_rData_rs1_exponent;
+  assign sqrt_input_payload_rs1_sign = decode_sqrt_rData_rs1_sign;
+  assign sqrt_input_payload_rs1_special = decode_sqrt_rData_rs1_special;
+  assign sqrt_input_payload_rd = decode_sqrt_rData_rd;
+  assign sqrt_input_payload_roundMode = decode_sqrt_rData_roundMode;
   always @(*) begin
     sqrt_haltIt = 1'b1;
     if(sqrt_sqrt_io_output_valid) begin
@@ -13021,18 +12981,18 @@ module FpuCore (
     end
   end
 
-  assign decode_sqrt_input_fire_1 = (decode_sqrt_input_valid && decode_sqrt_input_ready);
-  assign when_FpuCore_l221_3 = (decode_sqrt_input_fire_1 && 1'b1);
-  assign _zz_decode_sqrt_input_ready = (! (sqrt_haltIt || (! sqrt_isCommited)));
-  assign decode_sqrt_input_ready = (sqrt_output_ready && _zz_decode_sqrt_input_ready);
-  assign sqrt_output_valid = (decode_sqrt_input_valid && _zz_decode_sqrt_input_ready);
-  assign sqrt_needShift = (! decode_sqrt_input_payload_rs1_exponent[0]);
-  assign sqrt_sqrt_io_input_payload_a = (sqrt_needShift ? {{1'b1,decode_sqrt_input_payload_rs1_mantissa},1'b0} : {2'b01,decode_sqrt_input_payload_rs1_mantissa});
+  assign sqrt_input_fire_1 = (sqrt_input_valid && sqrt_input_ready);
+  assign when_FpuCore_l221_3 = (sqrt_input_fire_1 && 1'b1);
+  assign _zz_sqrt_input_ready = (! (sqrt_haltIt || (! sqrt_isCommited)));
+  assign sqrt_input_ready = (sqrt_output_ready && _zz_sqrt_input_ready);
+  assign sqrt_output_valid = (sqrt_input_valid && _zz_sqrt_input_ready);
+  assign sqrt_needShift = (! sqrt_input_payload_rs1_exponent[0]);
+  assign sqrt_sqrt_io_input_payload_a = (sqrt_needShift ? {{1'b1,sqrt_input_payload_rs1_mantissa},1'b0} : {2'b01,sqrt_input_payload_rs1_mantissa});
   assign sqrt_sqrt_io_input_fire = (sqrt_sqrt_io_input_valid && sqrt_sqrt_io_input_ready);
   assign when_FpuCore_l1118 = (! sqrt_haltIt);
-  assign sqrt_sqrt_io_input_valid = (decode_sqrt_input_valid && (! sqrt_cmdSent));
-  assign sqrt_output_payload_rd = decode_sqrt_input_payload_rd;
-  assign sqrt_output_payload_roundMode = decode_sqrt_input_payload_roundMode;
+  assign sqrt_sqrt_io_input_valid = (sqrt_input_valid && (! sqrt_cmdSent));
+  assign sqrt_output_payload_rd = sqrt_input_payload_rd;
+  assign sqrt_output_payload_roundMode = sqrt_input_payload_roundMode;
   assign sqrt_scrap = (sqrt_sqrt_io_output_payload_remain != 28'h0);
   always @(*) begin
     sqrt_output_payload_value_special = 1'b0;
@@ -13050,7 +13010,7 @@ module FpuCore (
     end
   end
 
-  assign sqrt_output_payload_value_sign = decode_sqrt_input_payload_rs1_sign;
+  assign sqrt_output_payload_value_sign = sqrt_input_payload_rs1_sign;
   always @(*) begin
     sqrt_output_payload_value_exponent = sqrt_exponent;
     if(when_FpuCore_l1137) begin
@@ -13086,15 +13046,15 @@ module FpuCore (
       sqrt_output_payload_NV = 1'b1;
     end
     if(when_FpuCore_l1144) begin
-      sqrt_output_payload_NV = (! decode_sqrt_input_payload_rs1_mantissa[22]);
+      sqrt_output_payload_NV = (! sqrt_input_payload_rs1_mantissa[22]);
     end
   end
 
   assign sqrt_output_payload_DZ = 1'b0;
-  assign sqrt_negative = (((! (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10))) && (! (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00)))) && decode_sqrt_input_payload_rs1_sign);
-  assign when_FpuCore_l1137 = (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b01));
-  assign when_FpuCore_l1144 = (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10));
-  assign when_FpuCore_l1148 = (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign sqrt_negative = (((! (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10))) && (! (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00)))) && sqrt_input_payload_rs1_sign);
+  assign when_FpuCore_l1137 = (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b01));
+  assign when_FpuCore_l1144 = (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10));
+  assign when_FpuCore_l1148 = (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00));
   assign add_preShifter_input_valid = decode_add_valid;
   assign decode_add_ready = add_preShifter_input_ready;
   assign add_preShifter_input_payload_rs1_mantissa = decode_add_payload_rs1_mantissa;
@@ -13129,50 +13089,50 @@ module FpuCore (
   assign add_preShifter_output_payload_absRs1Bigger = add_preShifter_absRs1Bigger;
   assign add_preShifter_output_payload_rs1ExponentBigger = add_preShifter_rs1ExponentBigger;
   always @(*) begin
-    add_preShifter_output_ready = add_preShifter_output_input_ready;
-    if(when_Stream_l342_12) begin
+    add_preShifter_output_ready = add_shifter_input_ready;
+    if(when_Stream_l368_12) begin
       add_preShifter_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_12 = (! add_preShifter_output_input_valid);
-  assign add_preShifter_output_input_valid = add_preShifter_output_rValid;
-  assign add_preShifter_output_input_payload_rs1_mantissa = add_preShifter_output_rData_rs1_mantissa;
-  assign add_preShifter_output_input_payload_rs1_exponent = add_preShifter_output_rData_rs1_exponent;
-  assign add_preShifter_output_input_payload_rs1_sign = add_preShifter_output_rData_rs1_sign;
-  assign add_preShifter_output_input_payload_rs1_special = add_preShifter_output_rData_rs1_special;
-  assign add_preShifter_output_input_payload_rs2_mantissa = add_preShifter_output_rData_rs2_mantissa;
-  assign add_preShifter_output_input_payload_rs2_exponent = add_preShifter_output_rData_rs2_exponent;
-  assign add_preShifter_output_input_payload_rs2_sign = add_preShifter_output_rData_rs2_sign;
-  assign add_preShifter_output_input_payload_rs2_special = add_preShifter_output_rData_rs2_special;
-  assign add_preShifter_output_input_payload_rd = add_preShifter_output_rData_rd;
-  assign add_preShifter_output_input_payload_roundMode = add_preShifter_output_rData_roundMode;
-  assign add_preShifter_output_input_payload_needCommit = add_preShifter_output_rData_needCommit;
-  assign add_preShifter_output_input_payload_absRs1Bigger = add_preShifter_output_rData_absRs1Bigger;
-  assign add_preShifter_output_input_payload_rs1ExponentBigger = add_preShifter_output_rData_rs1ExponentBigger;
-  assign add_shifter_output_valid = add_preShifter_output_input_valid;
-  assign add_preShifter_output_input_ready = add_shifter_output_ready;
-  assign add_shifter_output_payload_rs1_mantissa = add_preShifter_output_input_payload_rs1_mantissa;
-  assign add_shifter_output_payload_rs1_exponent = add_preShifter_output_input_payload_rs1_exponent;
-  assign add_shifter_output_payload_rs1_sign = add_preShifter_output_input_payload_rs1_sign;
-  assign add_shifter_output_payload_rs1_special = add_preShifter_output_input_payload_rs1_special;
-  assign add_shifter_output_payload_rs2_mantissa = add_preShifter_output_input_payload_rs2_mantissa;
-  assign add_shifter_output_payload_rs2_exponent = add_preShifter_output_input_payload_rs2_exponent;
-  assign add_shifter_output_payload_rs2_sign = add_preShifter_output_input_payload_rs2_sign;
-  assign add_shifter_output_payload_rs2_special = add_preShifter_output_input_payload_rs2_special;
-  assign add_shifter_output_payload_rd = add_preShifter_output_input_payload_rd;
-  assign add_shifter_output_payload_roundMode = add_preShifter_output_input_payload_roundMode;
-  assign add_shifter_output_payload_needCommit = add_preShifter_output_input_payload_needCommit;
-  assign add_shifter_exp21 = ({1'b0,add_preShifter_output_input_payload_rs2_exponent} - {1'b0,add_preShifter_output_input_payload_rs1_exponent});
+  assign when_Stream_l368_12 = (! add_shifter_input_valid);
+  assign add_shifter_input_valid = add_preShifter_output_rValid;
+  assign add_shifter_input_payload_rs1_mantissa = add_preShifter_output_rData_rs1_mantissa;
+  assign add_shifter_input_payload_rs1_exponent = add_preShifter_output_rData_rs1_exponent;
+  assign add_shifter_input_payload_rs1_sign = add_preShifter_output_rData_rs1_sign;
+  assign add_shifter_input_payload_rs1_special = add_preShifter_output_rData_rs1_special;
+  assign add_shifter_input_payload_rs2_mantissa = add_preShifter_output_rData_rs2_mantissa;
+  assign add_shifter_input_payload_rs2_exponent = add_preShifter_output_rData_rs2_exponent;
+  assign add_shifter_input_payload_rs2_sign = add_preShifter_output_rData_rs2_sign;
+  assign add_shifter_input_payload_rs2_special = add_preShifter_output_rData_rs2_special;
+  assign add_shifter_input_payload_rd = add_preShifter_output_rData_rd;
+  assign add_shifter_input_payload_roundMode = add_preShifter_output_rData_roundMode;
+  assign add_shifter_input_payload_needCommit = add_preShifter_output_rData_needCommit;
+  assign add_shifter_input_payload_absRs1Bigger = add_preShifter_output_rData_absRs1Bigger;
+  assign add_shifter_input_payload_rs1ExponentBigger = add_preShifter_output_rData_rs1ExponentBigger;
+  assign add_shifter_output_valid = add_shifter_input_valid;
+  assign add_shifter_input_ready = add_shifter_output_ready;
+  assign add_shifter_output_payload_rs1_mantissa = add_shifter_input_payload_rs1_mantissa;
+  assign add_shifter_output_payload_rs1_exponent = add_shifter_input_payload_rs1_exponent;
+  assign add_shifter_output_payload_rs1_sign = add_shifter_input_payload_rs1_sign;
+  assign add_shifter_output_payload_rs1_special = add_shifter_input_payload_rs1_special;
+  assign add_shifter_output_payload_rs2_mantissa = add_shifter_input_payload_rs2_mantissa;
+  assign add_shifter_output_payload_rs2_exponent = add_shifter_input_payload_rs2_exponent;
+  assign add_shifter_output_payload_rs2_sign = add_shifter_input_payload_rs2_sign;
+  assign add_shifter_output_payload_rs2_special = add_shifter_input_payload_rs2_special;
+  assign add_shifter_output_payload_rd = add_shifter_input_payload_rd;
+  assign add_shifter_output_payload_roundMode = add_shifter_input_payload_roundMode;
+  assign add_shifter_output_payload_needCommit = add_shifter_input_payload_needCommit;
+  assign add_shifter_exp21 = ({1'b0,add_shifter_input_payload_rs2_exponent} - {1'b0,add_shifter_input_payload_rs1_exponent});
   assign _zz_add_shifter_shiftBy = add_shifter_exp21;
   assign add_shifter_shiftBy = (_zz_add_shifter_shiftBy_1 + _zz_add_shifter_shiftBy_3);
   assign add_shifter_shiftOverflow = (10'h01a <= add_shifter_shiftBy);
-  assign add_shifter_passThrough = ((add_shifter_shiftOverflow || (add_preShifter_output_input_payload_rs1_special && (add_preShifter_output_input_payload_rs1_exponent[1 : 0] == 2'b00))) || (add_preShifter_output_input_payload_rs2_special && (add_preShifter_output_input_payload_rs2_exponent[1 : 0] == 2'b00)));
-  assign add_shifter_xySign = (add_preShifter_output_input_payload_absRs1Bigger ? add_preShifter_output_input_payload_rs1_sign : add_preShifter_output_input_payload_rs2_sign);
-  assign add_shifter_output_payload_xSign = (add_shifter_xySign ^ (add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs1_sign : add_preShifter_output_input_payload_rs2_sign));
-  assign add_shifter_output_payload_ySign = (add_shifter_xySign ^ (add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs2_sign : add_preShifter_output_input_payload_rs1_sign));
-  assign add_shifter_xMantissa = {1'b1,(add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs1_mantissa : add_preShifter_output_input_payload_rs2_mantissa)};
-  assign add_shifter_yMantissaUnshifted = {1'b1,(add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs2_mantissa : add_preShifter_output_input_payload_rs1_mantissa)};
+  assign add_shifter_passThrough = ((add_shifter_shiftOverflow || (add_shifter_input_payload_rs1_special && (add_shifter_input_payload_rs1_exponent[1 : 0] == 2'b00))) || (add_shifter_input_payload_rs2_special && (add_shifter_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign add_shifter_xySign = (add_shifter_input_payload_absRs1Bigger ? add_shifter_input_payload_rs1_sign : add_shifter_input_payload_rs2_sign);
+  assign add_shifter_output_payload_xSign = (add_shifter_xySign ^ (add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs1_sign : add_shifter_input_payload_rs2_sign));
+  assign add_shifter_output_payload_ySign = (add_shifter_xySign ^ (add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs2_sign : add_shifter_input_payload_rs1_sign));
+  assign add_shifter_xMantissa = {1'b1,(add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs1_mantissa : add_shifter_input_payload_rs2_mantissa)};
+  assign add_shifter_yMantissaUnshifted = {1'b1,(add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs2_mantissa : add_shifter_input_payload_rs1_mantissa)};
   assign add_shifter_yMantissa = add_shifter_yMantissaUnshifted;
   always @(*) begin
     add_shifter_roundingScrap = 1'b0;
@@ -13204,115 +13164,115 @@ module FpuCore (
   assign when_FpuCore_l1419_2 = (add_shifter_shiftBy[2] && (add_shifter_yMantissa_2[3 : 0] != 4'b0000));
   assign when_FpuCore_l1419_3 = (add_shifter_shiftBy[1] && (add_shifter_yMantissa_3[1 : 0] != 2'b00));
   assign when_FpuCore_l1419_4 = (add_shifter_shiftBy[0] && (add_shifter_yMantissa_4[0 : 0] != 1'b0));
-  assign when_FpuCore_l1424 = (add_preShifter_output_input_payload_rs1_special || add_preShifter_output_input_payload_rs2_special);
-  assign add_shifter_output_payload_xyExponent = (add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs1_exponent : add_preShifter_output_input_payload_rs2_exponent);
+  assign when_FpuCore_l1424 = (add_shifter_input_payload_rs1_special || add_shifter_input_payload_rs2_special);
+  assign add_shifter_output_payload_xyExponent = (add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs1_exponent : add_shifter_input_payload_rs2_exponent);
   assign add_shifter_output_payload_xMantissa = add_shifter_xMantissa;
   assign add_shifter_output_payload_yMantissa = add_shifter_yMantissa_5;
   assign add_shifter_output_payload_xySign = add_shifter_xySign;
   assign add_shifter_output_payload_roundingScrap = add_shifter_roundingScrap;
   always @(*) begin
-    add_shifter_output_ready = add_shifter_output_input_ready;
-    if(when_Stream_l342_13) begin
+    add_shifter_output_ready = add_math_input_ready;
+    if(when_Stream_l368_13) begin
       add_shifter_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_13 = (! add_shifter_output_input_valid);
-  assign add_shifter_output_input_valid = add_shifter_output_rValid;
-  assign add_shifter_output_input_payload_rs1_mantissa = add_shifter_output_rData_rs1_mantissa;
-  assign add_shifter_output_input_payload_rs1_exponent = add_shifter_output_rData_rs1_exponent;
-  assign add_shifter_output_input_payload_rs1_sign = add_shifter_output_rData_rs1_sign;
-  assign add_shifter_output_input_payload_rs1_special = add_shifter_output_rData_rs1_special;
-  assign add_shifter_output_input_payload_rs2_mantissa = add_shifter_output_rData_rs2_mantissa;
-  assign add_shifter_output_input_payload_rs2_exponent = add_shifter_output_rData_rs2_exponent;
-  assign add_shifter_output_input_payload_rs2_sign = add_shifter_output_rData_rs2_sign;
-  assign add_shifter_output_input_payload_rs2_special = add_shifter_output_rData_rs2_special;
-  assign add_shifter_output_input_payload_rd = add_shifter_output_rData_rd;
-  assign add_shifter_output_input_payload_roundMode = add_shifter_output_rData_roundMode;
-  assign add_shifter_output_input_payload_needCommit = add_shifter_output_rData_needCommit;
-  assign add_shifter_output_input_payload_xSign = add_shifter_output_rData_xSign;
-  assign add_shifter_output_input_payload_ySign = add_shifter_output_rData_ySign;
-  assign add_shifter_output_input_payload_xMantissa = add_shifter_output_rData_xMantissa;
-  assign add_shifter_output_input_payload_yMantissa = add_shifter_output_rData_yMantissa;
-  assign add_shifter_output_input_payload_xyExponent = add_shifter_output_rData_xyExponent;
-  assign add_shifter_output_input_payload_xySign = add_shifter_output_rData_xySign;
-  assign add_shifter_output_input_payload_roundingScrap = add_shifter_output_rData_roundingScrap;
-  assign add_math_output_valid = add_shifter_output_input_valid;
-  assign add_shifter_output_input_ready = add_math_output_ready;
-  assign add_math_output_payload_rs1_mantissa = add_shifter_output_input_payload_rs1_mantissa;
-  assign add_math_output_payload_rs1_exponent = add_shifter_output_input_payload_rs1_exponent;
-  assign add_math_output_payload_rs1_sign = add_shifter_output_input_payload_rs1_sign;
-  assign add_math_output_payload_rs1_special = add_shifter_output_input_payload_rs1_special;
-  assign add_math_output_payload_rs2_mantissa = add_shifter_output_input_payload_rs2_mantissa;
-  assign add_math_output_payload_rs2_exponent = add_shifter_output_input_payload_rs2_exponent;
-  assign add_math_output_payload_rs2_sign = add_shifter_output_input_payload_rs2_sign;
-  assign add_math_output_payload_rs2_special = add_shifter_output_input_payload_rs2_special;
-  assign add_math_output_payload_rd = add_shifter_output_input_payload_rd;
-  assign add_math_output_payload_roundMode = add_shifter_output_input_payload_roundMode;
-  assign add_math_output_payload_needCommit = add_shifter_output_input_payload_needCommit;
-  assign add_math_output_payload_xSign = add_shifter_output_input_payload_xSign;
-  assign add_math_output_payload_ySign = add_shifter_output_input_payload_ySign;
-  assign add_math_output_payload_xMantissa = add_shifter_output_input_payload_xMantissa;
-  assign add_math_output_payload_yMantissa = add_shifter_output_input_payload_yMantissa;
-  assign add_math_output_payload_xyExponent = add_shifter_output_input_payload_xyExponent;
-  assign add_math_output_payload_xySign = add_shifter_output_input_payload_xySign;
-  assign add_math_output_payload_roundingScrap = add_shifter_output_input_payload_roundingScrap;
+  assign when_Stream_l368_13 = (! add_math_input_valid);
+  assign add_math_input_valid = add_shifter_output_rValid;
+  assign add_math_input_payload_rs1_mantissa = add_shifter_output_rData_rs1_mantissa;
+  assign add_math_input_payload_rs1_exponent = add_shifter_output_rData_rs1_exponent;
+  assign add_math_input_payload_rs1_sign = add_shifter_output_rData_rs1_sign;
+  assign add_math_input_payload_rs1_special = add_shifter_output_rData_rs1_special;
+  assign add_math_input_payload_rs2_mantissa = add_shifter_output_rData_rs2_mantissa;
+  assign add_math_input_payload_rs2_exponent = add_shifter_output_rData_rs2_exponent;
+  assign add_math_input_payload_rs2_sign = add_shifter_output_rData_rs2_sign;
+  assign add_math_input_payload_rs2_special = add_shifter_output_rData_rs2_special;
+  assign add_math_input_payload_rd = add_shifter_output_rData_rd;
+  assign add_math_input_payload_roundMode = add_shifter_output_rData_roundMode;
+  assign add_math_input_payload_needCommit = add_shifter_output_rData_needCommit;
+  assign add_math_input_payload_xSign = add_shifter_output_rData_xSign;
+  assign add_math_input_payload_ySign = add_shifter_output_rData_ySign;
+  assign add_math_input_payload_xMantissa = add_shifter_output_rData_xMantissa;
+  assign add_math_input_payload_yMantissa = add_shifter_output_rData_yMantissa;
+  assign add_math_input_payload_xyExponent = add_shifter_output_rData_xyExponent;
+  assign add_math_input_payload_xySign = add_shifter_output_rData_xySign;
+  assign add_math_input_payload_roundingScrap = add_shifter_output_rData_roundingScrap;
+  assign add_math_output_valid = add_math_input_valid;
+  assign add_math_input_ready = add_math_output_ready;
+  assign add_math_output_payload_rs1_mantissa = add_math_input_payload_rs1_mantissa;
+  assign add_math_output_payload_rs1_exponent = add_math_input_payload_rs1_exponent;
+  assign add_math_output_payload_rs1_sign = add_math_input_payload_rs1_sign;
+  assign add_math_output_payload_rs1_special = add_math_input_payload_rs1_special;
+  assign add_math_output_payload_rs2_mantissa = add_math_input_payload_rs2_mantissa;
+  assign add_math_output_payload_rs2_exponent = add_math_input_payload_rs2_exponent;
+  assign add_math_output_payload_rs2_sign = add_math_input_payload_rs2_sign;
+  assign add_math_output_payload_rs2_special = add_math_input_payload_rs2_special;
+  assign add_math_output_payload_rd = add_math_input_payload_rd;
+  assign add_math_output_payload_roundMode = add_math_input_payload_roundMode;
+  assign add_math_output_payload_needCommit = add_math_input_payload_needCommit;
+  assign add_math_output_payload_xSign = add_math_input_payload_xSign;
+  assign add_math_output_payload_ySign = add_math_input_payload_ySign;
+  assign add_math_output_payload_xMantissa = add_math_input_payload_xMantissa;
+  assign add_math_output_payload_yMantissa = add_math_input_payload_yMantissa;
+  assign add_math_output_payload_xyExponent = add_math_input_payload_xyExponent;
+  assign add_math_output_payload_xySign = add_math_input_payload_xySign;
+  assign add_math_output_payload_roundingScrap = add_math_input_payload_roundingScrap;
   assign add_math_xSigned = _zz_add_math_xSigned;
   assign add_math_ySigned = _zz_add_math_ySigned;
   assign add_math_output_payload_xyMantissa = _zz_add_math_output_payload_xyMantissa[26 : 0];
   always @(*) begin
-    add_math_output_ready = add_math_output_input_ready;
-    if(when_Stream_l342_14) begin
+    add_math_output_ready = add_oh_input_ready;
+    if(when_Stream_l368_14) begin
       add_math_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_14 = (! add_math_output_input_valid);
-  assign add_math_output_input_valid = add_math_output_rValid;
-  assign add_math_output_input_payload_rs1_mantissa = add_math_output_rData_rs1_mantissa;
-  assign add_math_output_input_payload_rs1_exponent = add_math_output_rData_rs1_exponent;
-  assign add_math_output_input_payload_rs1_sign = add_math_output_rData_rs1_sign;
-  assign add_math_output_input_payload_rs1_special = add_math_output_rData_rs1_special;
-  assign add_math_output_input_payload_rs2_mantissa = add_math_output_rData_rs2_mantissa;
-  assign add_math_output_input_payload_rs2_exponent = add_math_output_rData_rs2_exponent;
-  assign add_math_output_input_payload_rs2_sign = add_math_output_rData_rs2_sign;
-  assign add_math_output_input_payload_rs2_special = add_math_output_rData_rs2_special;
-  assign add_math_output_input_payload_rd = add_math_output_rData_rd;
-  assign add_math_output_input_payload_roundMode = add_math_output_rData_roundMode;
-  assign add_math_output_input_payload_needCommit = add_math_output_rData_needCommit;
-  assign add_math_output_input_payload_xSign = add_math_output_rData_xSign;
-  assign add_math_output_input_payload_ySign = add_math_output_rData_ySign;
-  assign add_math_output_input_payload_xMantissa = add_math_output_rData_xMantissa;
-  assign add_math_output_input_payload_yMantissa = add_math_output_rData_yMantissa;
-  assign add_math_output_input_payload_xyExponent = add_math_output_rData_xyExponent;
-  assign add_math_output_input_payload_xySign = add_math_output_rData_xySign;
-  assign add_math_output_input_payload_roundingScrap = add_math_output_rData_roundingScrap;
-  assign add_math_output_input_payload_xyMantissa = add_math_output_rData_xyMantissa;
-  assign add_math_output_input_fire = (add_math_output_input_valid && add_math_output_input_ready);
-  assign when_FpuCore_l221_4 = ((add_math_output_input_fire && add_math_output_input_payload_needCommit) && 1'b1);
+  assign when_Stream_l368_14 = (! add_oh_input_valid);
+  assign add_oh_input_valid = add_math_output_rValid;
+  assign add_oh_input_payload_rs1_mantissa = add_math_output_rData_rs1_mantissa;
+  assign add_oh_input_payload_rs1_exponent = add_math_output_rData_rs1_exponent;
+  assign add_oh_input_payload_rs1_sign = add_math_output_rData_rs1_sign;
+  assign add_oh_input_payload_rs1_special = add_math_output_rData_rs1_special;
+  assign add_oh_input_payload_rs2_mantissa = add_math_output_rData_rs2_mantissa;
+  assign add_oh_input_payload_rs2_exponent = add_math_output_rData_rs2_exponent;
+  assign add_oh_input_payload_rs2_sign = add_math_output_rData_rs2_sign;
+  assign add_oh_input_payload_rs2_special = add_math_output_rData_rs2_special;
+  assign add_oh_input_payload_rd = add_math_output_rData_rd;
+  assign add_oh_input_payload_roundMode = add_math_output_rData_roundMode;
+  assign add_oh_input_payload_needCommit = add_math_output_rData_needCommit;
+  assign add_oh_input_payload_xSign = add_math_output_rData_xSign;
+  assign add_oh_input_payload_ySign = add_math_output_rData_ySign;
+  assign add_oh_input_payload_xMantissa = add_math_output_rData_xMantissa;
+  assign add_oh_input_payload_yMantissa = add_math_output_rData_yMantissa;
+  assign add_oh_input_payload_xyExponent = add_math_output_rData_xyExponent;
+  assign add_oh_input_payload_xySign = add_math_output_rData_xySign;
+  assign add_oh_input_payload_roundingScrap = add_math_output_rData_roundingScrap;
+  assign add_oh_input_payload_xyMantissa = add_math_output_rData_xyMantissa;
+  assign add_oh_input_fire = (add_oh_input_valid && add_oh_input_ready);
+  assign when_FpuCore_l221_4 = ((add_oh_input_fire && add_oh_input_payload_needCommit) && 1'b1);
   assign add_oh_isCommited = commitLogic_0_add_notEmpty;
-  assign _zz_add_math_output_input_ready = (! (add_math_output_input_payload_needCommit && (! add_oh_isCommited)));
-  assign add_math_output_input_ready = (add_oh_output_ready && _zz_add_math_output_input_ready);
-  assign add_oh_output_valid = (add_math_output_input_valid && _zz_add_math_output_input_ready);
-  assign add_oh_output_payload_rs1_mantissa = add_math_output_input_payload_rs1_mantissa;
-  assign add_oh_output_payload_rs1_exponent = add_math_output_input_payload_rs1_exponent;
-  assign add_oh_output_payload_rs1_sign = add_math_output_input_payload_rs1_sign;
-  assign add_oh_output_payload_rs1_special = add_math_output_input_payload_rs1_special;
-  assign add_oh_output_payload_rs2_mantissa = add_math_output_input_payload_rs2_mantissa;
-  assign add_oh_output_payload_rs2_exponent = add_math_output_input_payload_rs2_exponent;
-  assign add_oh_output_payload_rs2_sign = add_math_output_input_payload_rs2_sign;
-  assign add_oh_output_payload_rs2_special = add_math_output_input_payload_rs2_special;
-  assign add_oh_output_payload_rd = add_math_output_input_payload_rd;
-  assign add_oh_output_payload_roundMode = add_math_output_input_payload_roundMode;
-  assign add_oh_output_payload_needCommit = add_math_output_input_payload_needCommit;
-  assign add_oh_output_payload_xSign = add_math_output_input_payload_xSign;
-  assign add_oh_output_payload_ySign = add_math_output_input_payload_ySign;
-  assign add_oh_output_payload_xMantissa = add_math_output_input_payload_xMantissa;
-  assign add_oh_output_payload_yMantissa = add_math_output_input_payload_yMantissa;
-  assign add_oh_output_payload_xyExponent = add_math_output_input_payload_xyExponent;
-  assign add_oh_output_payload_xySign = add_math_output_input_payload_xySign;
-  assign add_oh_output_payload_roundingScrap = add_math_output_input_payload_roundingScrap;
-  assign add_oh_output_payload_xyMantissa = add_math_output_input_payload_xyMantissa;
+  assign _zz_add_oh_input_ready = (! (add_oh_input_payload_needCommit && (! add_oh_isCommited)));
+  assign add_oh_input_ready = (add_oh_output_ready && _zz_add_oh_input_ready);
+  assign add_oh_output_valid = (add_oh_input_valid && _zz_add_oh_input_ready);
+  assign add_oh_output_payload_rs1_mantissa = add_oh_input_payload_rs1_mantissa;
+  assign add_oh_output_payload_rs1_exponent = add_oh_input_payload_rs1_exponent;
+  assign add_oh_output_payload_rs1_sign = add_oh_input_payload_rs1_sign;
+  assign add_oh_output_payload_rs1_special = add_oh_input_payload_rs1_special;
+  assign add_oh_output_payload_rs2_mantissa = add_oh_input_payload_rs2_mantissa;
+  assign add_oh_output_payload_rs2_exponent = add_oh_input_payload_rs2_exponent;
+  assign add_oh_output_payload_rs2_sign = add_oh_input_payload_rs2_sign;
+  assign add_oh_output_payload_rs2_special = add_oh_input_payload_rs2_special;
+  assign add_oh_output_payload_rd = add_oh_input_payload_rd;
+  assign add_oh_output_payload_roundMode = add_oh_input_payload_roundMode;
+  assign add_oh_output_payload_needCommit = add_oh_input_payload_needCommit;
+  assign add_oh_output_payload_xSign = add_oh_input_payload_xSign;
+  assign add_oh_output_payload_ySign = add_oh_input_payload_ySign;
+  assign add_oh_output_payload_xMantissa = add_oh_input_payload_xMantissa;
+  assign add_oh_output_payload_yMantissa = add_oh_input_payload_yMantissa;
+  assign add_oh_output_payload_xyExponent = add_oh_input_payload_xyExponent;
+  assign add_oh_output_payload_xySign = add_oh_input_payload_xySign;
+  assign add_oh_output_payload_roundingScrap = add_oh_input_payload_roundingScrap;
+  assign add_oh_output_payload_xyMantissa = add_oh_input_payload_xyMantissa;
   assign _zz_add_oh_shift = {add_oh_output_payload_xyMantissa[0],{add_oh_output_payload_xyMantissa[1],{add_oh_output_payload_xyMantissa[2],{add_oh_output_payload_xyMantissa[3],{add_oh_output_payload_xyMantissa[4],{add_oh_output_payload_xyMantissa[5],{add_oh_output_payload_xyMantissa[6],{add_oh_output_payload_xyMantissa[7],{add_oh_output_payload_xyMantissa[8],{_zz__zz_add_oh_shift,{_zz__zz_add_oh_shift_1,_zz__zz_add_oh_shift_2}}}}}}}}}}};
   assign _zz_add_oh_shift_1 = (_zz_add_oh_shift & (~ _zz__zz_add_oh_shift_1_1));
   assign _zz_add_oh_shift_2 = _zz_add_oh_shift_1[3];
@@ -13344,56 +13304,56 @@ module FpuCore (
   assign add_oh_shift = {_zz_add_oh_shift_27,{_zz_add_oh_shift_26,{_zz_add_oh_shift_25,{_zz_add_oh_shift_24,_zz_add_oh_shift_23}}}};
   assign add_oh_output_payload_shift = add_oh_shift;
   always @(*) begin
-    add_oh_output_ready = add_oh_output_input_ready;
-    if(when_Stream_l342_15) begin
+    add_oh_output_ready = add_norm_input_ready;
+    if(when_Stream_l368_15) begin
       add_oh_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_15 = (! add_oh_output_input_valid);
-  assign add_oh_output_input_valid = add_oh_output_rValid;
-  assign add_oh_output_input_payload_rs1_mantissa = add_oh_output_rData_rs1_mantissa;
-  assign add_oh_output_input_payload_rs1_exponent = add_oh_output_rData_rs1_exponent;
-  assign add_oh_output_input_payload_rs1_sign = add_oh_output_rData_rs1_sign;
-  assign add_oh_output_input_payload_rs1_special = add_oh_output_rData_rs1_special;
-  assign add_oh_output_input_payload_rs2_mantissa = add_oh_output_rData_rs2_mantissa;
-  assign add_oh_output_input_payload_rs2_exponent = add_oh_output_rData_rs2_exponent;
-  assign add_oh_output_input_payload_rs2_sign = add_oh_output_rData_rs2_sign;
-  assign add_oh_output_input_payload_rs2_special = add_oh_output_rData_rs2_special;
-  assign add_oh_output_input_payload_rd = add_oh_output_rData_rd;
-  assign add_oh_output_input_payload_roundMode = add_oh_output_rData_roundMode;
-  assign add_oh_output_input_payload_needCommit = add_oh_output_rData_needCommit;
-  assign add_oh_output_input_payload_xSign = add_oh_output_rData_xSign;
-  assign add_oh_output_input_payload_ySign = add_oh_output_rData_ySign;
-  assign add_oh_output_input_payload_xMantissa = add_oh_output_rData_xMantissa;
-  assign add_oh_output_input_payload_yMantissa = add_oh_output_rData_yMantissa;
-  assign add_oh_output_input_payload_xyExponent = add_oh_output_rData_xyExponent;
-  assign add_oh_output_input_payload_xySign = add_oh_output_rData_xySign;
-  assign add_oh_output_input_payload_roundingScrap = add_oh_output_rData_roundingScrap;
-  assign add_oh_output_input_payload_xyMantissa = add_oh_output_rData_xyMantissa;
-  assign add_oh_output_input_payload_shift = add_oh_output_rData_shift;
-  assign add_norm_output_valid = add_oh_output_input_valid;
-  assign add_oh_output_input_ready = add_norm_output_ready;
-  assign add_norm_output_payload_rs1_mantissa = add_oh_output_input_payload_rs1_mantissa;
-  assign add_norm_output_payload_rs1_exponent = add_oh_output_input_payload_rs1_exponent;
-  assign add_norm_output_payload_rs1_sign = add_oh_output_input_payload_rs1_sign;
-  assign add_norm_output_payload_rs1_special = add_oh_output_input_payload_rs1_special;
-  assign add_norm_output_payload_rs2_mantissa = add_oh_output_input_payload_rs2_mantissa;
-  assign add_norm_output_payload_rs2_exponent = add_oh_output_input_payload_rs2_exponent;
-  assign add_norm_output_payload_rs2_sign = add_oh_output_input_payload_rs2_sign;
-  assign add_norm_output_payload_rs2_special = add_oh_output_input_payload_rs2_special;
-  assign add_norm_output_payload_rd = add_oh_output_input_payload_rd;
-  assign add_norm_output_payload_roundMode = add_oh_output_input_payload_roundMode;
-  assign add_norm_output_payload_needCommit = add_oh_output_input_payload_needCommit;
-  assign add_norm_output_payload_xySign = add_oh_output_input_payload_xySign;
-  assign add_norm_output_payload_roundingScrap = add_oh_output_input_payload_roundingScrap;
-  assign add_norm_output_payload_mantissa = (add_oh_output_input_payload_xyMantissa <<< add_oh_output_input_payload_shift);
+  assign when_Stream_l368_15 = (! add_norm_input_valid);
+  assign add_norm_input_valid = add_oh_output_rValid;
+  assign add_norm_input_payload_rs1_mantissa = add_oh_output_rData_rs1_mantissa;
+  assign add_norm_input_payload_rs1_exponent = add_oh_output_rData_rs1_exponent;
+  assign add_norm_input_payload_rs1_sign = add_oh_output_rData_rs1_sign;
+  assign add_norm_input_payload_rs1_special = add_oh_output_rData_rs1_special;
+  assign add_norm_input_payload_rs2_mantissa = add_oh_output_rData_rs2_mantissa;
+  assign add_norm_input_payload_rs2_exponent = add_oh_output_rData_rs2_exponent;
+  assign add_norm_input_payload_rs2_sign = add_oh_output_rData_rs2_sign;
+  assign add_norm_input_payload_rs2_special = add_oh_output_rData_rs2_special;
+  assign add_norm_input_payload_rd = add_oh_output_rData_rd;
+  assign add_norm_input_payload_roundMode = add_oh_output_rData_roundMode;
+  assign add_norm_input_payload_needCommit = add_oh_output_rData_needCommit;
+  assign add_norm_input_payload_xSign = add_oh_output_rData_xSign;
+  assign add_norm_input_payload_ySign = add_oh_output_rData_ySign;
+  assign add_norm_input_payload_xMantissa = add_oh_output_rData_xMantissa;
+  assign add_norm_input_payload_yMantissa = add_oh_output_rData_yMantissa;
+  assign add_norm_input_payload_xyExponent = add_oh_output_rData_xyExponent;
+  assign add_norm_input_payload_xySign = add_oh_output_rData_xySign;
+  assign add_norm_input_payload_roundingScrap = add_oh_output_rData_roundingScrap;
+  assign add_norm_input_payload_xyMantissa = add_oh_output_rData_xyMantissa;
+  assign add_norm_input_payload_shift = add_oh_output_rData_shift;
+  assign add_norm_output_valid = add_norm_input_valid;
+  assign add_norm_input_ready = add_norm_output_ready;
+  assign add_norm_output_payload_rs1_mantissa = add_norm_input_payload_rs1_mantissa;
+  assign add_norm_output_payload_rs1_exponent = add_norm_input_payload_rs1_exponent;
+  assign add_norm_output_payload_rs1_sign = add_norm_input_payload_rs1_sign;
+  assign add_norm_output_payload_rs1_special = add_norm_input_payload_rs1_special;
+  assign add_norm_output_payload_rs2_mantissa = add_norm_input_payload_rs2_mantissa;
+  assign add_norm_output_payload_rs2_exponent = add_norm_input_payload_rs2_exponent;
+  assign add_norm_output_payload_rs2_sign = add_norm_input_payload_rs2_sign;
+  assign add_norm_output_payload_rs2_special = add_norm_input_payload_rs2_special;
+  assign add_norm_output_payload_rd = add_norm_input_payload_rd;
+  assign add_norm_output_payload_roundMode = add_norm_input_payload_roundMode;
+  assign add_norm_output_payload_needCommit = add_norm_input_payload_needCommit;
+  assign add_norm_output_payload_xySign = add_norm_input_payload_xySign;
+  assign add_norm_output_payload_roundingScrap = add_norm_input_payload_roundingScrap;
+  assign add_norm_output_payload_mantissa = (add_norm_input_payload_xyMantissa <<< add_norm_input_payload_shift);
   assign add_norm_output_payload_exponent = (_zz_add_norm_output_payload_exponent + 10'h001);
-  assign add_norm_output_payload_forceInfinity = ((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b01)));
-  assign add_norm_output_payload_forceZero = ((add_oh_output_input_payload_xyMantissa == 27'h0) || ((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b00))));
-  assign add_norm_output_payload_infinityNan = (((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b01))) && (add_oh_output_input_payload_rs1_sign ^ add_oh_output_input_payload_rs2_sign));
-  assign add_norm_output_payload_forceNan = (((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b10))) || add_norm_output_payload_infinityNan);
-  assign add_norm_output_payload_xyMantissaZero = (add_oh_output_input_payload_xyMantissa == 27'h0);
+  assign add_norm_output_payload_forceInfinity = ((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign add_norm_output_payload_forceZero = ((add_norm_input_payload_xyMantissa == 27'h0) || ((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b00))));
+  assign add_norm_output_payload_infinityNan = (((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b01))) && (add_norm_input_payload_rs1_sign ^ add_norm_input_payload_rs2_sign));
+  assign add_norm_output_payload_forceNan = (((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b10))) || add_norm_output_payload_infinityNan);
+  assign add_norm_output_payload_xyMantissaZero = (add_norm_input_payload_xyMantissa == 27'h0);
   assign add_result_input_valid = add_norm_output_valid;
   assign add_norm_output_ready = add_result_input_ready;
   assign add_result_input_payload_rs1_mantissa = add_norm_output_payload_rs1_mantissa;
@@ -13478,15 +13438,15 @@ module FpuCore (
   assign add_result_output_payload_NV = ((add_result_input_payload_infinityNan || ((add_result_input_payload_rs1_special && (add_result_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! add_result_input_payload_rs1_mantissa[24]))) || ((add_result_input_payload_rs2_special && (add_result_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! add_result_input_payload_rs2_mantissa[24])));
   assign add_result_output_payload_DZ = 1'b0;
   assign when_FpuCore_l1513 = (add_result_input_payload_xyMantissaZero || ((add_result_input_payload_rs1_special && (add_result_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (add_result_input_payload_rs2_special && (add_result_input_payload_rs2_exponent[1 : 0] == 2'b00))));
-  assign when_FpuCore_l1516 = ((add_result_input_payload_rs1_sign || add_result_input_payload_rs2_sign) && (add_result_input_payload_roundMode == `FpuRoundMode_opt_RDN));
+  assign when_FpuCore_l1516 = ((add_result_input_payload_rs1_sign || add_result_input_payload_rs2_sign) && (add_result_input_payload_roundMode == FpuRoundMode_RDN));
   always @(*) begin
     load_s1_output_ready = load_s1_output_m2sPipe_ready;
-    if(when_Stream_l342_16) begin
+    if(when_Stream_l368_16) begin
       load_s1_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_16 = (! load_s1_output_m2sPipe_valid);
+  assign when_Stream_l368_16 = (! load_s1_output_m2sPipe_valid);
   assign load_s1_output_m2sPipe_valid = load_s1_output_rValid;
   assign load_s1_output_m2sPipe_payload_rd = load_s1_output_rData_rd;
   assign load_s1_output_m2sPipe_payload_value_mantissa = load_s1_output_rData_value_mantissa;
@@ -13499,12 +13459,12 @@ module FpuCore (
   assign load_s1_output_m2sPipe_payload_DZ = load_s1_output_rData_DZ;
   always @(*) begin
     shortPip_output_ready = shortPip_output_m2sPipe_ready;
-    if(when_Stream_l342_17) begin
+    if(when_Stream_l368_17) begin
       shortPip_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_17 = (! shortPip_output_m2sPipe_valid);
+  assign when_Stream_l368_17 = (! shortPip_output_m2sPipe_valid);
   assign shortPip_output_m2sPipe_valid = shortPip_output_rValid;
   assign shortPip_output_m2sPipe_payload_rd = shortPip_output_rData_rd;
   assign shortPip_output_m2sPipe_payload_value_mantissa = shortPip_output_rData_value_mantissa;
@@ -13550,16 +13510,16 @@ module FpuCore (
   assign roundFront_roundAdjusted = {_zz_roundFront_roundAdjusted[roundFront_discardCount],((roundFront_manAggregate & roundFront_exactMask) != 25'h0)};
   always @(*) begin
     case(roundFront_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         _zz_roundFront_mantissaIncrement = (roundFront_roundAdjusted[1] && (roundFront_roundAdjusted[0] || _zz__zz_roundFront_mantissaIncrement[roundFront_discardCount]));
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         _zz_roundFront_mantissaIncrement = 1'b0;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         _zz_roundFront_mantissaIncrement = ((roundFront_roundAdjusted != 2'b00) && roundFront_input_payload_value_sign);
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         _zz_roundFront_mantissaIncrement = ((roundFront_roundAdjusted != 2'b00) && (! roundFront_input_payload_value_sign));
       end
       default : begin
@@ -13664,16 +13624,16 @@ module FpuCore (
   assign roundBack_ofThreshold = 9'h17e;
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         roundBack_threshold = 3'b110;
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         roundBack_threshold = 3'b110;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         roundBack_threshold = (roundBack_input_payload_value_sign ? 3'b101 : 3'b111);
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         roundBack_threshold = (roundBack_input_payload_value_sign ? 3'b111 : 3'b101);
       end
       default : begin
@@ -13688,16 +13648,16 @@ module FpuCore (
   assign when_FpuCore_l1611 = ((! roundBack_math_special) && (roundBack_ofThreshold < roundBack_math_exponent));
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         when_FpuCore_l1621 = 1'b0;
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         when_FpuCore_l1621 = 1'b1;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         when_FpuCore_l1621 = (! roundBack_math_sign);
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         when_FpuCore_l1621 = roundBack_math_sign;
       end
       default : begin
@@ -13709,16 +13669,16 @@ module FpuCore (
   assign when_FpuCore_l1630 = ((! roundBack_math_special) && (roundBack_math_exponent < _zz_when_FpuCore_l1630));
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         when_FpuCore_l1640 = 1'b0;
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         when_FpuCore_l1640 = 1'b0;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         when_FpuCore_l1640 = roundBack_math_sign;
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         when_FpuCore_l1640 = (! roundBack_math_sign);
       end
       default : begin
@@ -13811,7 +13771,7 @@ module FpuCore (
       if(io_port_0_cmd_valid) begin
         io_port_0_cmd_rValid <= 1'b1;
       end
-      if(io_port_0_cmd_input_ready) begin
+      if(scheduler_0_input_ready) begin
         io_port_0_cmd_rValid <= 1'b0;
       end
       if(read_s0_ready) begin
@@ -13859,7 +13819,7 @@ module FpuCore (
       if(decode_div_valid) begin
         decode_div_rValid <= 1'b1;
       end
-      if(decode_div_input_fire) begin
+      if(div_input_fire) begin
         decode_div_rValid <= 1'b0;
       end
       if(div_divider_io_input_fire) begin
@@ -13871,7 +13831,7 @@ module FpuCore (
       if(decode_sqrt_valid) begin
         decode_sqrt_rValid <= 1'b1;
       end
-      if(decode_sqrt_input_fire) begin
+      if(sqrt_input_fire) begin
         decode_sqrt_rValid <= 1'b0;
       end
       if(sqrt_sqrt_io_input_fire) begin
@@ -13904,20 +13864,20 @@ module FpuCore (
       if(writeback_port_valid) begin
         `ifndef SYNTHESIS
           `ifdef FORMAL
-            assert((! ((writeback_port_payload_data_value_exponent == 9'h0) && (! writeback_port_payload_data_value_special))));
+            assert((! ((writeback_port_payload_data_value_exponent == 9'h0) && (! writeback_port_payload_data_value_special)))); // FpuCore.scala:L1705
           `else
             if(!(! ((writeback_port_payload_data_value_exponent == 9'h0) && (! writeback_port_payload_data_value_special)))) begin
-              $display("FAILURE Special violation");
+              $display("FAILURE Special violation"); // FpuCore.scala:L1705
               $finish;
             end
           `endif
         `endif
         `ifndef SYNTHESIS
           `ifdef FORMAL
-            assert((! ((writeback_port_payload_data_value_exponent == 9'h1ff) && (! writeback_port_payload_data_value_special))));
+            assert((! ((writeback_port_payload_data_value_exponent == 9'h1ff) && (! writeback_port_payload_data_value_special)))); // FpuCore.scala:L1706
           `else
             if(!(! ((writeback_port_payload_data_value_exponent == 9'h1ff) && (! writeback_port_payload_data_value_special)))) begin
-              $display("FAILURE Special violation");
+              $display("FAILURE Special violation"); // FpuCore.scala:L1706
               $finish;
             end
           `endif
@@ -13988,7 +13948,7 @@ module FpuCore (
         end else begin
           load_s1_fsm_shift_by <= {_zz_load_s1_fsm_shift_by_32,{_zz_load_s1_fsm_shift_by_31,{_zz_load_s1_fsm_shift_by_30,{_zz_load_s1_fsm_shift_by_29,_zz_load_s1_fsm_shift_by_28}}}};
           load_s1_fsm_boot <= 1'b0;
-          load_s1_fsm_i2fZero <= (load_s0_output_input_payload_value[31 : 0] == 32'h0);
+          load_s1_fsm_i2fZero <= (load_s1_input_payload_value[31 : 0] == 32'h0);
         end
       end else begin
         load_s1_fsm_done <= 1'b1;
@@ -14367,6 +14327,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -14390,6 +14351,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -14406,6 +14369,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -14447,40 +14411,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -14490,33 +14454,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -14524,18 +14488,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -14547,17 +14511,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -14611,14 +14575,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -14632,42 +14596,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -14677,7 +14641,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -14687,7 +14651,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -14697,7 +14661,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -14722,14 +14686,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -14739,7 +14703,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -14749,7 +14713,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -14759,7 +14723,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -14772,15 +14736,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -14788,7 +14752,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -14810,42 +14774,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -14853,7 +14817,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -14863,27 +14827,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -14894,8 +14858,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -14903,26 +14867,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -14943,22 +14907,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -14967,8 +14931,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -14981,8 +14945,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -14997,8 +14961,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -15008,12 +14972,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -15022,11 +14986,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -15042,12 +15006,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -15055,26 +15019,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -15085,27 +15049,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -15126,28 +15090,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -15158,7 +15128,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -15166,7 +15136,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -15217,6 +15187,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -15234,7 +15205,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -15280,8 +15251,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -15351,10 +15322,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -15382,7 +15353,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
@@ -15481,7 +15452,7 @@ module StreamArbiter_1 (
   input               io_inputs_0_payload_value_sign,
   input               io_inputs_0_payload_value_special,
   input               io_inputs_0_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_0_payload_roundMode,
+  input      [2:0]    io_inputs_0_payload_roundMode,
   input               io_inputs_0_payload_NV,
   input               io_inputs_0_payload_DZ,
   input               io_inputs_1_valid,
@@ -15492,7 +15463,7 @@ module StreamArbiter_1 (
   input               io_inputs_1_payload_value_sign,
   input               io_inputs_1_payload_value_special,
   input               io_inputs_1_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_1_payload_roundMode,
+  input      [2:0]    io_inputs_1_payload_roundMode,
   input               io_inputs_1_payload_NV,
   input               io_inputs_1_payload_DZ,
   input               io_inputs_2_valid,
@@ -15503,7 +15474,7 @@ module StreamArbiter_1 (
   input               io_inputs_2_payload_value_sign,
   input               io_inputs_2_payload_value_special,
   input               io_inputs_2_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_2_payload_roundMode,
+  input      [2:0]    io_inputs_2_payload_roundMode,
   input               io_inputs_2_payload_NV,
   input               io_inputs_2_payload_DZ,
   input               io_inputs_3_valid,
@@ -15514,7 +15485,7 @@ module StreamArbiter_1 (
   input               io_inputs_3_payload_value_sign,
   input               io_inputs_3_payload_value_special,
   input               io_inputs_3_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_3_payload_roundMode,
+  input      [2:0]    io_inputs_3_payload_roundMode,
   input               io_inputs_3_payload_NV,
   input               io_inputs_3_payload_DZ,
   input               io_inputs_4_valid,
@@ -15525,7 +15496,7 @@ module StreamArbiter_1 (
   input               io_inputs_4_payload_value_sign,
   input               io_inputs_4_payload_value_special,
   input               io_inputs_4_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_4_payload_roundMode,
+  input      [2:0]    io_inputs_4_payload_roundMode,
   input               io_inputs_4_payload_NV,
   input               io_inputs_4_payload_DZ,
   input               io_inputs_5_valid,
@@ -15536,7 +15507,7 @@ module StreamArbiter_1 (
   input               io_inputs_5_payload_value_sign,
   input               io_inputs_5_payload_value_special,
   input               io_inputs_5_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_5_payload_roundMode,
+  input      [2:0]    io_inputs_5_payload_roundMode,
   input               io_inputs_5_payload_NV,
   input               io_inputs_5_payload_DZ,
   output              io_output_valid,
@@ -15547,7 +15518,7 @@ module StreamArbiter_1 (
   output              io_output_payload_value_sign,
   output              io_output_payload_value_special,
   output              io_output_payload_scrap,
-  output     `FpuRoundMode_opt_type io_output_payload_roundMode,
+  output     [2:0]    io_output_payload_roundMode,
   output              io_output_payload_NV,
   output              io_output_payload_DZ,
   output     [2:0]    io_chosen,
@@ -15555,8 +15526,14 @@ module StreamArbiter_1 (
   input               clk,
   input               reset
 );
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire       [5:0]    _zz__zz_maskProposal_1_1;
-  reg        `FpuRoundMode_opt_type _zz__zz_io_output_payload_roundMode;
+  reg        [2:0]    _zz__zz_io_output_payload_roundMode;
   reg        [4:0]    _zz_io_output_payload_rd_4;
   reg        [23:0]   _zz_io_output_payload_value_mantissa;
   reg        [8:0]    _zz_io_output_payload_value_exponent;
@@ -15590,7 +15567,7 @@ module StreamArbiter_1 (
   wire                _zz_io_output_payload_rd_1;
   wire                _zz_io_output_payload_rd_2;
   wire       [2:0]    _zz_io_output_payload_rd_3;
-  wire       `FpuRoundMode_opt_type _zz_io_output_payload_roundMode;
+  wire       [2:0]    _zz_io_output_payload_roundMode;
   wire                _zz_io_chosen;
   wire                _zz_io_chosen_1;
   wire                _zz_io_chosen_2;
@@ -15683,81 +15660,81 @@ module StreamArbiter_1 (
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_inputs_0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_0_payload_roundMode_string = "RMM";
       default : io_inputs_0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_1_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_1_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_1_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_1_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_1_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_1_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_1_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_1_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_1_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_1_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_1_payload_roundMode_string = "RMM";
       default : io_inputs_1_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_2_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_2_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_2_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_2_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_2_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_2_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_2_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_2_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_2_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_2_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_2_payload_roundMode_string = "RMM";
       default : io_inputs_2_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_3_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_3_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_3_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_3_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_3_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_3_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_3_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_3_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_3_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_3_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_3_payload_roundMode_string = "RMM";
       default : io_inputs_3_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_4_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_4_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_4_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_4_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_4_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_4_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_4_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_4_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_4_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_4_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_4_payload_roundMode_string = "RMM";
       default : io_inputs_4_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_5_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_5_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_5_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_5_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_5_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_5_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_5_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_5_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_5_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_5_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_5_payload_roundMode_string = "RMM";
       default : io_inputs_5_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_output_payload_roundMode_string = "RMM";
       default : io_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_io_output_payload_roundMode_string = "RMM";
       default : _zz_io_output_payload_roundMode_string = "???";
     endcase
   end
@@ -15831,6 +15808,7 @@ module FpuSqrt (
   input               clk,
   input               reset
 );
+
   wire       [27:0]   _zz_t;
   wire       [25:0]   _zz_t_1;
   wire       [24:0]   _zz_q;
@@ -15926,6 +15904,7 @@ module FpuDiv (
   input               clk,
   input               reset
 );
+
   wire       [24:0]   _zz_shifter_1;
   wire       [24:0]   _zz_div1;
   wire       [26:0]   _zz_div3;
@@ -16035,28 +16014,52 @@ endmodule
 module StreamArbiter (
   input               io_inputs_0_valid,
   output              io_inputs_0_ready,
-  input      `FpuOpcode_binary_sequential_type io_inputs_0_payload_opcode,
+  input      [3:0]    io_inputs_0_payload_opcode,
   input      [1:0]    io_inputs_0_payload_arg,
   input      [4:0]    io_inputs_0_payload_rs1,
   input      [4:0]    io_inputs_0_payload_rs2,
   input      [4:0]    io_inputs_0_payload_rs3,
   input      [4:0]    io_inputs_0_payload_rd,
-  input      `FpuFormat_binary_sequential_type io_inputs_0_payload_format,
-  input      `FpuRoundMode_opt_type io_inputs_0_payload_roundMode,
+  input      [0:0]    io_inputs_0_payload_format,
+  input      [2:0]    io_inputs_0_payload_roundMode,
   output              io_output_valid,
   input               io_output_ready,
-  output     `FpuOpcode_binary_sequential_type io_output_payload_opcode,
+  output     [3:0]    io_output_payload_opcode,
   output     [1:0]    io_output_payload_arg,
   output     [4:0]    io_output_payload_rs1,
   output     [4:0]    io_output_payload_rs2,
   output     [4:0]    io_output_payload_rs3,
   output     [4:0]    io_output_payload_rd,
-  output     `FpuFormat_binary_sequential_type io_output_payload_format,
-  output     `FpuRoundMode_opt_type io_output_payload_roundMode,
+  output     [0:0]    io_output_payload_format,
+  output     [2:0]    io_output_payload_roundMode,
   output     [0:0]    io_chosenOH,
   input               clk,
   input               reset
 );
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+  localparam FpuFormat_FLOAT = 1'd0;
+  localparam FpuFormat_DOUBLE = 1'd1;
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire       [1:0]    _zz__zz_maskProposal_0_2;
   wire       [1:0]    _zz__zz_maskProposal_0_2_1;
   wire       [0:0]    _zz__zz_maskProposal_0_2_2;
@@ -16068,9 +16071,9 @@ module StreamArbiter (
   wire       [0:0]    _zz_maskProposal_0;
   wire       [1:0]    _zz_maskProposal_0_1;
   wire       [1:0]    _zz_maskProposal_0_2;
-  wire       `FpuOpcode_binary_sequential_type _zz_io_output_payload_opcode;
-  wire       `FpuFormat_binary_sequential_type _zz_io_output_payload_format;
-  wire       `FpuRoundMode_opt_type _zz_io_output_payload_roundMode;
+  wire       [3:0]    _zz_io_output_payload_opcode;
+  wire       [0:0]    _zz_io_output_payload_format;
+  wire       [2:0]    _zz_io_output_payload_roundMode;
   `ifndef SYNTHESIS
   reg [63:0] io_inputs_0_payload_opcode_string;
   reg [47:0] io_inputs_0_payload_format_string;
@@ -16091,115 +16094,115 @@ module StreamArbiter (
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_inputs_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_inputs_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_inputs_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_inputs_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_inputs_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_inputs_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_inputs_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_inputs_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_inputs_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_inputs_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_inputs_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_inputs_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_inputs_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_inputs_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_inputs_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_inputs_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_inputs_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_inputs_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_inputs_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_inputs_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_inputs_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_inputs_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_inputs_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_inputs_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_inputs_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_inputs_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_inputs_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_inputs_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_inputs_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_inputs_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_inputs_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_inputs_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_inputs_0_payload_opcode_string = "FCVT_X_X";
       default : io_inputs_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_inputs_0_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_inputs_0_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_inputs_0_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_inputs_0_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_inputs_0_payload_format_string = "DOUBLE";
       default : io_inputs_0_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_inputs_0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_0_payload_roundMode_string = "RMM";
       default : io_inputs_0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_output_payload_opcode_string = "FCVT_X_X";
       default : io_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_output_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_output_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_output_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_output_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_output_payload_format_string = "DOUBLE";
       default : io_output_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_output_payload_roundMode_string = "RMM";
       default : io_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_io_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_io_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_io_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_io_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_io_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_io_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_io_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_io_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_io_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_io_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_io_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_io_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_io_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_io_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_io_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_io_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_io_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_io_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_io_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_io_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_io_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_io_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_io_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_io_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_io_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_io_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_io_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_io_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_io_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_io_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_io_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_io_output_payload_opcode_string = "FCVT_X_X";
       default : _zz_io_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : _zz_io_output_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : _zz_io_output_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : _zz_io_output_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : _zz_io_output_payload_format_string = "DOUBLE";
       default : _zz_io_output_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_io_output_payload_roundMode_string = "RMM";
       default : _zz_io_output_payload_roundMode_string = "???";
     endcase
   end
@@ -16241,23 +16244,40 @@ endmodule
 module StreamFork (
   input               io_input_valid,
   output              io_input_ready,
-  input      `FpuOpcode_binary_sequential_type io_input_payload_opcode,
+  input      [3:0]    io_input_payload_opcode,
   input      [4:0]    io_input_payload_rd,
   input               io_input_payload_write,
   input      [31:0]   io_input_payload_value,
   output              io_outputs_0_valid,
   input               io_outputs_0_ready,
-  output     `FpuOpcode_binary_sequential_type io_outputs_0_payload_opcode,
+  output     [3:0]    io_outputs_0_payload_opcode,
   output     [4:0]    io_outputs_0_payload_rd,
   output              io_outputs_0_payload_write,
   output     [31:0]   io_outputs_0_payload_value,
   output              io_outputs_1_valid,
   input               io_outputs_1_ready,
-  output     `FpuOpcode_binary_sequential_type io_outputs_1_payload_opcode,
+  output     [3:0]    io_outputs_1_payload_opcode,
   output     [4:0]    io_outputs_1_payload_rd,
   output              io_outputs_1_payload_write,
   output     [31:0]   io_outputs_1_payload_value
 );
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+
   `ifndef SYNTHESIS
   reg [63:0] io_input_payload_opcode_string;
   reg [63:0] io_outputs_0_payload_opcode_string;
@@ -16268,64 +16288,64 @@ module StreamFork (
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_input_payload_opcode_string = "FCVT_X_X";
       default : io_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_outputs_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_outputs_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_outputs_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_outputs_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_outputs_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_outputs_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_outputs_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_outputs_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_outputs_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_outputs_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_outputs_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_outputs_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_outputs_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_outputs_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_outputs_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_outputs_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_outputs_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_outputs_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_outputs_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_outputs_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_outputs_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_outputs_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_outputs_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_outputs_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_outputs_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_outputs_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_outputs_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_outputs_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_outputs_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_outputs_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_outputs_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_outputs_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_outputs_0_payload_opcode_string = "FCVT_X_X";
       default : io_outputs_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_outputs_1_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_outputs_1_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_outputs_1_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_outputs_1_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_outputs_1_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_outputs_1_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_outputs_1_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_outputs_1_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_outputs_1_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_outputs_1_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_outputs_1_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_outputs_1_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_outputs_1_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_outputs_1_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_outputs_1_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_outputs_1_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_outputs_1_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_outputs_1_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_outputs_1_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_outputs_1_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_outputs_1_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_outputs_1_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_outputs_1_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_outputs_1_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_outputs_1_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_outputs_1_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_outputs_1_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_outputs_1_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_outputs_1_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_outputs_1_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_outputs_1_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_outputs_1_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_outputs_1_payload_opcode_string = "FCVT_X_X";
       default : io_outputs_1_payload_opcode_string = "????????";
     endcase
   end

--- a/soc/vexriscv/VexRiscv_FpuCfu.v
+++ b/soc/vexriscv/VexRiscv_FpuCfu.v
@@ -1,81 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : e695a6d139f77e4c1099f09f0880f22e85a17e82
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define FpuOpcode_binary_sequential_type [3:0]
-`define FpuOpcode_binary_sequential_LOAD 4'b0000
-`define FpuOpcode_binary_sequential_STORE 4'b0001
-`define FpuOpcode_binary_sequential_MUL 4'b0010
-`define FpuOpcode_binary_sequential_ADD 4'b0011
-`define FpuOpcode_binary_sequential_FMA 4'b0100
-`define FpuOpcode_binary_sequential_I2F 4'b0101
-`define FpuOpcode_binary_sequential_F2I 4'b0110
-`define FpuOpcode_binary_sequential_CMP 4'b0111
-`define FpuOpcode_binary_sequential_DIV 4'b1000
-`define FpuOpcode_binary_sequential_SQRT 4'b1001
-`define FpuOpcode_binary_sequential_MIN_MAX 4'b1010
-`define FpuOpcode_binary_sequential_SGNJ 4'b1011
-`define FpuOpcode_binary_sequential_FMV_X_W 4'b1100
-`define FpuOpcode_binary_sequential_FMV_W_X 4'b1101
-`define FpuOpcode_binary_sequential_FCLASS 4'b1110
-`define FpuOpcode_binary_sequential_FCVT_X_X 4'b1111
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
-`define FpuFormat_binary_sequential_type [0:0]
-`define FpuFormat_binary_sequential_FLOAT 1'b0
-`define FpuFormat_binary_sequential_DOUBLE 1'b1
-
-`define FpuRoundMode_opt_type [2:0]
-`define FpuRoundMode_opt_RNE 3'b000
-`define FpuRoundMode_opt_RTZ 3'b001
-`define FpuRoundMode_opt_RDN 3'b010
-`define FpuRoundMode_opt_RUP 3'b011
-`define FpuRoundMode_opt_RMM 3'b100
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -115,6 +42,58 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+  localparam FpuFormat_FLOAT = 1'd0;
+  localparam FpuFormat_DOUBLE = 1'd1;
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -143,6 +122,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -249,6 +230,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
@@ -271,240 +254,227 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_FPU_RSP_13;
   wire                _zz__zz_decode_FPU_RSP_14;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_15;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_16;
+  wire                _zz__zz_decode_FPU_RSP_16;
   wire                _zz__zz_decode_FPU_RSP_17;
-  wire                _zz__zz_decode_FPU_RSP_18;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_19;
-  wire                _zz__zz_decode_FPU_RSP_20;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_21;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_18;
+  wire                _zz__zz_decode_FPU_RSP_19;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_20;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_21;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_22;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_23;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_23;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_24;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_25;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_26;
-  wire                _zz__zz_decode_FPU_RSP_27;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_28;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_29;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_25;
+  wire                _zz__zz_decode_FPU_RSP_26;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_27;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_28;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_29;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_30;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_31;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_32;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_31;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_32;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_33;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_34;
-  wire       [37:0]   _zz__zz_decode_FPU_RSP_35;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_36;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_37;
+  wire       [37:0]   _zz__zz_decode_FPU_RSP_34;
+  wire       [4:0]    _zz__zz_decode_FPU_RSP_35;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_36;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_37;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_38;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_39;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_40;
-  wire                _zz__zz_decode_FPU_RSP_41;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_42;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_43;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_39;
+  wire                _zz__zz_decode_FPU_RSP_40;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_41;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_42;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_43;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_44;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_45;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_46;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_45;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_46;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_47;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_48;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_49;
-  wire                _zz__zz_decode_FPU_RSP_50;
+  wire                _zz__zz_decode_FPU_RSP_48;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_49;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_50;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_51;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_52;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_53;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_54;
-  wire                _zz__zz_decode_FPU_RSP_55;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_52;
+  wire                _zz__zz_decode_FPU_RSP_53;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_54;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_55;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_56;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_57;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_58;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_57;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_58;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_59;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_60;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_61;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_62;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_63;
-  wire       [34:0]   _zz__zz_decode_FPU_RSP_64;
-  wire                _zz__zz_decode_FPU_RSP_65;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_60;
+  wire       [34:0]   _zz__zz_decode_FPU_RSP_61;
+  wire                _zz__zz_decode_FPU_RSP_62;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_63;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_64;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_65;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_66;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_67;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_68;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_69;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_70;
-  wire       [32:0]   _zz__zz_decode_FPU_RSP_71;
-  wire                _zz__zz_decode_FPU_RSP_72;
+  wire       [32:0]   _zz__zz_decode_FPU_RSP_70;
+  wire                _zz__zz_decode_FPU_RSP_71;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_72;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_73;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_74;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_75;
-  wire       [30:0]   _zz__zz_decode_FPU_RSP_76;
-  wire                _zz__zz_decode_FPU_RSP_77;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_78;
+  wire       [30:0]   _zz__zz_decode_FPU_RSP_74;
+  wire                _zz__zz_decode_FPU_RSP_75;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_76;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_77;
+  wire       [28:0]   _zz__zz_decode_FPU_RSP_78;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_79;
-  wire       [28:0]   _zz__zz_decode_FPU_RSP_80;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_81;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_82;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_83;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_84;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_85;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_86;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_80;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_81;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_82;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_83;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_84;
+  wire                _zz__zz_decode_FPU_RSP_85;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_86;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_87;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_88;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_89;
-  wire                _zz__zz_decode_FPU_RSP_90;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_89;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_90;
   wire                _zz__zz_decode_FPU_RSP_91;
-  wire                _zz__zz_decode_FPU_RSP_92;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_93;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_94;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_95;
+  wire       [23:0]   _zz__zz_decode_FPU_RSP_92;
+  wire                _zz__zz_decode_FPU_RSP_93;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_94;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_95;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_96;
-  wire       [23:0]   _zz__zz_decode_FPU_RSP_97;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_98;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_99;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_100;
-  wire                _zz__zz_decode_FPU_RSP_101;
-  wire                _zz__zz_decode_FPU_RSP_102;
-  wire                _zz__zz_decode_FPU_RSP_103;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_104;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_97;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_98;
+  wire                _zz__zz_decode_FPU_RSP_99;
+  wire                _zz__zz_decode_FPU_RSP_100;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_101;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_102;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_103;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_104;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_105;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_106;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_107;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_108;
+  wire                _zz__zz_decode_FPU_RSP_106;
+  wire       [19:0]   _zz__zz_decode_FPU_RSP_107;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_108;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_109;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_110;
+  wire                _zz__zz_decode_FPU_RSP_110;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_111;
-  wire       [20:0]   _zz__zz_decode_FPU_RSP_112;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_112;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_113;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_114;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_115;
-  wire                _zz__zz_decode_FPU_RSP_116;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_114;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_115;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_116;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_117;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_118;
+  wire       [16:0]   _zz__zz_decode_FPU_RSP_118;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_119;
-  wire                _zz__zz_decode_FPU_RSP_120;
-  wire       [17:0]   _zz__zz_decode_FPU_RSP_121;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_122;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_123;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_124;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_120;
+  wire                _zz__zz_decode_FPU_RSP_121;
+  wire                _zz__zz_decode_FPU_RSP_122;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_123;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_124;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_125;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_126;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_127;
-  wire                _zz__zz_decode_FPU_RSP_128;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_129;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_126;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_127;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_128;
+  wire       [4:0]    _zz__zz_decode_FPU_RSP_129;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_130;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_131;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_132;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_131;
+  wire                _zz__zz_decode_FPU_RSP_132;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_133;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_134;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_134;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_135;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_136;
-  wire       [14:0]   _zz__zz_decode_FPU_RSP_137;
-  wire       [5:0]    _zz__zz_decode_FPU_RSP_138;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_137;
+  wire                _zz__zz_decode_FPU_RSP_138;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_139;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_140;
-  wire                _zz__zz_decode_FPU_RSP_141;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_142;
+  wire       [13:0]   _zz__zz_decode_FPU_RSP_140;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_141;
+  wire                _zz__zz_decode_FPU_RSP_142;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_143;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_144;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_145;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_146;
-  wire                _zz__zz_decode_FPU_RSP_147;
+  wire       [3:0]    _zz__zz_decode_FPU_RSP_144;
+  wire                _zz__zz_decode_FPU_RSP_145;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_146;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_147;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_148;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_149;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_150;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_151;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_149;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_150;
+  wire                _zz__zz_decode_FPU_RSP_151;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_152;
-  wire       [5:0]    _zz__zz_decode_FPU_RSP_153;
-  wire                _zz__zz_decode_FPU_RSP_154;
+  wire                _zz__zz_decode_FPU_RSP_153;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_154;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_155;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_156;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_157;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_158;
+  wire       [3:0]    _zz__zz_decode_FPU_RSP_157;
+  wire                _zz__zz_decode_FPU_RSP_158;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_159;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_160;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_161;
-  wire                _zz__zz_decode_FPU_RSP_162;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_163;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_164;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_160;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_161;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_162;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_163;
+  wire                _zz__zz_decode_FPU_RSP_164;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_165;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_166;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_167;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_168;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_169;
-  wire       [11:0]   _zz__zz_decode_FPU_RSP_170;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_171;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_172;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_173;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_174;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_175;
-  wire                _zz__zz_decode_FPU_RSP_176;
+  wire                _zz__zz_decode_FPU_RSP_166;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_167;
+  wire       [10:0]   _zz__zz_decode_FPU_RSP_168;
+  wire       [6:0]    _zz__zz_decode_FPU_RSP_169;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_170;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_171;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_172;
+  wire       [4:0]    _zz__zz_decode_FPU_RSP_173;
+  wire                _zz__zz_decode_FPU_RSP_174;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_175;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_176;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_177;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_178;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_179;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_180;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_181;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_182;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_178;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_179;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_180;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_181;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_182;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_183;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_184;
-  wire                _zz__zz_decode_FPU_RSP_185;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_186;
-  wire       [5:0]    _zz__zz_decode_FPU_RSP_187;
-  wire                _zz__zz_decode_FPU_RSP_188;
+  wire                _zz__zz_decode_FPU_RSP_184;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_185;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_186;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_187;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_188;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_189;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_190;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_191;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_192;
-  wire       [3:0]    _zz__zz_decode_FPU_RSP_193;
-  wire                _zz__zz_decode_FPU_RSP_194;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_190;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_191;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_192;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_193;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_194;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_195;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_196;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_197;
+  wire       [7:0]    _zz__zz_decode_FPU_RSP_197;
   wire                _zz__zz_decode_FPU_RSP_198;
   wire                _zz__zz_decode_FPU_RSP_199;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_200;
-  wire       [3:0]    _zz__zz_decode_FPU_RSP_201;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_200;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_201;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_202;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_203;
-  wire                _zz__zz_decode_FPU_RSP_204;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_205;
-  wire       [3:0]    _zz__zz_decode_FPU_RSP_206;
-  wire       [8:0]    _zz__zz_decode_FPU_RSP_207;
-  wire                _zz__zz_decode_FPU_RSP_208;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_209;
-  wire       [1:0]    _zz__zz_decode_FPU_RSP_210;
-  wire                _zz__zz_decode_FPU_RSP_211;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_212;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_203;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_204;
+  wire       [5:0]    _zz__zz_decode_FPU_RSP_205;
+  wire                _zz__zz_decode_FPU_RSP_206;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_207;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_208;
+  wire       [5:0]    _zz__zz_decode_FPU_RSP_209;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_210;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_211;
+  wire                _zz__zz_decode_FPU_RSP_212;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_213;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_214;
+  wire       [2:0]    _zz__zz_decode_FPU_RSP_214;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_215;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_216;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_217;
-  wire       [6:0]    _zz__zz_decode_FPU_RSP_218;
-  wire                _zz__zz_decode_FPU_RSP_219;
-  wire                _zz__zz_decode_FPU_RSP_220;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_221;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_222;
-  wire       [5:0]    _zz__zz_decode_FPU_RSP_223;
-  wire                _zz__zz_decode_FPU_RSP_224;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_225;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_226;
-  wire       [3:0]    _zz__zz_decode_FPU_RSP_227;
-  wire                _zz__zz_decode_FPU_RSP_228;
+  wire                _zz__zz_decode_FPU_RSP_217;
+  wire                _zz__zz_decode_FPU_RSP_218;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_219;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_220;
+  wire       [3:0]    _zz__zz_decode_FPU_RSP_221;
+  wire                _zz__zz_decode_FPU_RSP_222;
+  wire                _zz__zz_decode_FPU_RSP_223;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_224;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_225;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_226;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_227;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_228;
   wire       [0:0]    _zz__zz_decode_FPU_RSP_229;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_230;
-  wire       [5:0]    _zz__zz_decode_FPU_RSP_231;
-  wire       [4:0]    _zz__zz_decode_FPU_RSP_232;
-  wire                _zz__zz_decode_FPU_RSP_233;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_234;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_235;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_230;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_231;
+  wire       [31:0]   _zz__zz_decode_FPU_RSP_232;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_233;
+  wire       [1:0]    _zz__zz_decode_FPU_RSP_234;
+  wire       [0:0]    _zz__zz_decode_FPU_RSP_235;
   wire       [31:0]   _zz__zz_decode_FPU_RSP_236;
-  wire       [31:0]   _zz__zz_decode_FPU_RSP_237;
-  wire                _zz__zz_decode_FPU_RSP_238;
-  wire                _zz__zz_decode_FPU_RSP_239;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_240;
-  wire       [2:0]    _zz__zz_decode_FPU_RSP_241;
-  wire                _zz__zz_decode_FPU_RSP_242;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_243;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_244;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_245;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_246;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_247;
-  wire       [0:0]    _zz__zz_decode_FPU_RSP_248;
-  wire                _zz__zz_decode_FPU_RSP_249;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -591,16 +561,16 @@ module VexRiscv (
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   memory_RS1;
-  wire       `FpuOpcode_binary_sequential_type memory_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_memory_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_memory_to_writeBack_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_memory_to_writeBack_FPU_OPCODE_1;
-  wire       `FpuOpcode_binary_sequential_type execute_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_execute_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_execute_to_memory_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_execute_to_memory_FPU_OPCODE_1;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_to_execute_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_to_execute_FPU_OPCODE_1;
+  wire       [3:0]    memory_FPU_OPCODE;
+  wire       [3:0]    _zz_memory_FPU_OPCODE;
+  wire       [3:0]    _zz_memory_to_writeBack_FPU_OPCODE;
+  wire       [3:0]    _zz_memory_to_writeBack_FPU_OPCODE_1;
+  wire       [3:0]    execute_FPU_OPCODE;
+  wire       [3:0]    _zz_execute_FPU_OPCODE;
+  wire       [3:0]    _zz_execute_to_memory_FPU_OPCODE;
+  wire       [3:0]    _zz_execute_to_memory_FPU_OPCODE_1;
+  wire       [3:0]    _zz_decode_to_execute_FPU_OPCODE;
+  wire       [3:0]    _zz_decode_to_execute_FPU_OPCODE_1;
   wire                memory_FPU_RSP;
   wire                execute_FPU_RSP;
   wire                decode_FPU_RSP;
@@ -609,10 +579,10 @@ module VexRiscv (
   wire                decode_FPU_COMMIT;
   wire                memory_FPU_ENABLE;
   wire                execute_FPU_ENABLE;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -620,46 +590,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -676,18 +648,20 @@ module VexRiscv (
   wire                writeBack_FPU_RSP;
   wire                writeBack_FPU_FORKED;
   wire       [1:0]    decode_FPU_ARG;
-  wire       `FpuOpcode_binary_sequential_type decode_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_FPU_OPCODE;
+  wire       [3:0]    decode_FPU_OPCODE;
+  wire       [3:0]    _zz_decode_FPU_OPCODE;
   wire                decode_FPU_ENABLE;
-  wire       `FpuOpcode_binary_sequential_type writeBack_FPU_OPCODE;
-  wire       `FpuOpcode_binary_sequential_type _zz_writeBack_FPU_OPCODE;
+  wire       [3:0]    writeBack_FPU_OPCODE;
+  wire       [3:0]    _zz_writeBack_FPU_OPCODE;
   wire                writeBack_FPU_ENABLE;
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -701,20 +675,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -728,44 +701,44 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
   wire       [31:0]   _zz_execute_SRC1;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_FPU_OPCODE_1;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [3:0]    _zz_decode_FPU_OPCODE_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -774,6 +747,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -786,8 +760,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -799,7 +773,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -843,6 +817,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -911,6 +886,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -936,17 +912,17 @@ module VexRiscv (
   wire                CsrPlugin_allowEbreakException;
   wire                FpuPlugin_port_cmd_valid /* verilator public */ ;
   wire                FpuPlugin_port_cmd_ready /* verilator public */ ;
-  wire       `FpuOpcode_binary_sequential_type FpuPlugin_port_cmd_payload_opcode /* verilator public */ ;
+  wire       [3:0]    FpuPlugin_port_cmd_payload_opcode /* verilator public */ ;
   wire       [1:0]    FpuPlugin_port_cmd_payload_arg /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rs1 /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rs2 /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rs3 /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_cmd_payload_rd /* verilator public */ ;
-  wire       `FpuFormat_binary_sequential_type FpuPlugin_port_cmd_payload_format /* verilator public */ ;
-  wire       `FpuRoundMode_opt_type FpuPlugin_port_cmd_payload_roundMode /* verilator public */ ;
+  wire       [0:0]    FpuPlugin_port_cmd_payload_format /* verilator public */ ;
+  wire       [2:0]    FpuPlugin_port_cmd_payload_roundMode /* verilator public */ ;
   wire                FpuPlugin_port_commit_valid /* verilator public */ ;
   wire                FpuPlugin_port_commit_ready /* verilator public */ ;
-  wire       `FpuOpcode_binary_sequential_type FpuPlugin_port_commit_payload_opcode /* verilator public */ ;
+  wire       [3:0]    FpuPlugin_port_commit_payload_opcode /* verilator public */ ;
   wire       [4:0]    FpuPlugin_port_commit_payload_rd /* verilator public */ ;
   wire                FpuPlugin_port_commit_payload_write /* verilator public */ ;
   wire       [31:0]   FpuPlugin_port_commit_payload_value /* verilator public */ ;
@@ -981,14 +957,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -1030,18 +1006,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -1060,7 +1036,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1107,31 +1082,30 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [43:0]   _zz_decode_FPU_RSP;
   wire                _zz_decode_FPU_RSP_1;
   wire                _zz_decode_FPU_RSP_2;
@@ -1145,16 +1119,15 @@ module VexRiscv (
   wire                _zz_decode_FPU_RSP_10;
   wire                _zz_decode_FPU_RSP_11;
   wire                _zz_decode_FPU_RSP_12;
-  wire                _zz_decode_FPU_RSP_13;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_FPU_OPCODE_2;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire       [3:0]    _zz_decode_FPU_OPCODE_2;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -1208,7 +1181,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1228,7 +1201,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1247,11 +1220,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1268,59 +1241,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1368,22 +1341,25 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   reg        [5:0]    FpuPlugin_pendings;
   wire                FpuPlugin_port_cmd_fire;
   wire                FpuPlugin_port_rsp_fire;
@@ -1412,8 +1388,8 @@ module VexRiscv (
   wire                FpuPlugin_port_cmd_isStall;
   wire       [2:0]    decode_FpuPlugin_iRoundMode;
   wire       [2:0]    decode_FpuPlugin_roundMode;
-  wire       `FpuRoundMode_opt_type _zz_FpuPlugin_port_cmd_payload_roundMode;
-  wire       `FpuRoundMode_opt_type _zz_FpuPlugin_port_cmd_payload_roundMode_1;
+  wire       [2:0]    _zz_FpuPlugin_port_cmd_payload_roundMode;
+  wire       [2:0]    _zz_FpuPlugin_port_cmd_payload_roundMode_1;
   wire                FpuPlugin_port_cmd_fire_2;
   wire                writeBack_FpuPlugin_isRsp;
   wire                writeBack_FpuPlugin_isCommit;
@@ -1424,23 +1400,23 @@ module VexRiscv (
   wire                when_FpuPlugin_l287;
   wire                writeBack_FpuPlugin_commit_valid /* verilator public */ ;
   wire                writeBack_FpuPlugin_commit_ready /* verilator public */ ;
-  wire       `FpuOpcode_binary_sequential_type writeBack_FpuPlugin_commit_payload_opcode /* verilator public */ ;
+  wire       [3:0]    writeBack_FpuPlugin_commit_payload_opcode /* verilator public */ ;
   wire       [4:0]    writeBack_FpuPlugin_commit_payload_rd /* verilator public */ ;
   wire                writeBack_FpuPlugin_commit_payload_write /* verilator public */ ;
   wire       [31:0]   writeBack_FpuPlugin_commit_payload_value /* verilator public */ ;
   wire                when_FpuPlugin_l301;
   wire                writeBack_FpuPlugin_commit_s2mPipe_valid;
   wire                writeBack_FpuPlugin_commit_s2mPipe_ready;
-  wire       `FpuOpcode_binary_sequential_type writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
+  wire       [3:0]    writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
   wire       [4:0]    writeBack_FpuPlugin_commit_s2mPipe_payload_rd;
   wire                writeBack_FpuPlugin_commit_s2mPipe_payload_write;
   wire       [31:0]   writeBack_FpuPlugin_commit_s2mPipe_payload_value;
   reg                 writeBack_FpuPlugin_commit_rValid;
-  reg        `FpuOpcode_binary_sequential_type writeBack_FpuPlugin_commit_rData_opcode;
+  reg        [3:0]    writeBack_FpuPlugin_commit_rData_opcode;
   reg        [4:0]    writeBack_FpuPlugin_commit_rData_rd;
   reg                 writeBack_FpuPlugin_commit_rData_write;
   reg        [31:0]   writeBack_FpuPlugin_commit_rData_value;
-  wire       `FpuOpcode_binary_sequential_type _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
+  wire       [3:0]    _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1462,7 +1438,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1472,9 +1448,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1494,120 +1470,126 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg                 decode_to_execute_FPU_ENABLE;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg                 execute_to_memory_FPU_ENABLE;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 memory_to_writeBack_FPU_ENABLE;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_FPU_COMMIT;
+  reg                 decode_to_execute_FPU_ENABLE;
   wire                when_Pipeline_l124_49;
-  reg                 execute_to_memory_FPU_COMMIT;
+  reg                 execute_to_memory_FPU_ENABLE;
   wire                when_Pipeline_l124_50;
-  reg                 memory_to_writeBack_FPU_COMMIT;
+  reg                 memory_to_writeBack_FPU_ENABLE;
   wire                when_Pipeline_l124_51;
-  reg                 decode_to_execute_FPU_RSP;
+  reg                 decode_to_execute_FPU_COMMIT;
   wire                when_Pipeline_l124_52;
-  reg                 execute_to_memory_FPU_RSP;
+  reg                 execute_to_memory_FPU_COMMIT;
   wire                when_Pipeline_l124_53;
-  reg                 memory_to_writeBack_FPU_RSP;
+  reg                 memory_to_writeBack_FPU_COMMIT;
   wire                when_Pipeline_l124_54;
-  reg        `FpuOpcode_binary_sequential_type decode_to_execute_FPU_OPCODE;
+  reg                 decode_to_execute_FPU_RSP;
   wire                when_Pipeline_l124_55;
-  reg        `FpuOpcode_binary_sequential_type execute_to_memory_FPU_OPCODE;
+  reg                 execute_to_memory_FPU_RSP;
   wire                when_Pipeline_l124_56;
-  reg        `FpuOpcode_binary_sequential_type memory_to_writeBack_FPU_OPCODE;
+  reg                 memory_to_writeBack_FPU_RSP;
   wire                when_Pipeline_l124_57;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg        [3:0]    decode_to_execute_FPU_OPCODE;
   wire                when_Pipeline_l124_58;
-  reg        [31:0]   execute_to_memory_RS1;
+  reg        [3:0]    execute_to_memory_FPU_OPCODE;
   wire                when_Pipeline_l124_59;
-  reg        [31:0]   memory_to_writeBack_RS1;
+  reg        [3:0]    memory_to_writeBack_FPU_OPCODE;
   wire                when_Pipeline_l124_60;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_61;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [31:0]   execute_to_memory_RS1;
   wire                when_Pipeline_l124_62;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   memory_to_writeBack_RS1;
   wire                when_Pipeline_l124_63;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_64;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_65;
-  reg                 decode_to_execute_FPU_FORKED;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_66;
-  reg                 execute_to_memory_FPU_FORKED;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_67;
-  reg                 memory_to_writeBack_FPU_FORKED;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_68;
-  reg                 decode_to_execute_FPU_COMMIT_LOAD;
+  reg                 decode_to_execute_FPU_FORKED;
   wire                when_Pipeline_l124_69;
-  reg                 execute_to_memory_FPU_COMMIT_LOAD;
+  reg                 execute_to_memory_FPU_FORKED;
   wire                when_Pipeline_l124_70;
-  reg                 memory_to_writeBack_FPU_COMMIT_LOAD;
+  reg                 memory_to_writeBack_FPU_FORKED;
   wire                when_Pipeline_l124_71;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_FPU_COMMIT_LOAD;
   wire                when_Pipeline_l124_72;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 execute_to_memory_FPU_COMMIT_LOAD;
   wire                when_Pipeline_l124_73;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 memory_to_writeBack_FPU_COMMIT_LOAD;
   wire                when_Pipeline_l124_74;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_75;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_76;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_77;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_78;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_79;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_80;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_81;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_82;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_83;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_84;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_85;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_86;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1615,67 +1597,68 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1264_24;
+  wire                when_CsrPlugin_l1277_24;
   reg                 execute_CsrPlugin_csr_3;
-  wire                when_CsrPlugin_l1264_25;
+  wire                when_CsrPlugin_l1277_25;
   reg                 execute_CsrPlugin_csr_2;
-  wire                when_CsrPlugin_l1264_26;
+  wire                when_CsrPlugin_l1277_26;
   reg                 execute_CsrPlugin_csr_1;
-  wire                when_CsrPlugin_l1264_27;
+  wire                when_CsrPlugin_l1277_27;
   reg                 execute_CsrPlugin_csr_256;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1700,8 +1683,8 @@ module VexRiscv (
   wire       [4:0]    _zz_FpuPlugin_flags_NX_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_27;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_28;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1833,7 +1816,7 @@ module VexRiscv (
   reg [63:0] memory_to_writeBack_FPU_OPCODE_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1848,7 +1831,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1860,6 +1843,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1956,10 +1941,9 @@ module VexRiscv (
   assign _zz__zz_decode_FPU_RSP_2 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_3) == 32'h20001010);
   assign _zz__zz_decode_FPU_RSP_4 = {(_zz__zz_decode_FPU_RSP_5 == _zz__zz_decode_FPU_RSP_6),(_zz__zz_decode_FPU_RSP_7 == _zz__zz_decode_FPU_RSP_8)};
   assign _zz__zz_decode_FPU_RSP_9 = {(_zz__zz_decode_FPU_RSP_10 == _zz__zz_decode_FPU_RSP_11),{_zz__zz_decode_FPU_RSP_12,_zz__zz_decode_FPU_RSP_14}};
-  assign _zz__zz_decode_FPU_RSP_16 = 3'b000;
-  assign _zz__zz_decode_FPU_RSP_17 = ({_zz__zz_decode_FPU_RSP_18,_zz__zz_decode_FPU_RSP_20} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_22 = ({_zz__zz_decode_FPU_RSP_23,_zz__zz_decode_FPU_RSP_26} != 4'b0000);
-  assign _zz__zz_decode_FPU_RSP_35 = {(_zz__zz_decode_FPU_RSP_36 != _zz__zz_decode_FPU_RSP_49),{_zz__zz_decode_FPU_RSP_50,{_zz__zz_decode_FPU_RSP_53,_zz__zz_decode_FPU_RSP_64}}};
+  assign _zz__zz_decode_FPU_RSP_16 = (|{_zz__zz_decode_FPU_RSP_17,_zz__zz_decode_FPU_RSP_19});
+  assign _zz__zz_decode_FPU_RSP_21 = (|{_zz__zz_decode_FPU_RSP_22,_zz__zz_decode_FPU_RSP_25});
+  assign _zz__zz_decode_FPU_RSP_34 = {(|_zz__zz_decode_FPU_RSP_35),{_zz__zz_decode_FPU_RSP_48,{_zz__zz_decode_FPU_RSP_51,_zz__zz_decode_FPU_RSP_61}}};
   assign _zz__zz_decode_FPU_RSP_3 = 32'h20001010;
   assign _zz__zz_decode_FPU_RSP_5 = (decode_INSTRUCTION & 32'h28000010);
   assign _zz__zz_decode_FPU_RSP_6 = 32'h08000010;
@@ -1969,238 +1953,226 @@ module VexRiscv (
   assign _zz__zz_decode_FPU_RSP_11 = 32'h60000010;
   assign _zz__zz_decode_FPU_RSP_12 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_13) == 32'h18000010);
   assign _zz__zz_decode_FPU_RSP_14 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_15) == 32'h20000010);
-  assign _zz__zz_decode_FPU_RSP_18 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_19) == 32'h80000000);
-  assign _zz__zz_decode_FPU_RSP_20 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_21) == 32'h00000040);
-  assign _zz__zz_decode_FPU_RSP_23 = (_zz__zz_decode_FPU_RSP_24 == _zz__zz_decode_FPU_RSP_25);
-  assign _zz__zz_decode_FPU_RSP_26 = {_zz__zz_decode_FPU_RSP_27,{_zz__zz_decode_FPU_RSP_29,_zz__zz_decode_FPU_RSP_32}};
-  assign _zz__zz_decode_FPU_RSP_36 = {_zz_decode_FPU_RSP_9,{_zz__zz_decode_FPU_RSP_37,_zz__zz_decode_FPU_RSP_40}};
-  assign _zz__zz_decode_FPU_RSP_49 = 5'h0;
-  assign _zz__zz_decode_FPU_RSP_50 = ({_zz__zz_decode_FPU_RSP_51,_zz__zz_decode_FPU_RSP_52} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_53 = (_zz__zz_decode_FPU_RSP_54 != _zz__zz_decode_FPU_RSP_63);
-  assign _zz__zz_decode_FPU_RSP_64 = {_zz__zz_decode_FPU_RSP_65,{_zz__zz_decode_FPU_RSP_70,_zz__zz_decode_FPU_RSP_71}};
+  assign _zz__zz_decode_FPU_RSP_17 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_18) == 32'h80000000);
+  assign _zz__zz_decode_FPU_RSP_19 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_20) == 32'h00000040);
+  assign _zz__zz_decode_FPU_RSP_22 = (_zz__zz_decode_FPU_RSP_23 == _zz__zz_decode_FPU_RSP_24);
+  assign _zz__zz_decode_FPU_RSP_25 = {_zz__zz_decode_FPU_RSP_26,{_zz__zz_decode_FPU_RSP_28,_zz__zz_decode_FPU_RSP_31}};
+  assign _zz__zz_decode_FPU_RSP_35 = {_zz_decode_FPU_RSP_9,{_zz__zz_decode_FPU_RSP_36,_zz__zz_decode_FPU_RSP_39}};
+  assign _zz__zz_decode_FPU_RSP_48 = (|{_zz__zz_decode_FPU_RSP_49,_zz__zz_decode_FPU_RSP_50});
+  assign _zz__zz_decode_FPU_RSP_51 = (|_zz__zz_decode_FPU_RSP_52);
+  assign _zz__zz_decode_FPU_RSP_61 = {_zz__zz_decode_FPU_RSP_62,{_zz__zz_decode_FPU_RSP_69,_zz__zz_decode_FPU_RSP_70}};
   assign _zz__zz_decode_FPU_RSP_13 = 32'h18000010;
   assign _zz__zz_decode_FPU_RSP_15 = 32'ha0000010;
-  assign _zz__zz_decode_FPU_RSP_19 = 32'h80000004;
-  assign _zz__zz_decode_FPU_RSP_21 = 32'h00000050;
-  assign _zz__zz_decode_FPU_RSP_24 = (decode_INSTRUCTION & 32'h10001010);
-  assign _zz__zz_decode_FPU_RSP_25 = 32'h00001010;
-  assign _zz__zz_decode_FPU_RSP_27 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_28) == 32'h00000010);
-  assign _zz__zz_decode_FPU_RSP_29 = (_zz__zz_decode_FPU_RSP_30 == _zz__zz_decode_FPU_RSP_31);
-  assign _zz__zz_decode_FPU_RSP_32 = (_zz__zz_decode_FPU_RSP_33 == _zz__zz_decode_FPU_RSP_34);
-  assign _zz__zz_decode_FPU_RSP_37 = (_zz__zz_decode_FPU_RSP_38 == _zz__zz_decode_FPU_RSP_39);
-  assign _zz__zz_decode_FPU_RSP_40 = {_zz__zz_decode_FPU_RSP_41,{_zz__zz_decode_FPU_RSP_43,_zz__zz_decode_FPU_RSP_46}};
-  assign _zz__zz_decode_FPU_RSP_51 = _zz_decode_FPU_RSP_9;
-  assign _zz__zz_decode_FPU_RSP_52 = _zz_decode_FPU_RSP_6;
-  assign _zz__zz_decode_FPU_RSP_54 = {_zz__zz_decode_FPU_RSP_55,{_zz__zz_decode_FPU_RSP_57,_zz__zz_decode_FPU_RSP_60}};
-  assign _zz__zz_decode_FPU_RSP_63 = 3'b000;
-  assign _zz__zz_decode_FPU_RSP_65 = ({_zz__zz_decode_FPU_RSP_66,_zz__zz_decode_FPU_RSP_69} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_70 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_71 = {_zz__zz_decode_FPU_RSP_72,{_zz__zz_decode_FPU_RSP_73,_zz__zz_decode_FPU_RSP_76}};
-  assign _zz__zz_decode_FPU_RSP_28 = 32'h30000010;
-  assign _zz__zz_decode_FPU_RSP_30 = (decode_INSTRUCTION & 32'h88000010);
-  assign _zz__zz_decode_FPU_RSP_31 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_33 = (decode_INSTRUCTION & 32'h50000010);
-  assign _zz__zz_decode_FPU_RSP_34 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_38 = (decode_INSTRUCTION & 32'h90000010);
-  assign _zz__zz_decode_FPU_RSP_39 = 32'h90000010;
-  assign _zz__zz_decode_FPU_RSP_41 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_42) == 32'h40000010);
-  assign _zz__zz_decode_FPU_RSP_43 = (_zz__zz_decode_FPU_RSP_44 == _zz__zz_decode_FPU_RSP_45);
-  assign _zz__zz_decode_FPU_RSP_46 = (_zz__zz_decode_FPU_RSP_47 == _zz__zz_decode_FPU_RSP_48);
-  assign _zz__zz_decode_FPU_RSP_55 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_56) == 32'h10000000);
-  assign _zz__zz_decode_FPU_RSP_57 = (_zz__zz_decode_FPU_RSP_58 == _zz__zz_decode_FPU_RSP_59);
-  assign _zz__zz_decode_FPU_RSP_60 = (_zz__zz_decode_FPU_RSP_61 == _zz__zz_decode_FPU_RSP_62);
+  assign _zz__zz_decode_FPU_RSP_18 = 32'h80000004;
+  assign _zz__zz_decode_FPU_RSP_20 = 32'h00000050;
+  assign _zz__zz_decode_FPU_RSP_23 = (decode_INSTRUCTION & 32'h10001010);
+  assign _zz__zz_decode_FPU_RSP_24 = 32'h00001010;
+  assign _zz__zz_decode_FPU_RSP_26 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_27) == 32'h00000010);
+  assign _zz__zz_decode_FPU_RSP_28 = (_zz__zz_decode_FPU_RSP_29 == _zz__zz_decode_FPU_RSP_30);
+  assign _zz__zz_decode_FPU_RSP_31 = (_zz__zz_decode_FPU_RSP_32 == _zz__zz_decode_FPU_RSP_33);
+  assign _zz__zz_decode_FPU_RSP_36 = (_zz__zz_decode_FPU_RSP_37 == _zz__zz_decode_FPU_RSP_38);
+  assign _zz__zz_decode_FPU_RSP_39 = {_zz__zz_decode_FPU_RSP_40,{_zz__zz_decode_FPU_RSP_42,_zz__zz_decode_FPU_RSP_45}};
+  assign _zz__zz_decode_FPU_RSP_49 = _zz_decode_FPU_RSP_9;
+  assign _zz__zz_decode_FPU_RSP_50 = _zz_decode_FPU_RSP_6;
+  assign _zz__zz_decode_FPU_RSP_52 = {_zz__zz_decode_FPU_RSP_53,{_zz__zz_decode_FPU_RSP_55,_zz__zz_decode_FPU_RSP_58}};
+  assign _zz__zz_decode_FPU_RSP_62 = (|{_zz__zz_decode_FPU_RSP_63,_zz__zz_decode_FPU_RSP_66});
+  assign _zz__zz_decode_FPU_RSP_69 = 1'b0;
+  assign _zz__zz_decode_FPU_RSP_70 = {_zz__zz_decode_FPU_RSP_71,{_zz__zz_decode_FPU_RSP_72,_zz__zz_decode_FPU_RSP_74}};
+  assign _zz__zz_decode_FPU_RSP_27 = 32'h30000010;
+  assign _zz__zz_decode_FPU_RSP_29 = (decode_INSTRUCTION & 32'h88000010);
+  assign _zz__zz_decode_FPU_RSP_30 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_32 = (decode_INSTRUCTION & 32'h50000010);
+  assign _zz__zz_decode_FPU_RSP_33 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_37 = (decode_INSTRUCTION & 32'h90000010);
+  assign _zz__zz_decode_FPU_RSP_38 = 32'h90000010;
+  assign _zz__zz_decode_FPU_RSP_40 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_41) == 32'h40000010);
+  assign _zz__zz_decode_FPU_RSP_42 = (_zz__zz_decode_FPU_RSP_43 == _zz__zz_decode_FPU_RSP_44);
+  assign _zz__zz_decode_FPU_RSP_45 = (_zz__zz_decode_FPU_RSP_46 == _zz__zz_decode_FPU_RSP_47);
+  assign _zz__zz_decode_FPU_RSP_53 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_54) == 32'h10000000);
+  assign _zz__zz_decode_FPU_RSP_55 = (_zz__zz_decode_FPU_RSP_56 == _zz__zz_decode_FPU_RSP_57);
+  assign _zz__zz_decode_FPU_RSP_58 = (_zz__zz_decode_FPU_RSP_59 == _zz__zz_decode_FPU_RSP_60);
+  assign _zz__zz_decode_FPU_RSP_63 = (_zz__zz_decode_FPU_RSP_64 == _zz__zz_decode_FPU_RSP_65);
   assign _zz__zz_decode_FPU_RSP_66 = (_zz__zz_decode_FPU_RSP_67 == _zz__zz_decode_FPU_RSP_68);
-  assign _zz__zz_decode_FPU_RSP_69 = _zz_decode_FPU_RSP_10;
-  assign _zz__zz_decode_FPU_RSP_72 = (_zz_decode_FPU_RSP_11 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_73 = (_zz__zz_decode_FPU_RSP_74 != _zz__zz_decode_FPU_RSP_75);
-  assign _zz__zz_decode_FPU_RSP_76 = {_zz__zz_decode_FPU_RSP_77,{_zz__zz_decode_FPU_RSP_78,_zz__zz_decode_FPU_RSP_80}};
-  assign _zz__zz_decode_FPU_RSP_42 = 32'hc0000010;
-  assign _zz__zz_decode_FPU_RSP_44 = (decode_INSTRUCTION & 32'h58000010);
-  assign _zz__zz_decode_FPU_RSP_45 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_47 = (decode_INSTRUCTION & 32'hb0000010);
-  assign _zz__zz_decode_FPU_RSP_48 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_56 = 32'h10000020;
-  assign _zz__zz_decode_FPU_RSP_58 = (decode_INSTRUCTION & 32'h80000020);
-  assign _zz__zz_decode_FPU_RSP_59 = 32'h0;
-  assign _zz__zz_decode_FPU_RSP_61 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz__zz_decode_FPU_RSP_62 = 32'h0;
-  assign _zz__zz_decode_FPU_RSP_67 = (decode_INSTRUCTION & 32'h00000060);
-  assign _zz__zz_decode_FPU_RSP_68 = 32'h00000040;
-  assign _zz__zz_decode_FPU_RSP_74 = _zz_decode_FPU_RSP_13;
-  assign _zz__zz_decode_FPU_RSP_75 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_77 = (_zz_decode_FPU_RSP_13 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_78 = (((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_79) == 32'h02004020) != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_80 = {((_zz__zz_decode_FPU_RSP_81 == _zz__zz_decode_FPU_RSP_82) != 1'b0),{({_zz__zz_decode_FPU_RSP_83,_zz__zz_decode_FPU_RSP_84} != 2'b00),{(_zz__zz_decode_FPU_RSP_86 != _zz__zz_decode_FPU_RSP_89),{_zz__zz_decode_FPU_RSP_90,{_zz__zz_decode_FPU_RSP_93,_zz__zz_decode_FPU_RSP_97}}}}};
-  assign _zz__zz_decode_FPU_RSP_79 = 32'h02004064;
-  assign _zz__zz_decode_FPU_RSP_81 = (decode_INSTRUCTION & 32'h02004074);
-  assign _zz__zz_decode_FPU_RSP_82 = 32'h02000030;
-  assign _zz__zz_decode_FPU_RSP_83 = _zz_decode_FPU_RSP_12;
-  assign _zz__zz_decode_FPU_RSP_84 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_85) == 32'h10000030);
-  assign _zz__zz_decode_FPU_RSP_86 = {_zz_decode_FPU_RSP_12,(_zz__zz_decode_FPU_RSP_87 == _zz__zz_decode_FPU_RSP_88)};
-  assign _zz__zz_decode_FPU_RSP_89 = 2'b00;
-  assign _zz__zz_decode_FPU_RSP_90 = ({_zz__zz_decode_FPU_RSP_91,_zz__zz_decode_FPU_RSP_92} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_93 = ({_zz__zz_decode_FPU_RSP_94,_zz__zz_decode_FPU_RSP_95} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_97 = {(_zz__zz_decode_FPU_RSP_98 != _zz__zz_decode_FPU_RSP_100),{_zz__zz_decode_FPU_RSP_101,{_zz__zz_decode_FPU_RSP_104,_zz__zz_decode_FPU_RSP_112}}};
-  assign _zz__zz_decode_FPU_RSP_85 = 32'h10203034;
-  assign _zz__zz_decode_FPU_RSP_87 = (decode_INSTRUCTION & 32'h10403034);
-  assign _zz__zz_decode_FPU_RSP_88 = 32'h10000030;
-  assign _zz__zz_decode_FPU_RSP_91 = ((decode_INSTRUCTION & 32'h00001070) == 32'h00001070);
-  assign _zz__zz_decode_FPU_RSP_92 = ((decode_INSTRUCTION & 32'h00002070) == 32'h00002070);
-  assign _zz__zz_decode_FPU_RSP_94 = _zz_decode_FPU_RSP_7;
-  assign _zz__zz_decode_FPU_RSP_95 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_96) == 32'h00000024);
-  assign _zz__zz_decode_FPU_RSP_98 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_99) == 32'h00000060);
-  assign _zz__zz_decode_FPU_RSP_100 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_101 = ({_zz__zz_decode_FPU_RSP_102,_zz__zz_decode_FPU_RSP_103} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_104 = ({_zz__zz_decode_FPU_RSP_105,_zz__zz_decode_FPU_RSP_107} != 3'b000);
-  assign _zz__zz_decode_FPU_RSP_112 = {(_zz__zz_decode_FPU_RSP_113 != _zz__zz_decode_FPU_RSP_115),{_zz__zz_decode_FPU_RSP_116,{_zz__zz_decode_FPU_RSP_119,_zz__zz_decode_FPU_RSP_121}}};
-  assign _zz__zz_decode_FPU_RSP_96 = 32'h00002034;
-  assign _zz__zz_decode_FPU_RSP_99 = 32'h00000078;
-  assign _zz__zz_decode_FPU_RSP_102 = ((decode_INSTRUCTION & 32'h00007074) == 32'h00005010);
-  assign _zz__zz_decode_FPU_RSP_103 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz__zz_decode_FPU_RSP_105 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_106) == 32'h40001010);
-  assign _zz__zz_decode_FPU_RSP_107 = {(_zz__zz_decode_FPU_RSP_108 == _zz__zz_decode_FPU_RSP_109),(_zz__zz_decode_FPU_RSP_110 == _zz__zz_decode_FPU_RSP_111)};
-  assign _zz__zz_decode_FPU_RSP_113 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_114) == 32'h00000034);
-  assign _zz__zz_decode_FPU_RSP_115 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_116 = ((_zz__zz_decode_FPU_RSP_117 == _zz__zz_decode_FPU_RSP_118) != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_119 = (_zz__zz_decode_FPU_RSP_120 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_121 = {(_zz__zz_decode_FPU_RSP_122 != _zz__zz_decode_FPU_RSP_127),{_zz__zz_decode_FPU_RSP_128,{_zz__zz_decode_FPU_RSP_131,_zz__zz_decode_FPU_RSP_137}}};
-  assign _zz__zz_decode_FPU_RSP_106 = 32'h40003054;
-  assign _zz__zz_decode_FPU_RSP_108 = (decode_INSTRUCTION & 32'h00007074);
-  assign _zz__zz_decode_FPU_RSP_109 = 32'h00001010;
-  assign _zz__zz_decode_FPU_RSP_110 = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz__zz_decode_FPU_RSP_111 = 32'h00001010;
-  assign _zz__zz_decode_FPU_RSP_114 = 32'h00000034;
-  assign _zz__zz_decode_FPU_RSP_117 = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz__zz_decode_FPU_RSP_118 = 32'h00001000;
-  assign _zz__zz_decode_FPU_RSP_120 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz__zz_decode_FPU_RSP_122 = {(_zz__zz_decode_FPU_RSP_123 == _zz__zz_decode_FPU_RSP_124),(_zz__zz_decode_FPU_RSP_125 == _zz__zz_decode_FPU_RSP_126)};
-  assign _zz__zz_decode_FPU_RSP_127 = 2'b00;
-  assign _zz__zz_decode_FPU_RSP_128 = ((_zz__zz_decode_FPU_RSP_129 == _zz__zz_decode_FPU_RSP_130) != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_131 = ({_zz__zz_decode_FPU_RSP_132,_zz__zz_decode_FPU_RSP_134} != 3'b000);
-  assign _zz__zz_decode_FPU_RSP_137 = {(_zz__zz_decode_FPU_RSP_138 != _zz__zz_decode_FPU_RSP_153),{_zz__zz_decode_FPU_RSP_154,{_zz__zz_decode_FPU_RSP_155,_zz__zz_decode_FPU_RSP_170}}};
-  assign _zz__zz_decode_FPU_RSP_123 = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz__zz_decode_FPU_RSP_124 = 32'h00002000;
-  assign _zz__zz_decode_FPU_RSP_125 = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz__zz_decode_FPU_RSP_126 = 32'h00001000;
-  assign _zz__zz_decode_FPU_RSP_129 = (decode_INSTRUCTION & 32'h00004054);
-  assign _zz__zz_decode_FPU_RSP_130 = 32'h00004004;
-  assign _zz__zz_decode_FPU_RSP_132 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_133) == 32'h00000020);
-  assign _zz__zz_decode_FPU_RSP_134 = {_zz_decode_FPU_RSP_11,(_zz__zz_decode_FPU_RSP_135 == _zz__zz_decode_FPU_RSP_136)};
-  assign _zz__zz_decode_FPU_RSP_138 = {(_zz__zz_decode_FPU_RSP_139 == _zz__zz_decode_FPU_RSP_140),{_zz__zz_decode_FPU_RSP_141,{_zz__zz_decode_FPU_RSP_143,_zz__zz_decode_FPU_RSP_146}}};
-  assign _zz__zz_decode_FPU_RSP_153 = 6'h0;
-  assign _zz__zz_decode_FPU_RSP_154 = (_zz_decode_FPU_RSP_9 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_155 = ({_zz__zz_decode_FPU_RSP_156,_zz__zz_decode_FPU_RSP_157} != 6'h0);
-  assign _zz__zz_decode_FPU_RSP_170 = {(_zz__zz_decode_FPU_RSP_171 != _zz__zz_decode_FPU_RSP_184),{_zz__zz_decode_FPU_RSP_185,{_zz__zz_decode_FPU_RSP_200,_zz__zz_decode_FPU_RSP_207}}};
-  assign _zz__zz_decode_FPU_RSP_133 = 32'h00000034;
-  assign _zz__zz_decode_FPU_RSP_135 = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz__zz_decode_FPU_RSP_136 = 32'h00000020;
-  assign _zz__zz_decode_FPU_RSP_139 = (decode_INSTRUCTION & 32'h00001060);
-  assign _zz__zz_decode_FPU_RSP_140 = 32'h00001060;
-  assign _zz__zz_decode_FPU_RSP_141 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_142) == 32'h00002060);
-  assign _zz__zz_decode_FPU_RSP_143 = (_zz__zz_decode_FPU_RSP_144 == _zz__zz_decode_FPU_RSP_145);
-  assign _zz__zz_decode_FPU_RSP_146 = {_zz__zz_decode_FPU_RSP_147,{_zz__zz_decode_FPU_RSP_149,_zz__zz_decode_FPU_RSP_150}};
-  assign _zz__zz_decode_FPU_RSP_156 = _zz_decode_FPU_RSP_3;
-  assign _zz__zz_decode_FPU_RSP_157 = {_zz_decode_FPU_RSP_8,{_zz__zz_decode_FPU_RSP_158,_zz__zz_decode_FPU_RSP_161}};
-  assign _zz__zz_decode_FPU_RSP_171 = {_zz_decode_FPU_RSP_8,{_zz__zz_decode_FPU_RSP_172,_zz__zz_decode_FPU_RSP_175}};
-  assign _zz__zz_decode_FPU_RSP_184 = 5'h0;
-  assign _zz__zz_decode_FPU_RSP_185 = ({_zz__zz_decode_FPU_RSP_186,_zz__zz_decode_FPU_RSP_187} != 7'h0);
-  assign _zz__zz_decode_FPU_RSP_200 = (_zz__zz_decode_FPU_RSP_201 != _zz__zz_decode_FPU_RSP_206);
-  assign _zz__zz_decode_FPU_RSP_207 = {_zz__zz_decode_FPU_RSP_208,{_zz__zz_decode_FPU_RSP_213,_zz__zz_decode_FPU_RSP_218}};
-  assign _zz__zz_decode_FPU_RSP_142 = 32'h00002060;
-  assign _zz__zz_decode_FPU_RSP_144 = (decode_INSTRUCTION & 32'h00400060);
-  assign _zz__zz_decode_FPU_RSP_145 = 32'h00000060;
-  assign _zz__zz_decode_FPU_RSP_147 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_148) == 32'h00000060);
-  assign _zz__zz_decode_FPU_RSP_149 = _zz_decode_FPU_RSP_10;
-  assign _zz__zz_decode_FPU_RSP_150 = (_zz__zz_decode_FPU_RSP_151 == _zz__zz_decode_FPU_RSP_152);
-  assign _zz__zz_decode_FPU_RSP_158 = (_zz__zz_decode_FPU_RSP_159 == _zz__zz_decode_FPU_RSP_160);
-  assign _zz__zz_decode_FPU_RSP_161 = {_zz__zz_decode_FPU_RSP_162,{_zz__zz_decode_FPU_RSP_164,_zz__zz_decode_FPU_RSP_167}};
-  assign _zz__zz_decode_FPU_RSP_172 = (_zz__zz_decode_FPU_RSP_173 == _zz__zz_decode_FPU_RSP_174);
-  assign _zz__zz_decode_FPU_RSP_175 = {_zz__zz_decode_FPU_RSP_176,{_zz__zz_decode_FPU_RSP_178,_zz__zz_decode_FPU_RSP_181}};
-  assign _zz__zz_decode_FPU_RSP_186 = _zz_decode_FPU_RSP_7;
-  assign _zz__zz_decode_FPU_RSP_187 = {_zz__zz_decode_FPU_RSP_188,{_zz__zz_decode_FPU_RSP_190,_zz__zz_decode_FPU_RSP_193}};
-  assign _zz__zz_decode_FPU_RSP_201 = {_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_202,_zz__zz_decode_FPU_RSP_203}};
-  assign _zz__zz_decode_FPU_RSP_206 = 4'b0000;
-  assign _zz__zz_decode_FPU_RSP_208 = ({_zz__zz_decode_FPU_RSP_209,_zz__zz_decode_FPU_RSP_210} != 3'b000);
-  assign _zz__zz_decode_FPU_RSP_213 = (_zz__zz_decode_FPU_RSP_214 != _zz__zz_decode_FPU_RSP_217);
-  assign _zz__zz_decode_FPU_RSP_218 = {_zz__zz_decode_FPU_RSP_219,{_zz__zz_decode_FPU_RSP_222,_zz__zz_decode_FPU_RSP_232}};
-  assign _zz__zz_decode_FPU_RSP_148 = 32'h00000070;
-  assign _zz__zz_decode_FPU_RSP_151 = (decode_INSTRUCTION & 32'h00000078);
-  assign _zz__zz_decode_FPU_RSP_152 = 32'h0;
-  assign _zz__zz_decode_FPU_RSP_159 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_FPU_RSP_160 = 32'h00004020;
-  assign _zz__zz_decode_FPU_RSP_162 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_163) == 32'h00000060);
-  assign _zz__zz_decode_FPU_RSP_164 = (_zz__zz_decode_FPU_RSP_165 == _zz__zz_decode_FPU_RSP_166);
-  assign _zz__zz_decode_FPU_RSP_167 = (_zz__zz_decode_FPU_RSP_168 == _zz__zz_decode_FPU_RSP_169);
-  assign _zz__zz_decode_FPU_RSP_173 = (decode_INSTRUCTION & 32'h00002070);
-  assign _zz__zz_decode_FPU_RSP_174 = 32'h00002010;
-  assign _zz__zz_decode_FPU_RSP_176 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_177) == 32'h00002020);
-  assign _zz__zz_decode_FPU_RSP_178 = (_zz__zz_decode_FPU_RSP_179 == _zz__zz_decode_FPU_RSP_180);
-  assign _zz__zz_decode_FPU_RSP_181 = (_zz__zz_decode_FPU_RSP_182 == _zz__zz_decode_FPU_RSP_183);
-  assign _zz__zz_decode_FPU_RSP_188 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_189) == 32'h00000010);
-  assign _zz__zz_decode_FPU_RSP_190 = (_zz__zz_decode_FPU_RSP_191 == _zz__zz_decode_FPU_RSP_192);
-  assign _zz__zz_decode_FPU_RSP_193 = {_zz__zz_decode_FPU_RSP_194,{_zz__zz_decode_FPU_RSP_196,_zz__zz_decode_FPU_RSP_197}};
-  assign _zz__zz_decode_FPU_RSP_202 = _zz_decode_FPU_RSP_2;
-  assign _zz__zz_decode_FPU_RSP_203 = {_zz_decode_FPU_RSP_5,_zz__zz_decode_FPU_RSP_204};
-  assign _zz__zz_decode_FPU_RSP_209 = _zz_decode_FPU_RSP_3;
-  assign _zz__zz_decode_FPU_RSP_210 = {_zz__zz_decode_FPU_RSP_211,_zz_decode_FPU_RSP_5};
-  assign _zz__zz_decode_FPU_RSP_214 = (_zz__zz_decode_FPU_RSP_215 == _zz__zz_decode_FPU_RSP_216);
-  assign _zz__zz_decode_FPU_RSP_217 = 1'b0;
-  assign _zz__zz_decode_FPU_RSP_219 = (_zz__zz_decode_FPU_RSP_220 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_222 = (_zz__zz_decode_FPU_RSP_223 != _zz__zz_decode_FPU_RSP_231);
-  assign _zz__zz_decode_FPU_RSP_232 = {_zz__zz_decode_FPU_RSP_233,{_zz__zz_decode_FPU_RSP_234,_zz__zz_decode_FPU_RSP_241}};
-  assign _zz__zz_decode_FPU_RSP_163 = 32'h00000060;
-  assign _zz__zz_decode_FPU_RSP_165 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz__zz_decode_FPU_RSP_166 = 32'h00000020;
-  assign _zz__zz_decode_FPU_RSP_168 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_FPU_RSP_169 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_177 = 32'h02002060;
-  assign _zz__zz_decode_FPU_RSP_179 = (decode_INSTRUCTION & 32'h00001070);
-  assign _zz__zz_decode_FPU_RSP_180 = 32'h00000010;
-  assign _zz__zz_decode_FPU_RSP_182 = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz__zz_decode_FPU_RSP_183 = 32'h00000020;
-  assign _zz__zz_decode_FPU_RSP_189 = 32'h00000050;
-  assign _zz__zz_decode_FPU_RSP_191 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_FPU_RSP_192 = 32'h00001030;
-  assign _zz__zz_decode_FPU_RSP_194 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_195) == 32'h00002030);
-  assign _zz__zz_decode_FPU_RSP_196 = _zz_decode_FPU_RSP_6;
-  assign _zz__zz_decode_FPU_RSP_197 = {_zz__zz_decode_FPU_RSP_198,_zz__zz_decode_FPU_RSP_199};
-  assign _zz__zz_decode_FPU_RSP_204 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_205) == 32'h00000020);
-  assign _zz__zz_decode_FPU_RSP_211 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_212) == 32'h0);
-  assign _zz__zz_decode_FPU_RSP_215 = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz__zz_decode_FPU_RSP_216 = 32'h00004010;
-  assign _zz__zz_decode_FPU_RSP_220 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_221) == 32'h00002010);
-  assign _zz__zz_decode_FPU_RSP_223 = {_zz__zz_decode_FPU_RSP_224,{_zz__zz_decode_FPU_RSP_225,_zz__zz_decode_FPU_RSP_227}};
-  assign _zz__zz_decode_FPU_RSP_231 = 6'h0;
-  assign _zz__zz_decode_FPU_RSP_233 = (_zz_decode_FPU_RSP_4 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_234 = (_zz__zz_decode_FPU_RSP_235 != _zz__zz_decode_FPU_RSP_240);
-  assign _zz__zz_decode_FPU_RSP_241 = {_zz__zz_decode_FPU_RSP_242,{_zz__zz_decode_FPU_RSP_245,_zz__zz_decode_FPU_RSP_248}};
-  assign _zz__zz_decode_FPU_RSP_195 = 32'h00002030;
-  assign _zz__zz_decode_FPU_RSP_198 = ((decode_INSTRUCTION & 32'h00002024) == 32'h00000024);
-  assign _zz__zz_decode_FPU_RSP_199 = ((decode_INSTRUCTION & 32'h00000064) == 32'h0);
-  assign _zz__zz_decode_FPU_RSP_205 = 32'h00000070;
-  assign _zz__zz_decode_FPU_RSP_212 = 32'h00000020;
-  assign _zz__zz_decode_FPU_RSP_221 = 32'h00006014;
-  assign _zz__zz_decode_FPU_RSP_224 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz__zz_decode_FPU_RSP_225 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_226) == 32'h00000020);
-  assign _zz__zz_decode_FPU_RSP_227 = {_zz_decode_FPU_RSP_4,{_zz__zz_decode_FPU_RSP_228,{_zz__zz_decode_FPU_RSP_229,_zz__zz_decode_FPU_RSP_230}}};
-  assign _zz__zz_decode_FPU_RSP_235 = {(_zz__zz_decode_FPU_RSP_236 == _zz__zz_decode_FPU_RSP_237),{_zz__zz_decode_FPU_RSP_238,_zz__zz_decode_FPU_RSP_239}};
-  assign _zz__zz_decode_FPU_RSP_240 = 3'b000;
-  assign _zz__zz_decode_FPU_RSP_242 = ({_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_243,_zz__zz_decode_FPU_RSP_244}} != 3'b000);
-  assign _zz__zz_decode_FPU_RSP_245 = ({_zz__zz_decode_FPU_RSP_246,_zz__zz_decode_FPU_RSP_247} != 2'b00);
-  assign _zz__zz_decode_FPU_RSP_248 = (_zz__zz_decode_FPU_RSP_249 != 1'b0);
-  assign _zz__zz_decode_FPU_RSP_226 = 32'h00000038;
-  assign _zz__zz_decode_FPU_RSP_228 = ((decode_INSTRUCTION & 32'h00006024) == 32'h00002020);
-  assign _zz__zz_decode_FPU_RSP_229 = ((decode_INSTRUCTION & 32'h00005024) == 32'h00001020);
-  assign _zz__zz_decode_FPU_RSP_230 = ((decode_INSTRUCTION & 32'h90000034) == 32'h90000010);
-  assign _zz__zz_decode_FPU_RSP_236 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_FPU_RSP_237 = 32'h00000040;
-  assign _zz__zz_decode_FPU_RSP_238 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_FPU_RSP_239 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz__zz_decode_FPU_RSP_243 = _zz_decode_FPU_RSP_1;
-  assign _zz__zz_decode_FPU_RSP_244 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
-  assign _zz__zz_decode_FPU_RSP_246 = _zz_decode_FPU_RSP_2;
-  assign _zz__zz_decode_FPU_RSP_247 = _zz_decode_FPU_RSP_1;
-  assign _zz__zz_decode_FPU_RSP_249 = ((decode_INSTRUCTION & 32'h00005054) == 32'h00001004);
+  assign _zz__zz_decode_FPU_RSP_71 = (|_zz_decode_FPU_RSP_10);
+  assign _zz__zz_decode_FPU_RSP_72 = (|_zz__zz_decode_FPU_RSP_73);
+  assign _zz__zz_decode_FPU_RSP_74 = {_zz__zz_decode_FPU_RSP_75,{_zz__zz_decode_FPU_RSP_76,_zz__zz_decode_FPU_RSP_78}};
+  assign _zz__zz_decode_FPU_RSP_41 = 32'hc0000010;
+  assign _zz__zz_decode_FPU_RSP_43 = (decode_INSTRUCTION & 32'h58000010);
+  assign _zz__zz_decode_FPU_RSP_44 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_46 = (decode_INSTRUCTION & 32'hb0000010);
+  assign _zz__zz_decode_FPU_RSP_47 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_54 = 32'h10000020;
+  assign _zz__zz_decode_FPU_RSP_56 = (decode_INSTRUCTION & 32'h80000020);
+  assign _zz__zz_decode_FPU_RSP_57 = 32'h0;
+  assign _zz__zz_decode_FPU_RSP_59 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_FPU_RSP_60 = 32'h0;
+  assign _zz__zz_decode_FPU_RSP_64 = (decode_INSTRUCTION & 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_65 = 32'h00000040;
+  assign _zz__zz_decode_FPU_RSP_67 = (decode_INSTRUCTION & 32'h0000005c);
+  assign _zz__zz_decode_FPU_RSP_68 = 32'h00000004;
+  assign _zz__zz_decode_FPU_RSP_73 = _zz_decode_FPU_RSP_12;
+  assign _zz__zz_decode_FPU_RSP_75 = (|_zz_decode_FPU_RSP_12);
+  assign _zz__zz_decode_FPU_RSP_76 = (|((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_77) == 32'h02004020));
+  assign _zz__zz_decode_FPU_RSP_78 = {(|(_zz__zz_decode_FPU_RSP_79 == _zz__zz_decode_FPU_RSP_80)),{(|{_zz__zz_decode_FPU_RSP_81,_zz__zz_decode_FPU_RSP_82}),{(|_zz__zz_decode_FPU_RSP_83),{_zz__zz_decode_FPU_RSP_85,{_zz__zz_decode_FPU_RSP_90,_zz__zz_decode_FPU_RSP_92}}}}};
+  assign _zz__zz_decode_FPU_RSP_77 = 32'h02004064;
+  assign _zz__zz_decode_FPU_RSP_79 = (decode_INSTRUCTION & 32'h02004074);
+  assign _zz__zz_decode_FPU_RSP_80 = 32'h02000030;
+  assign _zz__zz_decode_FPU_RSP_81 = _zz_decode_FPU_RSP_11;
+  assign _zz__zz_decode_FPU_RSP_82 = ((decode_INSTRUCTION & 32'h10203034) == 32'h10000030);
+  assign _zz__zz_decode_FPU_RSP_83 = {_zz_decode_FPU_RSP_11,((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_84) == 32'h10000030)};
+  assign _zz__zz_decode_FPU_RSP_85 = (|{(_zz__zz_decode_FPU_RSP_86 == _zz__zz_decode_FPU_RSP_87),(_zz__zz_decode_FPU_RSP_88 == _zz__zz_decode_FPU_RSP_89)});
+  assign _zz__zz_decode_FPU_RSP_90 = (|{_zz_decode_FPU_RSP_7,_zz__zz_decode_FPU_RSP_91});
+  assign _zz__zz_decode_FPU_RSP_92 = {(|_zz__zz_decode_FPU_RSP_93),{(|_zz__zz_decode_FPU_RSP_94),{_zz__zz_decode_FPU_RSP_99,{_zz__zz_decode_FPU_RSP_105,_zz__zz_decode_FPU_RSP_107}}}};
+  assign _zz__zz_decode_FPU_RSP_84 = 32'h10403034;
+  assign _zz__zz_decode_FPU_RSP_86 = (decode_INSTRUCTION & 32'h00001070);
+  assign _zz__zz_decode_FPU_RSP_87 = 32'h00001070;
+  assign _zz__zz_decode_FPU_RSP_88 = (decode_INSTRUCTION & 32'h00002070);
+  assign _zz__zz_decode_FPU_RSP_89 = 32'h00002070;
+  assign _zz__zz_decode_FPU_RSP_91 = ((decode_INSTRUCTION & 32'h00002034) == 32'h00000024);
+  assign _zz__zz_decode_FPU_RSP_93 = ((decode_INSTRUCTION & 32'h00000078) == 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_94 = {(_zz__zz_decode_FPU_RSP_95 == _zz__zz_decode_FPU_RSP_96),(_zz__zz_decode_FPU_RSP_97 == _zz__zz_decode_FPU_RSP_98)};
+  assign _zz__zz_decode_FPU_RSP_99 = (|{_zz__zz_decode_FPU_RSP_100,{_zz__zz_decode_FPU_RSP_101,_zz__zz_decode_FPU_RSP_103}});
+  assign _zz__zz_decode_FPU_RSP_105 = (|_zz__zz_decode_FPU_RSP_106);
+  assign _zz__zz_decode_FPU_RSP_107 = {(|_zz__zz_decode_FPU_RSP_108),{_zz__zz_decode_FPU_RSP_110,{_zz__zz_decode_FPU_RSP_113,_zz__zz_decode_FPU_RSP_118}}};
+  assign _zz__zz_decode_FPU_RSP_95 = (decode_INSTRUCTION & 32'h00007074);
+  assign _zz__zz_decode_FPU_RSP_96 = 32'h00005010;
+  assign _zz__zz_decode_FPU_RSP_97 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz__zz_decode_FPU_RSP_98 = 32'h00005020;
+  assign _zz__zz_decode_FPU_RSP_100 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz__zz_decode_FPU_RSP_101 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_102) == 32'h00001010);
+  assign _zz__zz_decode_FPU_RSP_103 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_104) == 32'h00001010);
+  assign _zz__zz_decode_FPU_RSP_106 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000034);
+  assign _zz__zz_decode_FPU_RSP_108 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_109) == 32'h00001000);
+  assign _zz__zz_decode_FPU_RSP_110 = (|(_zz__zz_decode_FPU_RSP_111 == _zz__zz_decode_FPU_RSP_112));
+  assign _zz__zz_decode_FPU_RSP_113 = (|{_zz__zz_decode_FPU_RSP_114,_zz__zz_decode_FPU_RSP_116});
+  assign _zz__zz_decode_FPU_RSP_118 = {(|_zz__zz_decode_FPU_RSP_119),{_zz__zz_decode_FPU_RSP_121,{_zz__zz_decode_FPU_RSP_126,_zz__zz_decode_FPU_RSP_140}}};
+  assign _zz__zz_decode_FPU_RSP_102 = 32'h00007074;
+  assign _zz__zz_decode_FPU_RSP_104 = 32'h02007054;
+  assign _zz__zz_decode_FPU_RSP_109 = 32'h00001000;
+  assign _zz__zz_decode_FPU_RSP_111 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz__zz_decode_FPU_RSP_112 = 32'h00002000;
+  assign _zz__zz_decode_FPU_RSP_114 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_115) == 32'h00002000);
+  assign _zz__zz_decode_FPU_RSP_116 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_117) == 32'h00001000);
+  assign _zz__zz_decode_FPU_RSP_119 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_120) == 32'h00004004);
+  assign _zz__zz_decode_FPU_RSP_121 = (|{_zz__zz_decode_FPU_RSP_122,{_zz__zz_decode_FPU_RSP_123,_zz__zz_decode_FPU_RSP_124}});
+  assign _zz__zz_decode_FPU_RSP_126 = (|{_zz__zz_decode_FPU_RSP_127,_zz__zz_decode_FPU_RSP_129});
+  assign _zz__zz_decode_FPU_RSP_140 = {(|_zz__zz_decode_FPU_RSP_141),{_zz__zz_decode_FPU_RSP_142,{_zz__zz_decode_FPU_RSP_155,_zz__zz_decode_FPU_RSP_168}}};
+  assign _zz__zz_decode_FPU_RSP_115 = 32'h00002010;
+  assign _zz__zz_decode_FPU_RSP_117 = 32'h00005000;
+  assign _zz__zz_decode_FPU_RSP_120 = 32'h00004054;
+  assign _zz__zz_decode_FPU_RSP_122 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_123 = _zz_decode_FPU_RSP_10;
+  assign _zz__zz_decode_FPU_RSP_124 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_125) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_127 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_128) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_129 = {(_zz__zz_decode_FPU_RSP_130 == _zz__zz_decode_FPU_RSP_131),{_zz__zz_decode_FPU_RSP_132,{_zz__zz_decode_FPU_RSP_134,_zz__zz_decode_FPU_RSP_137}}};
+  assign _zz__zz_decode_FPU_RSP_141 = _zz_decode_FPU_RSP_9;
+  assign _zz__zz_decode_FPU_RSP_142 = (|{_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_143,_zz__zz_decode_FPU_RSP_144}});
+  assign _zz__zz_decode_FPU_RSP_155 = (|{_zz__zz_decode_FPU_RSP_156,_zz__zz_decode_FPU_RSP_157});
+  assign _zz__zz_decode_FPU_RSP_168 = {(|_zz__zz_decode_FPU_RSP_169),{_zz__zz_decode_FPU_RSP_184,{_zz__zz_decode_FPU_RSP_191,_zz__zz_decode_FPU_RSP_197}}};
+  assign _zz__zz_decode_FPU_RSP_125 = 32'h00000064;
+  assign _zz__zz_decode_FPU_RSP_128 = 32'h00000030;
+  assign _zz__zz_decode_FPU_RSP_130 = (decode_INSTRUCTION & 32'h00001060);
+  assign _zz__zz_decode_FPU_RSP_131 = 32'h00001060;
+  assign _zz__zz_decode_FPU_RSP_132 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_133) == 32'h00002060);
+  assign _zz__zz_decode_FPU_RSP_134 = (_zz__zz_decode_FPU_RSP_135 == _zz__zz_decode_FPU_RSP_136);
+  assign _zz__zz_decode_FPU_RSP_137 = {_zz_decode_FPU_RSP_4,_zz__zz_decode_FPU_RSP_138};
+  assign _zz__zz_decode_FPU_RSP_143 = _zz_decode_FPU_RSP_8;
+  assign _zz__zz_decode_FPU_RSP_144 = {_zz__zz_decode_FPU_RSP_145,{_zz__zz_decode_FPU_RSP_147,_zz__zz_decode_FPU_RSP_150}};
+  assign _zz__zz_decode_FPU_RSP_156 = _zz_decode_FPU_RSP_8;
+  assign _zz__zz_decode_FPU_RSP_157 = {_zz__zz_decode_FPU_RSP_158,{_zz__zz_decode_FPU_RSP_160,_zz__zz_decode_FPU_RSP_163}};
+  assign _zz__zz_decode_FPU_RSP_169 = {_zz_decode_FPU_RSP_7,{_zz__zz_decode_FPU_RSP_170,_zz__zz_decode_FPU_RSP_173}};
+  assign _zz__zz_decode_FPU_RSP_184 = (|{_zz__zz_decode_FPU_RSP_185,_zz__zz_decode_FPU_RSP_186});
+  assign _zz__zz_decode_FPU_RSP_191 = (|_zz__zz_decode_FPU_RSP_192);
+  assign _zz__zz_decode_FPU_RSP_197 = {_zz__zz_decode_FPU_RSP_198,{_zz__zz_decode_FPU_RSP_201,_zz__zz_decode_FPU_RSP_205}};
+  assign _zz__zz_decode_FPU_RSP_133 = 32'h00002060;
+  assign _zz__zz_decode_FPU_RSP_135 = (decode_INSTRUCTION & 32'h10000060);
+  assign _zz__zz_decode_FPU_RSP_136 = 32'h00000060;
+  assign _zz__zz_decode_FPU_RSP_138 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_139) == 32'h10000020);
+  assign _zz__zz_decode_FPU_RSP_145 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_146) == 32'h00004020);
+  assign _zz__zz_decode_FPU_RSP_147 = (_zz__zz_decode_FPU_RSP_148 == _zz__zz_decode_FPU_RSP_149);
+  assign _zz__zz_decode_FPU_RSP_150 = {_zz__zz_decode_FPU_RSP_151,_zz__zz_decode_FPU_RSP_153};
+  assign _zz__zz_decode_FPU_RSP_158 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_159) == 32'h00002010);
+  assign _zz__zz_decode_FPU_RSP_160 = (_zz__zz_decode_FPU_RSP_161 == _zz__zz_decode_FPU_RSP_162);
+  assign _zz__zz_decode_FPU_RSP_163 = {_zz__zz_decode_FPU_RSP_164,_zz__zz_decode_FPU_RSP_166};
+  assign _zz__zz_decode_FPU_RSP_170 = (_zz__zz_decode_FPU_RSP_171 == _zz__zz_decode_FPU_RSP_172);
+  assign _zz__zz_decode_FPU_RSP_173 = {_zz__zz_decode_FPU_RSP_174,{_zz__zz_decode_FPU_RSP_176,_zz__zz_decode_FPU_RSP_179}};
+  assign _zz__zz_decode_FPU_RSP_185 = _zz_decode_FPU_RSP_3;
+  assign _zz__zz_decode_FPU_RSP_186 = {_zz_decode_FPU_RSP_2,{_zz__zz_decode_FPU_RSP_187,_zz__zz_decode_FPU_RSP_188}};
+  assign _zz__zz_decode_FPU_RSP_192 = {_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_193,_zz__zz_decode_FPU_RSP_196}};
+  assign _zz__zz_decode_FPU_RSP_198 = (|_zz__zz_decode_FPU_RSP_199);
+  assign _zz__zz_decode_FPU_RSP_201 = (|_zz__zz_decode_FPU_RSP_202);
+  assign _zz__zz_decode_FPU_RSP_205 = {_zz__zz_decode_FPU_RSP_206,{_zz__zz_decode_FPU_RSP_219,_zz__zz_decode_FPU_RSP_221}};
+  assign _zz__zz_decode_FPU_RSP_139 = 32'h10400024;
+  assign _zz__zz_decode_FPU_RSP_146 = 32'h00004020;
+  assign _zz__zz_decode_FPU_RSP_148 = (decode_INSTRUCTION & 32'h00000060);
+  assign _zz__zz_decode_FPU_RSP_149 = 32'h00000060;
+  assign _zz__zz_decode_FPU_RSP_151 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_152) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_153 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_154) == 32'h00000010);
+  assign _zz__zz_decode_FPU_RSP_159 = 32'h00002070;
+  assign _zz__zz_decode_FPU_RSP_161 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_FPU_RSP_162 = 32'h00002020;
+  assign _zz__zz_decode_FPU_RSP_164 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_165) == 32'h00000010);
+  assign _zz__zz_decode_FPU_RSP_166 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_167) == 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_171 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_FPU_RSP_172 = 32'h00000010;
+  assign _zz__zz_decode_FPU_RSP_174 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_175) == 32'h00001030);
+  assign _zz__zz_decode_FPU_RSP_176 = (_zz__zz_decode_FPU_RSP_177 == _zz__zz_decode_FPU_RSP_178);
+  assign _zz__zz_decode_FPU_RSP_179 = {_zz_decode_FPU_RSP_6,{_zz__zz_decode_FPU_RSP_180,_zz__zz_decode_FPU_RSP_182}};
+  assign _zz__zz_decode_FPU_RSP_187 = _zz_decode_FPU_RSP_5;
+  assign _zz__zz_decode_FPU_RSP_188 = (_zz__zz_decode_FPU_RSP_189 == _zz__zz_decode_FPU_RSP_190);
+  assign _zz__zz_decode_FPU_RSP_193 = (_zz__zz_decode_FPU_RSP_194 == _zz__zz_decode_FPU_RSP_195);
+  assign _zz__zz_decode_FPU_RSP_196 = _zz_decode_FPU_RSP_5;
+  assign _zz__zz_decode_FPU_RSP_199 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_200) == 32'h00004010);
+  assign _zz__zz_decode_FPU_RSP_202 = (_zz__zz_decode_FPU_RSP_203 == _zz__zz_decode_FPU_RSP_204);
+  assign _zz__zz_decode_FPU_RSP_206 = (|{_zz__zz_decode_FPU_RSP_207,_zz__zz_decode_FPU_RSP_209});
+  assign _zz__zz_decode_FPU_RSP_219 = (|_zz__zz_decode_FPU_RSP_220);
+  assign _zz__zz_decode_FPU_RSP_221 = {_zz__zz_decode_FPU_RSP_222,{_zz__zz_decode_FPU_RSP_228,_zz__zz_decode_FPU_RSP_233}};
+  assign _zz__zz_decode_FPU_RSP_152 = 32'h02000020;
+  assign _zz__zz_decode_FPU_RSP_154 = 32'h00000070;
+  assign _zz__zz_decode_FPU_RSP_165 = 32'h00001070;
+  assign _zz__zz_decode_FPU_RSP_167 = 32'h02003020;
+  assign _zz__zz_decode_FPU_RSP_175 = 32'h00001030;
+  assign _zz__zz_decode_FPU_RSP_177 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_FPU_RSP_178 = 32'h00002030;
+  assign _zz__zz_decode_FPU_RSP_180 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_181) == 32'h00000024);
+  assign _zz__zz_decode_FPU_RSP_182 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_183) == 32'h0);
+  assign _zz__zz_decode_FPU_RSP_189 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_FPU_RSP_190 = 32'h00000020;
+  assign _zz__zz_decode_FPU_RSP_194 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_FPU_RSP_195 = 32'h0;
+  assign _zz__zz_decode_FPU_RSP_200 = 32'h00004014;
+  assign _zz__zz_decode_FPU_RSP_203 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_FPU_RSP_204 = 32'h00002010;
+  assign _zz__zz_decode_FPU_RSP_207 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_208) == 32'h0);
+  assign _zz__zz_decode_FPU_RSP_209 = {(_zz__zz_decode_FPU_RSP_210 == _zz__zz_decode_FPU_RSP_211),{_zz__zz_decode_FPU_RSP_212,{_zz__zz_decode_FPU_RSP_213,_zz__zz_decode_FPU_RSP_214}}};
+  assign _zz__zz_decode_FPU_RSP_220 = _zz_decode_FPU_RSP_4;
+  assign _zz__zz_decode_FPU_RSP_222 = (|{_zz__zz_decode_FPU_RSP_223,{_zz__zz_decode_FPU_RSP_224,_zz__zz_decode_FPU_RSP_226}});
+  assign _zz__zz_decode_FPU_RSP_228 = (|{_zz__zz_decode_FPU_RSP_229,_zz__zz_decode_FPU_RSP_230});
+  assign _zz__zz_decode_FPU_RSP_233 = {(|_zz__zz_decode_FPU_RSP_234),(|_zz__zz_decode_FPU_RSP_235)};
+  assign _zz__zz_decode_FPU_RSP_181 = 32'h00002024;
+  assign _zz__zz_decode_FPU_RSP_183 = 32'h00000064;
+  assign _zz__zz_decode_FPU_RSP_208 = 32'h00000044;
+  assign _zz__zz_decode_FPU_RSP_210 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz__zz_decode_FPU_RSP_211 = 32'h00000020;
+  assign _zz__zz_decode_FPU_RSP_212 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
+  assign _zz__zz_decode_FPU_RSP_213 = _zz_decode_FPU_RSP_4;
+  assign _zz__zz_decode_FPU_RSP_214 = {(_zz__zz_decode_FPU_RSP_215 == _zz__zz_decode_FPU_RSP_216),{_zz__zz_decode_FPU_RSP_217,_zz__zz_decode_FPU_RSP_218}};
+  assign _zz__zz_decode_FPU_RSP_223 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_FPU_RSP_224 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_225) == 32'h00002010);
+  assign _zz__zz_decode_FPU_RSP_226 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_227) == 32'h40000030);
+  assign _zz__zz_decode_FPU_RSP_229 = _zz_decode_FPU_RSP_3;
+  assign _zz__zz_decode_FPU_RSP_230 = {_zz_decode_FPU_RSP_1,(_zz__zz_decode_FPU_RSP_231 == _zz__zz_decode_FPU_RSP_232)};
+  assign _zz__zz_decode_FPU_RSP_234 = {_zz_decode_FPU_RSP_2,_zz_decode_FPU_RSP_1};
+  assign _zz__zz_decode_FPU_RSP_235 = ((decode_INSTRUCTION & _zz__zz_decode_FPU_RSP_236) == 32'h00001004);
+  assign _zz__zz_decode_FPU_RSP_215 = (decode_INSTRUCTION & 32'h00006024);
+  assign _zz__zz_decode_FPU_RSP_216 = 32'h00002020;
+  assign _zz__zz_decode_FPU_RSP_217 = ((decode_INSTRUCTION & 32'h00005024) == 32'h00001020);
+  assign _zz__zz_decode_FPU_RSP_218 = ((decode_INSTRUCTION & 32'h90000034) == 32'h90000010);
+  assign _zz__zz_decode_FPU_RSP_225 = 32'h00002014;
+  assign _zz__zz_decode_FPU_RSP_227 = 32'h40000034;
+  assign _zz__zz_decode_FPU_RSP_231 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz__zz_decode_FPU_RSP_232 = 32'h00000004;
+  assign _zz__zz_decode_FPU_RSP_236 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -2224,1493 +2196,1476 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   FpuCore FpuPlugin_fpu (
-    .io_port_0_cmd_valid                      (FpuPlugin_port_cmd_valid                             ), //i
-    .io_port_0_cmd_ready                      (FpuPlugin_fpu_io_port_0_cmd_ready                    ), //o
-    .io_port_0_cmd_payload_opcode             (FpuPlugin_port_cmd_payload_opcode                    ), //i
-    .io_port_0_cmd_payload_arg                (FpuPlugin_port_cmd_payload_arg                       ), //i
-    .io_port_0_cmd_payload_rs1                (FpuPlugin_port_cmd_payload_rs1                       ), //i
-    .io_port_0_cmd_payload_rs2                (FpuPlugin_port_cmd_payload_rs2                       ), //i
-    .io_port_0_cmd_payload_rs3                (FpuPlugin_port_cmd_payload_rs3                       ), //i
-    .io_port_0_cmd_payload_rd                 (FpuPlugin_port_cmd_payload_rd                        ), //i
-    .io_port_0_cmd_payload_format             (FpuPlugin_port_cmd_payload_format                    ), //i
-    .io_port_0_cmd_payload_roundMode          (FpuPlugin_port_cmd_payload_roundMode                 ), //i
-    .io_port_0_commit_valid                   (FpuPlugin_port_commit_valid                          ), //i
-    .io_port_0_commit_ready                   (FpuPlugin_fpu_io_port_0_commit_ready                 ), //o
-    .io_port_0_commit_payload_opcode          (FpuPlugin_port_commit_payload_opcode                 ), //i
-    .io_port_0_commit_payload_rd              (FpuPlugin_port_commit_payload_rd                     ), //i
-    .io_port_0_commit_payload_write           (FpuPlugin_port_commit_payload_write                  ), //i
-    .io_port_0_commit_payload_value           (FpuPlugin_port_commit_payload_value                  ), //i
-    .io_port_0_rsp_valid                      (FpuPlugin_fpu_io_port_0_rsp_valid                    ), //o
-    .io_port_0_rsp_ready                      (FpuPlugin_port_rsp_ready                             ), //i
-    .io_port_0_rsp_payload_value              (FpuPlugin_fpu_io_port_0_rsp_payload_value            ), //o
-    .io_port_0_rsp_payload_NV                 (FpuPlugin_fpu_io_port_0_rsp_payload_NV               ), //o
-    .io_port_0_rsp_payload_NX                 (FpuPlugin_fpu_io_port_0_rsp_payload_NX               ), //o
-    .io_port_0_completion_valid               (FpuPlugin_fpu_io_port_0_completion_valid             ), //o
-    .io_port_0_completion_payload_flags_NX    (FpuPlugin_fpu_io_port_0_completion_payload_flags_NX  ), //o
-    .io_port_0_completion_payload_flags_UF    (FpuPlugin_fpu_io_port_0_completion_payload_flags_UF  ), //o
-    .io_port_0_completion_payload_flags_OF    (FpuPlugin_fpu_io_port_0_completion_payload_flags_OF  ), //o
-    .io_port_0_completion_payload_flags_DZ    (FpuPlugin_fpu_io_port_0_completion_payload_flags_DZ  ), //o
-    .io_port_0_completion_payload_flags_NV    (FpuPlugin_fpu_io_port_0_completion_payload_flags_NV  ), //o
-    .io_port_0_completion_payload_written     (FpuPlugin_fpu_io_port_0_completion_payload_written   ), //o
-    .clk                                      (clk                                                  ), //i
-    .reset                                    (reset                                                )  //i
+    .io_port_0_cmd_valid                   (FpuPlugin_port_cmd_valid                           ), //i
+    .io_port_0_cmd_ready                   (FpuPlugin_fpu_io_port_0_cmd_ready                  ), //o
+    .io_port_0_cmd_payload_opcode          (FpuPlugin_port_cmd_payload_opcode[3:0]             ), //i
+    .io_port_0_cmd_payload_arg             (FpuPlugin_port_cmd_payload_arg[1:0]                ), //i
+    .io_port_0_cmd_payload_rs1             (FpuPlugin_port_cmd_payload_rs1[4:0]                ), //i
+    .io_port_0_cmd_payload_rs2             (FpuPlugin_port_cmd_payload_rs2[4:0]                ), //i
+    .io_port_0_cmd_payload_rs3             (FpuPlugin_port_cmd_payload_rs3[4:0]                ), //i
+    .io_port_0_cmd_payload_rd              (FpuPlugin_port_cmd_payload_rd[4:0]                 ), //i
+    .io_port_0_cmd_payload_format          (FpuPlugin_port_cmd_payload_format                  ), //i
+    .io_port_0_cmd_payload_roundMode       (FpuPlugin_port_cmd_payload_roundMode[2:0]          ), //i
+    .io_port_0_commit_valid                (FpuPlugin_port_commit_valid                        ), //i
+    .io_port_0_commit_ready                (FpuPlugin_fpu_io_port_0_commit_ready               ), //o
+    .io_port_0_commit_payload_opcode       (FpuPlugin_port_commit_payload_opcode[3:0]          ), //i
+    .io_port_0_commit_payload_rd           (FpuPlugin_port_commit_payload_rd[4:0]              ), //i
+    .io_port_0_commit_payload_write        (FpuPlugin_port_commit_payload_write                ), //i
+    .io_port_0_commit_payload_value        (FpuPlugin_port_commit_payload_value[31:0]          ), //i
+    .io_port_0_rsp_valid                   (FpuPlugin_fpu_io_port_0_rsp_valid                  ), //o
+    .io_port_0_rsp_ready                   (FpuPlugin_port_rsp_ready                           ), //i
+    .io_port_0_rsp_payload_value           (FpuPlugin_fpu_io_port_0_rsp_payload_value[31:0]    ), //o
+    .io_port_0_rsp_payload_NV              (FpuPlugin_fpu_io_port_0_rsp_payload_NV             ), //o
+    .io_port_0_rsp_payload_NX              (FpuPlugin_fpu_io_port_0_rsp_payload_NX             ), //o
+    .io_port_0_completion_valid            (FpuPlugin_fpu_io_port_0_completion_valid           ), //o
+    .io_port_0_completion_payload_flags_NX (FpuPlugin_fpu_io_port_0_completion_payload_flags_NX), //o
+    .io_port_0_completion_payload_flags_UF (FpuPlugin_fpu_io_port_0_completion_payload_flags_UF), //o
+    .io_port_0_completion_payload_flags_OF (FpuPlugin_fpu_io_port_0_completion_payload_flags_OF), //o
+    .io_port_0_completion_payload_flags_DZ (FpuPlugin_fpu_io_port_0_completion_payload_flags_DZ), //o
+    .io_port_0_completion_payload_flags_NV (FpuPlugin_fpu_io_port_0_completion_payload_flags_NV), //o
+    .io_port_0_completion_payload_written  (FpuPlugin_fpu_io_port_0_completion_payload_written ), //o
+    .clk                                   (clk                                                ), //i
+    .reset                                 (reset                                              )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : memory_FPU_OPCODE_string = "FCVT_X_X";
       default : memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_memory_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_memory_to_writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_memory_to_writeBack_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : execute_FPU_OPCODE_string = "FCVT_X_X";
       default : execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_execute_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_execute_to_memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_execute_to_memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_execute_to_memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_execute_to_memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_execute_to_memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_execute_to_memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_execute_to_memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_execute_to_memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_execute_to_memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_execute_to_memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_execute_to_memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_execute_to_memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_execute_to_memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_execute_to_memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_execute_to_memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_execute_to_memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_execute_to_memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_execute_to_memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_execute_to_memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_execute_to_memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_execute_to_memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_execute_to_memory_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_execute_to_memory_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_execute_to_memory_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_execute_to_memory_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_execute_to_memory_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_execute_to_memory_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_execute_to_memory_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_execute_to_memory_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_execute_to_memory_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_execute_to_memory_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_execute_to_memory_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_execute_to_memory_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_execute_to_memory_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_execute_to_memory_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_execute_to_memory_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_execute_to_memory_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_execute_to_memory_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_execute_to_memory_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_execute_to_memory_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_execute_to_memory_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_execute_to_memory_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_execute_to_memory_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_execute_to_memory_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_to_execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_to_execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_to_execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_to_execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_to_execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_to_execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_to_execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_to_execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_to_execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_to_execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_to_execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_to_execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_to_execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_to_execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_to_execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_to_execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_to_execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_to_execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_to_execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_to_execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_decode_to_execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_to_execute_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_to_execute_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_to_execute_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_to_execute_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_to_execute_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_to_execute_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_to_execute_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_to_execute_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_to_execute_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_to_execute_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_to_execute_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_to_execute_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_to_execute_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_to_execute_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_to_execute_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_to_execute_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_to_execute_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_to_execute_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_to_execute_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_to_execute_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_to_execute_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_to_execute_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_decode_to_execute_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : decode_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : decode_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : decode_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : decode_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : decode_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : decode_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : decode_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : decode_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : decode_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : decode_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_FPU_OPCODE_string = "FCVT_X_X";
       default : decode_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_decode_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : _zz_writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : _zz_writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : _zz_writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : _zz_writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : _zz_writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : _zz_writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : _zz_writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : _zz_writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : _zz_writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_FPU_OPCODE_1)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_FPU_OPCODE_1_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_FPU_OPCODE_1_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_FPU_OPCODE_1_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_FPU_OPCODE_1_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_FPU_OPCODE_1_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_FPU_OPCODE_1_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_FPU_OPCODE_1_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_FPU_OPCODE_1_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_FPU_OPCODE_1_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_FPU_OPCODE_1_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_FPU_OPCODE_1_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_FPU_OPCODE_1_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_FPU_OPCODE_1_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_FPU_OPCODE_1_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_FPU_OPCODE_1_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_FPU_OPCODE_1_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_FPU_OPCODE_1_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_FPU_OPCODE_1_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_FPU_OPCODE_1_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_FPU_OPCODE_1_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_FPU_OPCODE_1_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_FPU_OPCODE_1_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_FPU_OPCODE_1_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_FPU_OPCODE_1_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_FPU_OPCODE_1_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_FPU_OPCODE_1_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_FPU_OPCODE_1_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_FPU_OPCODE_1_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_FPU_OPCODE_1_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_FPU_OPCODE_1_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_FPU_OPCODE_1_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_FPU_OPCODE_1_string = "FCVT_X_X";
       default : _zz_decode_FPU_OPCODE_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_cmd_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : FpuPlugin_port_cmd_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : FpuPlugin_port_cmd_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : FpuPlugin_port_cmd_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : FpuPlugin_port_cmd_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : FpuPlugin_port_cmd_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : FpuPlugin_port_cmd_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : FpuPlugin_port_cmd_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : FpuPlugin_port_cmd_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : FpuPlugin_port_cmd_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : FpuPlugin_port_cmd_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : FpuPlugin_port_cmd_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : FpuPlugin_port_cmd_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : FpuPlugin_port_cmd_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : FpuPlugin_port_cmd_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : FpuPlugin_port_cmd_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : FpuPlugin_port_cmd_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : FpuPlugin_port_cmd_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : FpuPlugin_port_cmd_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : FpuPlugin_port_cmd_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : FpuPlugin_port_cmd_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : FpuPlugin_port_cmd_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : FpuPlugin_port_cmd_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : FpuPlugin_port_cmd_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : FpuPlugin_port_cmd_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : FpuPlugin_port_cmd_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : FpuPlugin_port_cmd_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : FpuPlugin_port_cmd_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : FpuPlugin_port_cmd_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : FpuPlugin_port_cmd_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : FpuPlugin_port_cmd_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : FpuPlugin_port_cmd_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : FpuPlugin_port_cmd_payload_opcode_string = "FCVT_X_X";
       default : FpuPlugin_port_cmd_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_cmd_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : FpuPlugin_port_cmd_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : FpuPlugin_port_cmd_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : FpuPlugin_port_cmd_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : FpuPlugin_port_cmd_payload_format_string = "DOUBLE";
       default : FpuPlugin_port_cmd_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_cmd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
       default : FpuPlugin_port_cmd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(FpuPlugin_port_commit_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : FpuPlugin_port_commit_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : FpuPlugin_port_commit_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : FpuPlugin_port_commit_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : FpuPlugin_port_commit_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : FpuPlugin_port_commit_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : FpuPlugin_port_commit_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : FpuPlugin_port_commit_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : FpuPlugin_port_commit_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : FpuPlugin_port_commit_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : FpuPlugin_port_commit_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : FpuPlugin_port_commit_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : FpuPlugin_port_commit_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : FpuPlugin_port_commit_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : FpuPlugin_port_commit_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : FpuPlugin_port_commit_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : FpuPlugin_port_commit_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : FpuPlugin_port_commit_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : FpuPlugin_port_commit_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : FpuPlugin_port_commit_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : FpuPlugin_port_commit_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : FpuPlugin_port_commit_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : FpuPlugin_port_commit_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : FpuPlugin_port_commit_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : FpuPlugin_port_commit_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : FpuPlugin_port_commit_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : FpuPlugin_port_commit_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : FpuPlugin_port_commit_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : FpuPlugin_port_commit_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : FpuPlugin_port_commit_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : FpuPlugin_port_commit_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : FpuPlugin_port_commit_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : FpuPlugin_port_commit_payload_opcode_string = "FCVT_X_X";
       default : FpuPlugin_port_commit_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_FPU_OPCODE_2)
-      `FpuOpcode_binary_sequential_LOAD : _zz_decode_FPU_OPCODE_2_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_decode_FPU_OPCODE_2_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_decode_FPU_OPCODE_2_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_decode_FPU_OPCODE_2_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_decode_FPU_OPCODE_2_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_decode_FPU_OPCODE_2_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_decode_FPU_OPCODE_2_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_decode_FPU_OPCODE_2_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_decode_FPU_OPCODE_2_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_decode_FPU_OPCODE_2_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_decode_FPU_OPCODE_2_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_decode_FPU_OPCODE_2_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_decode_FPU_OPCODE_2_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_decode_FPU_OPCODE_2_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_decode_FPU_OPCODE_2_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_decode_FPU_OPCODE_2_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_decode_FPU_OPCODE_2_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_decode_FPU_OPCODE_2_string = "STORE   ";
+      FpuOpcode_MUL : _zz_decode_FPU_OPCODE_2_string = "MUL     ";
+      FpuOpcode_ADD : _zz_decode_FPU_OPCODE_2_string = "ADD     ";
+      FpuOpcode_FMA : _zz_decode_FPU_OPCODE_2_string = "FMA     ";
+      FpuOpcode_I2F : _zz_decode_FPU_OPCODE_2_string = "I2F     ";
+      FpuOpcode_F2I : _zz_decode_FPU_OPCODE_2_string = "F2I     ";
+      FpuOpcode_CMP : _zz_decode_FPU_OPCODE_2_string = "CMP     ";
+      FpuOpcode_DIV : _zz_decode_FPU_OPCODE_2_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_decode_FPU_OPCODE_2_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_decode_FPU_OPCODE_2_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_decode_FPU_OPCODE_2_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_decode_FPU_OPCODE_2_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_decode_FPU_OPCODE_2_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_decode_FPU_OPCODE_2_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_decode_FPU_OPCODE_2_string = "FCVT_X_X";
       default : _zz_decode_FPU_OPCODE_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_FpuPlugin_port_cmd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "RMM";
       default : _zz_FpuPlugin_port_cmd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_FpuPlugin_port_cmd_payload_roundMode_1)
-      `FpuRoundMode_opt_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RMM";
+      FpuRoundMode_RNE : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RNE";
+      FpuRoundMode_RTZ : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RTZ";
+      FpuRoundMode_RDN : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RDN";
+      FpuRoundMode_RUP : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RUP";
+      FpuRoundMode_RMM : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "RMM";
       default : _zz_FpuPlugin_port_cmd_payload_roundMode_1_string = "???";
     endcase
   end
   always @(*) begin
     case(writeBack_FpuPlugin_commit_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FpuPlugin_commit_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FpuPlugin_commit_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FpuPlugin_commit_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FpuPlugin_commit_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FpuPlugin_commit_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FpuPlugin_commit_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FpuPlugin_commit_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FpuPlugin_commit_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FpuPlugin_commit_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FpuPlugin_commit_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FpuPlugin_commit_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FpuPlugin_commit_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FpuPlugin_commit_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FpuPlugin_commit_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FpuPlugin_commit_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FpuPlugin_commit_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FpuPlugin_commit_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FpuPlugin_commit_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FpuPlugin_commit_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FpuPlugin_commit_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FpuPlugin_commit_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FpuPlugin_commit_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FpuPlugin_commit_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FpuPlugin_commit_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FpuPlugin_commit_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FpuPlugin_commit_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FpuPlugin_commit_payload_opcode_string = "FCVT_X_X";
       default : writeBack_FpuPlugin_commit_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(writeBack_FpuPlugin_commit_s2mPipe_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
       default : writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(writeBack_FpuPlugin_commit_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : writeBack_FpuPlugin_commit_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : writeBack_FpuPlugin_commit_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : writeBack_FpuPlugin_commit_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : writeBack_FpuPlugin_commit_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : writeBack_FpuPlugin_commit_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : writeBack_FpuPlugin_commit_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : writeBack_FpuPlugin_commit_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : writeBack_FpuPlugin_commit_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : writeBack_FpuPlugin_commit_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : writeBack_FpuPlugin_commit_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : writeBack_FpuPlugin_commit_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : writeBack_FpuPlugin_commit_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : writeBack_FpuPlugin_commit_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : writeBack_FpuPlugin_commit_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : writeBack_FpuPlugin_commit_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : writeBack_FpuPlugin_commit_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : writeBack_FpuPlugin_commit_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : writeBack_FpuPlugin_commit_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : writeBack_FpuPlugin_commit_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : writeBack_FpuPlugin_commit_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : writeBack_FpuPlugin_commit_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : writeBack_FpuPlugin_commit_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : writeBack_FpuPlugin_commit_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : writeBack_FpuPlugin_commit_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : writeBack_FpuPlugin_commit_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : writeBack_FpuPlugin_commit_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : writeBack_FpuPlugin_commit_rData_opcode_string = "FCVT_X_X";
       default : writeBack_FpuPlugin_commit_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "FCVT_X_X";
       default : _zz_writeBack_FpuPlugin_commit_s2mPipe_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : decode_to_execute_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_to_execute_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_to_execute_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_to_execute_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_to_execute_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_to_execute_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_to_execute_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_to_execute_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_to_execute_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_to_execute_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_to_execute_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : decode_to_execute_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : decode_to_execute_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : decode_to_execute_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : decode_to_execute_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : decode_to_execute_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : decode_to_execute_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : decode_to_execute_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : decode_to_execute_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : decode_to_execute_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_to_execute_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_to_execute_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_to_execute_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_to_execute_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_to_execute_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_to_execute_FPU_OPCODE_string = "FCVT_X_X";
       default : decode_to_execute_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : execute_to_memory_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : execute_to_memory_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : execute_to_memory_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : execute_to_memory_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : execute_to_memory_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : execute_to_memory_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : execute_to_memory_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : execute_to_memory_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : execute_to_memory_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : execute_to_memory_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : execute_to_memory_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : execute_to_memory_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : execute_to_memory_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : execute_to_memory_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : execute_to_memory_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : execute_to_memory_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : execute_to_memory_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : execute_to_memory_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : execute_to_memory_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : execute_to_memory_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : execute_to_memory_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : execute_to_memory_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : execute_to_memory_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : execute_to_memory_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : execute_to_memory_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : execute_to_memory_FPU_OPCODE_string = "FCVT_X_X";
       default : execute_to_memory_FPU_OPCODE_string = "????????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_FPU_OPCODE)
-      `FpuOpcode_binary_sequential_LOAD : memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
+      FpuOpcode_LOAD : memory_to_writeBack_FPU_OPCODE_string = "LOAD    ";
+      FpuOpcode_STORE : memory_to_writeBack_FPU_OPCODE_string = "STORE   ";
+      FpuOpcode_MUL : memory_to_writeBack_FPU_OPCODE_string = "MUL     ";
+      FpuOpcode_ADD : memory_to_writeBack_FPU_OPCODE_string = "ADD     ";
+      FpuOpcode_FMA : memory_to_writeBack_FPU_OPCODE_string = "FMA     ";
+      FpuOpcode_I2F : memory_to_writeBack_FPU_OPCODE_string = "I2F     ";
+      FpuOpcode_F2I : memory_to_writeBack_FPU_OPCODE_string = "F2I     ";
+      FpuOpcode_CMP : memory_to_writeBack_FPU_OPCODE_string = "CMP     ";
+      FpuOpcode_DIV : memory_to_writeBack_FPU_OPCODE_string = "DIV     ";
+      FpuOpcode_SQRT : memory_to_writeBack_FPU_OPCODE_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : memory_to_writeBack_FPU_OPCODE_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : memory_to_writeBack_FPU_OPCODE_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : memory_to_writeBack_FPU_OPCODE_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : memory_to_writeBack_FPU_OPCODE_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : memory_to_writeBack_FPU_OPCODE_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : memory_to_writeBack_FPU_OPCODE_string = "FCVT_X_X";
       default : memory_to_writeBack_FPU_OPCODE_string = "????????";
     endcase
   end
@@ -3731,7 +3686,7 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign memory_FPU_COMMIT_LOAD = execute_to_memory_FPU_COMMIT_LOAD;
   assign execute_FPU_COMMIT_LOAD = decode_to_execute_FPU_COMMIT_LOAD;
-  assign decode_FPU_COMMIT_LOAD = (decode_FPU_OPCODE == `FpuOpcode_binary_sequential_LOAD);
+  assign decode_FPU_COMMIT_LOAD = (decode_FPU_OPCODE == FpuOpcode_LOAD);
   assign memory_FPU_FORKED = execute_to_memory_FPU_FORKED;
   assign execute_FPU_FORKED = decode_to_execute_FPU_FORKED;
   assign decode_FPU_FORKED = (decode_FpuPlugin_forked || FpuPlugin_port_cmd_fire_2);
@@ -3775,6 +3730,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_FPU_RSP[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_FPU_RSP[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_FPU_RSP[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_FPU_RSP[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -3849,6 +3806,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3869,14 +3828,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_FPU_RSP[15];
   assign decode_RS1_USE = _zz_decode_FPU_RSP[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -3952,10 +3910,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -3966,7 +3924,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -4004,10 +3962,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000043),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 31'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000043),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -4034,6 +3992,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -4091,7 +4050,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
     if(when_FpuPlugin_l238) begin
@@ -4110,7 +4069,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -4138,27 +4097,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
     if(when_FpuPlugin_l214) begin
@@ -4195,7 +4157,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -4213,7 +4175,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -4255,10 +4217,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -4269,29 +4231,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -4305,21 +4269,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4360,9 +4324,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -4385,7 +4349,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -4447,24 +4411,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -4489,7 +4459,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -4535,7 +4505,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -4583,7 +4553,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4664,12 +4634,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -4687,7 +4657,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -4706,9 +4676,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -4718,12 +4690,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -4742,7 +4714,7 @@ module VexRiscv (
 
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -4752,7 +4724,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -4771,7 +4743,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -4784,8 +4756,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -4798,7 +4770,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -4850,7 +4822,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -4863,7 +4835,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -4891,11 +4863,10 @@ module VexRiscv (
   assign _zz_decode_FPU_RSP_7 = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000028);
   assign _zz_decode_FPU_RSP_8 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_FPU_RSP_9 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_decode_FPU_RSP_10 = ((decode_INSTRUCTION & 32'h0000005c) == 32'h00000004);
-  assign _zz_decode_FPU_RSP_11 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000008);
-  assign _zz_decode_FPU_RSP_12 = ((decode_INSTRUCTION & 32'h10003070) == 32'h00000070);
-  assign _zz_decode_FPU_RSP_13 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_FPU_RSP = {({_zz_decode_FPU_RSP_8,(_zz__zz_decode_FPU_RSP == _zz__zz_decode_FPU_RSP_1)} != 2'b00),{({_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_2,_zz__zz_decode_FPU_RSP_4}} != 4'b0000),{1'b0,{(_zz__zz_decode_FPU_RSP_9 != _zz__zz_decode_FPU_RSP_16),{_zz__zz_decode_FPU_RSP_17,{_zz__zz_decode_FPU_RSP_22,_zz__zz_decode_FPU_RSP_35}}}}}};
+  assign _zz_decode_FPU_RSP_10 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000008);
+  assign _zz_decode_FPU_RSP_11 = ((decode_INSTRUCTION & 32'h10003070) == 32'h00000070);
+  assign _zz_decode_FPU_RSP_12 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_FPU_RSP = {(|{_zz_decode_FPU_RSP_8,(_zz__zz_decode_FPU_RSP == _zz__zz_decode_FPU_RSP_1)}),{(|{_zz_decode_FPU_RSP_3,{_zz__zz_decode_FPU_RSP_2,_zz__zz_decode_FPU_RSP_4}}),{1'b0,{(|_zz__zz_decode_FPU_RSP_9),{_zz__zz_decode_FPU_RSP_16,{_zz__zz_decode_FPU_RSP_21,_zz__zz_decode_FPU_RSP_34}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_FPU_RSP[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_FPU_RSP[7 : 6];
@@ -4945,10 +4916,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -4959,10 +4930,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -4973,13 +4944,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1_1 = _zz_execute_SRC1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1_1 = {29'd0, _zz__zz_execute_SRC1_1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1_1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -5038,13 +5009,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -5097,7 +5068,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -5214,9 +5185,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -5234,13 +5205,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -5313,10 +5284,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -5328,7 +5299,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -5363,11 +5334,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -5418,14 +5389,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -5434,9 +5405,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -5480,28 +5451,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -5509,7 +5480,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -5547,14 +5518,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5664,18 +5635,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -5683,20 +5654,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -5709,20 +5680,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5731,9 +5702,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -5744,8 +5715,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -5838,12 +5809,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -5877,7 +5851,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -5888,16 +5862,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign FpuPlugin_port_cmd_ready = FpuPlugin_fpu_io_port_0_cmd_ready;
   assign FpuPlugin_port_commit_ready = FpuPlugin_fpu_io_port_0_commit_ready;
   assign FpuPlugin_port_rsp_valid = FpuPlugin_fpu_io_port_0_rsp_valid;
@@ -5922,7 +5896,7 @@ module VexRiscv (
   assign FpuPlugin_csrActive = (execute_arbitration_isValid && execute_IS_CSR);
   assign when_FpuPlugin_l214 = (FpuPlugin_csrActive && FpuPlugin_hasPending);
   assign FpuPlugin_sd = (FpuPlugin_fs == 2'b11);
-  assign when_FpuPlugin_l219 = ((writeBack_arbitration_isFiring && writeBack_FPU_ENABLE) && (writeBack_FPU_OPCODE != `FpuOpcode_binary_sequential_STORE));
+  assign when_FpuPlugin_l219 = ((writeBack_arbitration_isFiring && writeBack_FPU_ENABLE) && (writeBack_FPU_OPCODE != FpuOpcode_STORE));
   assign FpuPlugin_port_cmd_fire_1 = (FpuPlugin_port_cmd_valid && FpuPlugin_port_cmd_ready);
   assign when_FpuPlugin_l234 = (! decode_arbitration_isStuck);
   assign decode_FpuPlugin_hazard = (FpuPlugin_pendings[5] || FpuPlugin_csrActive);
@@ -5937,7 +5911,7 @@ module VexRiscv (
   assign FpuPlugin_port_cmd_payload_rs2 = decode_INSTRUCTION[24 : 20];
   assign FpuPlugin_port_cmd_payload_rs3 = decode_INSTRUCTION[31 : 27];
   assign FpuPlugin_port_cmd_payload_rd = decode_INSTRUCTION[11 : 7];
-  assign FpuPlugin_port_cmd_payload_format = `FpuFormat_binary_sequential_FLOAT;
+  assign FpuPlugin_port_cmd_payload_format = FpuFormat_FLOAT;
   assign _zz_FpuPlugin_port_cmd_payload_roundMode_1 = decode_FpuPlugin_roundMode;
   assign _zz_FpuPlugin_port_cmd_payload_roundMode = _zz_FpuPlugin_port_cmd_payload_roundMode_1;
   assign FpuPlugin_port_cmd_payload_roundMode = _zz_FpuPlugin_port_cmd_payload_roundMode;
@@ -6015,91 +5989,94 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
   assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_46 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_47 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
   assign _zz_decode_to_execute_FPU_OPCODE_1 = decode_FPU_OPCODE;
   assign _zz_execute_to_memory_FPU_OPCODE_1 = execute_FPU_OPCODE;
   assign _zz_memory_to_writeBack_FPU_OPCODE_1 = memory_FPU_OPCODE;
   assign _zz_decode_FPU_OPCODE = _zz_decode_FPU_OPCODE_1;
-  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
-  assign _zz_execute_FPU_OPCODE = decode_to_execute_FPU_OPCODE;
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
-  assign _zz_memory_FPU_OPCODE = execute_to_memory_FPU_OPCODE;
-  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_FPU_OPCODE = memory_to_writeBack_FPU_OPCODE;
   assign when_Pipeline_l124_57 = (! execute_arbitration_isStuck);
+  assign _zz_execute_FPU_OPCODE = decode_to_execute_FPU_OPCODE;
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign _zz_memory_FPU_OPCODE = execute_to_memory_FPU_OPCODE;
   assign when_Pipeline_l124_59 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_FPU_OPCODE = memory_to_writeBack_FPU_OPCODE;
   assign when_Pipeline_l124_60 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_61 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_64 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_65 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_66 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_67 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_67 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_68 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_69 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_70 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_71 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_72 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_73 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_74 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_75 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_71 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_72 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_73 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_74 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_75 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_76 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_77 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_77 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_78 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_79 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_80 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_80 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_81 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_82 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_82 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_83 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_84 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_85 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_86 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -6126,34 +6103,34 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -6191,12 +6168,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[14 : 13] = FpuPlugin_fs;
       _zz_CsrPlugin_csrMapping_readDataInit_7[31 : 31] = FpuPlugin_sd;
     end
@@ -6360,8 +6338,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_29 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26) | (_zz_CsrPlugin_csrMapping_readDataInit_27 | _zz_CsrPlugin_csrMapping_readDataInit_28))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -6417,11 +6395,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -6433,6 +6409,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -6478,16 +6456,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -6505,13 +6483,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6520,7 +6498,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6529,7 +6507,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6538,7 +6516,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -6561,51 +6539,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -6614,7 +6596,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -6625,8 +6607,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -6636,7 +6618,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -6647,13 +6629,13 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
       FpuPlugin_pendings <= (_zz_FpuPlugin_pendings - _zz_FpuPlugin_pendings_6);
@@ -6699,16 +6681,16 @@ module VexRiscv (
       if(writeBack_FpuPlugin_commit_s2mPipe_ready) begin
         writeBack_FpuPlugin_commit_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_65) begin
+      if(when_Pipeline_l124_68) begin
         decode_to_execute_FPU_FORKED <= _zz_decode_to_execute_FPU_FORKED;
       end
-      if(when_Pipeline_l124_66) begin
+      if(when_Pipeline_l124_69) begin
         execute_to_memory_FPU_FORKED <= _zz_execute_to_memory_FPU_FORKED;
       end
-      if(when_Pipeline_l124_67) begin
+      if(when_Pipeline_l124_70) begin
         memory_to_writeBack_FPU_FORKED <= _zz_memory_to_writeBack_FPU_FORKED;
       end
-      if(when_Pipeline_l124_81) begin
+      if(when_Pipeline_l124_84) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -6737,9 +6719,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
           FpuPlugin_fs <= CsrPlugin_csrMapping_writeDataSignal[14 : 13];
         end
       end
@@ -6748,6 +6736,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -6833,10 +6841,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -6849,21 +6853,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -6987,249 +6991,258 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_FPU_ENABLE <= decode_FPU_ENABLE;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      execute_to_memory_FPU_ENABLE <= execute_FPU_ENABLE;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      memory_to_writeBack_FPU_ENABLE <= memory_FPU_ENABLE;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_FPU_COMMIT <= decode_FPU_COMMIT;
+      decode_to_execute_FPU_ENABLE <= decode_FPU_ENABLE;
     end
     if(when_Pipeline_l124_49) begin
-      execute_to_memory_FPU_COMMIT <= execute_FPU_COMMIT;
+      execute_to_memory_FPU_ENABLE <= execute_FPU_ENABLE;
     end
     if(when_Pipeline_l124_50) begin
-      memory_to_writeBack_FPU_COMMIT <= memory_FPU_COMMIT;
+      memory_to_writeBack_FPU_ENABLE <= memory_FPU_ENABLE;
     end
     if(when_Pipeline_l124_51) begin
-      decode_to_execute_FPU_RSP <= decode_FPU_RSP;
+      decode_to_execute_FPU_COMMIT <= decode_FPU_COMMIT;
     end
     if(when_Pipeline_l124_52) begin
-      execute_to_memory_FPU_RSP <= execute_FPU_RSP;
+      execute_to_memory_FPU_COMMIT <= execute_FPU_COMMIT;
     end
     if(when_Pipeline_l124_53) begin
-      memory_to_writeBack_FPU_RSP <= memory_FPU_RSP;
+      memory_to_writeBack_FPU_COMMIT <= memory_FPU_COMMIT;
     end
     if(when_Pipeline_l124_54) begin
-      decode_to_execute_FPU_OPCODE <= _zz_decode_to_execute_FPU_OPCODE;
+      decode_to_execute_FPU_RSP <= decode_FPU_RSP;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_FPU_OPCODE <= _zz_execute_to_memory_FPU_OPCODE;
+      execute_to_memory_FPU_RSP <= execute_FPU_RSP;
     end
     if(when_Pipeline_l124_56) begin
-      memory_to_writeBack_FPU_OPCODE <= _zz_memory_to_writeBack_FPU_OPCODE;
+      memory_to_writeBack_FPU_RSP <= memory_FPU_RSP;
     end
     if(when_Pipeline_l124_57) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_FPU_OPCODE <= _zz_decode_to_execute_FPU_OPCODE;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_RS1 <= _zz_execute_SRC1;
+      execute_to_memory_FPU_OPCODE <= _zz_execute_to_memory_FPU_OPCODE;
     end
     if(when_Pipeline_l124_59) begin
-      memory_to_writeBack_RS1 <= memory_RS1;
+      memory_to_writeBack_FPU_OPCODE <= _zz_memory_to_writeBack_FPU_OPCODE;
     end
     if(when_Pipeline_l124_60) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_61) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      execute_to_memory_RS1 <= _zz_execute_SRC1;
     end
     if(when_Pipeline_l124_62) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      memory_to_writeBack_RS1 <= memory_RS1;
     end
     if(when_Pipeline_l124_63) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_64) begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if(when_Pipeline_l124_65) begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if(when_Pipeline_l124_66) begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if(when_Pipeline_l124_67) begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if(when_Pipeline_l124_68) begin
+    if(when_Pipeline_l124_71) begin
       decode_to_execute_FPU_COMMIT_LOAD <= decode_FPU_COMMIT_LOAD;
     end
-    if(when_Pipeline_l124_69) begin
+    if(when_Pipeline_l124_72) begin
       execute_to_memory_FPU_COMMIT_LOAD <= execute_FPU_COMMIT_LOAD;
     end
-    if(when_Pipeline_l124_70) begin
+    if(when_Pipeline_l124_73) begin
       memory_to_writeBack_FPU_COMMIT_LOAD <= memory_FPU_COMMIT_LOAD;
     end
-    if(when_Pipeline_l124_71) begin
+    if(when_Pipeline_l124_74) begin
       execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
-    if(when_Pipeline_l124_72) begin
+    if(when_Pipeline_l124_75) begin
       memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
-    if(when_Pipeline_l124_73) begin
+    if(when_Pipeline_l124_76) begin
       execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
-    if(when_Pipeline_l124_74) begin
+    if(when_Pipeline_l124_77) begin
       memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
-    if(when_Pipeline_l124_75) begin
+    if(when_Pipeline_l124_78) begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if(when_Pipeline_l124_76) begin
+    if(when_Pipeline_l124_79) begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if(when_Pipeline_l124_77) begin
+    if(when_Pipeline_l124_80) begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
     end
-    if(when_Pipeline_l124_78) begin
+    if(when_Pipeline_l124_81) begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
-    if(when_Pipeline_l124_79) begin
+    if(when_Pipeline_l124_82) begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
-    if(when_Pipeline_l124_80) begin
+    if(when_Pipeline_l124_83) begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if(when_Pipeline_l124_82) begin
+    if(when_Pipeline_l124_85) begin
       memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
     end
-    if(when_Pipeline_l124_83) begin
+    if(when_Pipeline_l124_86) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1264_24) begin
+    if(when_CsrPlugin_l1277_24) begin
       execute_CsrPlugin_csr_3 <= (decode_INSTRUCTION[31 : 20] == 12'h003);
     end
-    if(when_CsrPlugin_l1264_25) begin
+    if(when_CsrPlugin_l1277_25) begin
       execute_CsrPlugin_csr_2 <= (decode_INSTRUCTION[31 : 20] == 12'h002);
     end
-    if(when_CsrPlugin_l1264_26) begin
+    if(when_CsrPlugin_l1277_26) begin
       execute_CsrPlugin_csr_1 <= (decode_INSTRUCTION[31 : 20] == 12'h001);
     end
-    if(when_CsrPlugin_l1264_27) begin
+    if(when_CsrPlugin_l1277_27) begin
       execute_CsrPlugin_csr_256 <= (decode_INSTRUCTION[31 : 20] == 12'h100);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -7264,26 +7277,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -7294,17 +7287,17 @@ endmodule
 module FpuCore (
   input               io_port_0_cmd_valid,
   output              io_port_0_cmd_ready,
-  input      `FpuOpcode_binary_sequential_type io_port_0_cmd_payload_opcode,
+  input      [3:0]    io_port_0_cmd_payload_opcode,
   input      [1:0]    io_port_0_cmd_payload_arg,
   input      [4:0]    io_port_0_cmd_payload_rs1,
   input      [4:0]    io_port_0_cmd_payload_rs2,
   input      [4:0]    io_port_0_cmd_payload_rs3,
   input      [4:0]    io_port_0_cmd_payload_rd,
-  input      `FpuFormat_binary_sequential_type io_port_0_cmd_payload_format,
-  input      `FpuRoundMode_opt_type io_port_0_cmd_payload_roundMode,
+  input      [0:0]    io_port_0_cmd_payload_format,
+  input      [2:0]    io_port_0_cmd_payload_roundMode,
   input               io_port_0_commit_valid,
   output              io_port_0_commit_ready,
-  input      `FpuOpcode_binary_sequential_type io_port_0_commit_payload_opcode,
+  input      [3:0]    io_port_0_commit_payload_opcode,
   input      [4:0]    io_port_0_commit_payload_rd,
   input               io_port_0_commit_payload_write,
   input      [31:0]   io_port_0_commit_payload_value,
@@ -7323,6 +7316,30 @@ module FpuCore (
   input               clk,
   input               reset
 );
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+  localparam FpuFormat_FLOAT = 1'd0;
+  localparam FpuFormat_DOUBLE = 1'd1;
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire                streamFork_1_io_outputs_1_ready;
   wire                div_divider_io_input_valid;
   wire       [23:0]   div_divider_io_input_payload_a;
@@ -7344,25 +7361,25 @@ module FpuCore (
   wire       [0:0]    _zz_rf_scoreboards_0_writes_port1;
   wire                streamFork_1_io_input_ready;
   wire                streamFork_1_io_outputs_0_valid;
-  wire       `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_0_payload_opcode;
+  wire       [3:0]    streamFork_1_io_outputs_0_payload_opcode;
   wire       [4:0]    streamFork_1_io_outputs_0_payload_rd;
   wire                streamFork_1_io_outputs_0_payload_write;
   wire       [31:0]   streamFork_1_io_outputs_0_payload_value;
   wire                streamFork_1_io_outputs_1_valid;
-  wire       `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_1_payload_opcode;
+  wire       [3:0]    streamFork_1_io_outputs_1_payload_opcode;
   wire       [4:0]    streamFork_1_io_outputs_1_payload_rd;
   wire                streamFork_1_io_outputs_1_payload_write;
   wire       [31:0]   streamFork_1_io_outputs_1_payload_value;
   wire                cmdArbiter_arbiter_io_inputs_0_ready;
   wire                cmdArbiter_arbiter_io_output_valid;
-  wire       `FpuOpcode_binary_sequential_type cmdArbiter_arbiter_io_output_payload_opcode;
+  wire       [3:0]    cmdArbiter_arbiter_io_output_payload_opcode;
   wire       [1:0]    cmdArbiter_arbiter_io_output_payload_arg;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rs1;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rs2;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rs3;
   wire       [4:0]    cmdArbiter_arbiter_io_output_payload_rd;
-  wire       `FpuFormat_binary_sequential_type cmdArbiter_arbiter_io_output_payload_format;
-  wire       `FpuRoundMode_opt_type cmdArbiter_arbiter_io_output_payload_roundMode;
+  wire       [0:0]    cmdArbiter_arbiter_io_output_payload_format;
+  wire       [2:0]    cmdArbiter_arbiter_io_output_payload_roundMode;
   wire       [0:0]    cmdArbiter_arbiter_io_chosenOH;
   wire                div_divider_io_input_ready;
   wire                div_divider_io_output_valid;
@@ -7385,7 +7402,7 @@ module FpuCore (
   wire                streamArbiter_2_io_output_payload_value_sign;
   wire                streamArbiter_2_io_output_payload_value_special;
   wire                streamArbiter_2_io_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type streamArbiter_2_io_output_payload_roundMode;
+  wire       [2:0]    streamArbiter_2_io_output_payload_roundMode;
   wire                streamArbiter_2_io_output_payload_NV;
   wire                streamArbiter_2_io_output_payload_DZ;
   wire       [2:0]    streamArbiter_2_io_chosen;
@@ -7423,7 +7440,7 @@ module FpuCore (
   wire       [3:0]    _zz_commitLogic_0_short_counter_3;
   wire       [0:0]    _zz_commitLogic_0_short_counter_4;
   wire       [0:0]    _zz_rf_scoreboards_0_writes_port;
-  wire       `FpuOpcode_binary_sequential_type _zz_decode_shortPipHit;
+  wire       [3:0]    _zz_decode_shortPipHit;
   wire                _zz_decode_shortPipHit_1;
   wire       [0:0]    _zz_decode_shortPipHit_2;
   wire       [0:0]    _zz_decode_shortPipHit_3;
@@ -7578,28 +7595,28 @@ module FpuCore (
   reg                 rf_scoreboards_0_hitWrite_payload_data;
   wire                commitFork_load_0_valid;
   reg                 commitFork_load_0_ready;
-  wire       `FpuOpcode_binary_sequential_type commitFork_load_0_payload_opcode;
+  wire       [3:0]    commitFork_load_0_payload_opcode;
   wire       [4:0]    commitFork_load_0_payload_rd;
   wire                commitFork_load_0_payload_write;
   wire       [31:0]   commitFork_load_0_payload_value;
   wire                commitFork_commit_0_valid;
   wire                commitFork_commit_0_ready;
-  wire       `FpuOpcode_binary_sequential_type commitFork_commit_0_payload_opcode;
+  wire       [3:0]    commitFork_commit_0_payload_opcode;
   wire       [4:0]    commitFork_commit_0_payload_rd;
   wire                commitFork_commit_0_payload_write;
   wire       [31:0]   commitFork_commit_0_payload_value;
   wire                streamFork_1_io_outputs_1_s2mPipe_valid;
   wire                streamFork_1_io_outputs_1_s2mPipe_ready;
-  wire       `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_1_s2mPipe_payload_opcode;
+  wire       [3:0]    streamFork_1_io_outputs_1_s2mPipe_payload_opcode;
   wire       [4:0]    streamFork_1_io_outputs_1_s2mPipe_payload_rd;
   wire                streamFork_1_io_outputs_1_s2mPipe_payload_write;
   wire       [31:0]   streamFork_1_io_outputs_1_s2mPipe_payload_value;
   reg                 streamFork_1_io_outputs_1_rValid;
-  reg        `FpuOpcode_binary_sequential_type streamFork_1_io_outputs_1_rData_opcode;
+  reg        [3:0]    streamFork_1_io_outputs_1_rData_opcode;
   reg        [4:0]    streamFork_1_io_outputs_1_rData_rd;
   reg                 streamFork_1_io_outputs_1_rData_write;
   reg        [31:0]   streamFork_1_io_outputs_1_rData_value;
-  wire       `FpuOpcode_binary_sequential_type _zz_payload_opcode;
+  wire       [3:0]    _zz_payload_opcode;
   reg        [3:0]    commitLogic_0_pending_counter;
   wire                commitLogic_0_pending_full;
   wire                commitLogic_0_pending_notEmpty;
@@ -7631,9 +7648,9 @@ module FpuCore (
   reg                 commitLogic_0_short_inc;
   reg                 commitLogic_0_short_dec;
   wire                _zz_commitFork_commit_0_ready;
-  wire       `FpuOpcode_binary_sequential_type _zz_commitLogic_0_input_payload_opcode;
+  wire       [3:0]    _zz_commitLogic_0_input_payload_opcode;
   wire                commitLogic_0_input_valid;
-  wire       `FpuOpcode_binary_sequential_type commitLogic_0_input_payload_opcode;
+  wire       [3:0]    commitLogic_0_input_payload_opcode;
   wire       [4:0]    commitLogic_0_input_payload_rd;
   wire                commitLogic_0_input_payload_write;
   wire       [31:0]   commitLogic_0_input_payload_value;
@@ -7642,28 +7659,28 @@ module FpuCore (
   wire                when_FpuCore_l210;
   wire                when_FpuCore_l211;
   wire                when_FpuCore_l212;
-  wire                io_port_0_cmd_input_valid;
-  wire                io_port_0_cmd_input_ready;
-  wire       `FpuOpcode_binary_sequential_type io_port_0_cmd_input_payload_opcode;
-  wire       [1:0]    io_port_0_cmd_input_payload_arg;
-  wire       [4:0]    io_port_0_cmd_input_payload_rs1;
-  wire       [4:0]    io_port_0_cmd_input_payload_rs2;
-  wire       [4:0]    io_port_0_cmd_input_payload_rs3;
-  wire       [4:0]    io_port_0_cmd_input_payload_rd;
-  wire       `FpuFormat_binary_sequential_type io_port_0_cmd_input_payload_format;
-  wire       `FpuRoundMode_opt_type io_port_0_cmd_input_payload_roundMode;
+  wire                scheduler_0_input_valid;
+  wire                scheduler_0_input_ready;
+  wire       [3:0]    scheduler_0_input_payload_opcode;
+  wire       [1:0]    scheduler_0_input_payload_arg;
+  wire       [4:0]    scheduler_0_input_payload_rs1;
+  wire       [4:0]    scheduler_0_input_payload_rs2;
+  wire       [4:0]    scheduler_0_input_payload_rs3;
+  wire       [4:0]    scheduler_0_input_payload_rd;
+  wire       [0:0]    scheduler_0_input_payload_format;
+  wire       [2:0]    scheduler_0_input_payload_roundMode;
   reg                 io_port_0_cmd_rValid;
-  reg        `FpuOpcode_binary_sequential_type io_port_0_cmd_rData_opcode;
+  reg        [3:0]    io_port_0_cmd_rData_opcode;
   reg        [1:0]    io_port_0_cmd_rData_arg;
   reg        [4:0]    io_port_0_cmd_rData_rs1;
   reg        [4:0]    io_port_0_cmd_rData_rs2;
   reg        [4:0]    io_port_0_cmd_rData_rs3;
   reg        [4:0]    io_port_0_cmd_rData_rd;
-  reg        `FpuFormat_binary_sequential_type io_port_0_cmd_rData_format;
-  reg        `FpuRoundMode_opt_type io_port_0_cmd_rData_roundMode;
-  wire       `FpuOpcode_binary_sequential_type _zz_io_port_0_cmd_input_payload_opcode;
-  wire       `FpuFormat_binary_sequential_type _zz_io_port_0_cmd_input_payload_format;
-  wire       `FpuRoundMode_opt_type _zz_io_port_0_cmd_input_payload_roundMode;
+  reg        [0:0]    io_port_0_cmd_rData_format;
+  reg        [2:0]    io_port_0_cmd_rData_roundMode;
+  wire       [3:0]    _zz_scheduler_0_input_payload_opcode;
+  wire       [0:0]    _zz_scheduler_0_input_payload_format;
+  wire       [2:0]    _zz_scheduler_0_input_payload_roundMode;
   reg                 scheduler_0_useRs1;
   reg                 scheduler_0_useRs2;
   reg                 scheduler_0_useRs3;
@@ -7685,63 +7702,63 @@ module FpuCore (
   wire                scheduler_0_hits_2;
   wire                scheduler_0_hits_3;
   wire                scheduler_0_hazard;
-  wire                _zz_io_port_0_cmd_input_ready;
+  wire                _zz_scheduler_0_input_ready;
   wire                scheduler_0_output_valid;
   wire                scheduler_0_output_ready;
-  wire       `FpuOpcode_binary_sequential_type scheduler_0_output_payload_opcode;
+  wire       [3:0]    scheduler_0_output_payload_opcode;
   wire       [1:0]    scheduler_0_output_payload_arg;
   reg        [4:0]    scheduler_0_output_payload_rs1;
   wire       [4:0]    scheduler_0_output_payload_rs2;
   wire       [4:0]    scheduler_0_output_payload_rs3;
   wire       [4:0]    scheduler_0_output_payload_rd;
-  wire       `FpuFormat_binary_sequential_type scheduler_0_output_payload_format;
-  wire       `FpuRoundMode_opt_type scheduler_0_output_payload_roundMode;
+  wire       [0:0]    scheduler_0_output_payload_format;
+  wire       [2:0]    scheduler_0_output_payload_roundMode;
   wire                when_FpuCore_l258;
   wire                when_FpuCore_l261;
   wire                scheduler_0_output_fire;
   wire                when_FpuCore_l265;
-  wire       `FpuOpcode_binary_sequential_type _zz_io_inputs_0_payload_opcode;
-  wire       `FpuFormat_binary_sequential_type _zz_io_inputs_0_payload_format;
-  wire       `FpuRoundMode_opt_type _zz_io_inputs_0_payload_roundMode;
+  wire       [3:0]    _zz_io_inputs_0_payload_opcode;
+  wire       [0:0]    _zz_io_inputs_0_payload_format;
+  wire       [2:0]    _zz_io_inputs_0_payload_roundMode;
   wire                cmdArbiter_output_valid;
   wire                cmdArbiter_output_ready;
-  wire       `FpuOpcode_binary_sequential_type cmdArbiter_output_payload_opcode;
+  wire       [3:0]    cmdArbiter_output_payload_opcode;
   wire       [4:0]    cmdArbiter_output_payload_rs1;
   wire       [4:0]    cmdArbiter_output_payload_rs2;
   wire       [4:0]    cmdArbiter_output_payload_rs3;
   wire       [4:0]    cmdArbiter_output_payload_rd;
   wire       [1:0]    cmdArbiter_output_payload_arg;
-  wire       `FpuRoundMode_opt_type cmdArbiter_output_payload_roundMode;
+  wire       [2:0]    cmdArbiter_output_payload_roundMode;
   wire                read_s0_valid;
   reg                 read_s0_ready;
-  wire       `FpuOpcode_binary_sequential_type read_s0_payload_opcode;
+  wire       [3:0]    read_s0_payload_opcode;
   wire       [4:0]    read_s0_payload_rs1;
   wire       [4:0]    read_s0_payload_rs2;
   wire       [4:0]    read_s0_payload_rs3;
   wire       [4:0]    read_s0_payload_rd;
   wire       [1:0]    read_s0_payload_arg;
-  wire       `FpuRoundMode_opt_type read_s0_payload_roundMode;
-  wire                read_s0_s1_valid;
-  wire                read_s0_s1_ready;
-  wire       `FpuOpcode_binary_sequential_type read_s0_s1_payload_opcode;
-  wire       [4:0]    read_s0_s1_payload_rs1;
-  wire       [4:0]    read_s0_s1_payload_rs2;
-  wire       [4:0]    read_s0_s1_payload_rs3;
-  wire       [4:0]    read_s0_s1_payload_rd;
-  wire       [1:0]    read_s0_s1_payload_arg;
-  wire       `FpuRoundMode_opt_type read_s0_s1_payload_roundMode;
+  wire       [2:0]    read_s0_payload_roundMode;
+  wire                read_s1_valid;
+  wire                read_s1_ready;
+  wire       [3:0]    read_s1_payload_opcode;
+  wire       [4:0]    read_s1_payload_rs1;
+  wire       [4:0]    read_s1_payload_rs2;
+  wire       [4:0]    read_s1_payload_rs3;
+  wire       [4:0]    read_s1_payload_rd;
+  wire       [1:0]    read_s1_payload_arg;
+  wire       [2:0]    read_s1_payload_roundMode;
   reg                 read_s0_rValid;
-  reg        `FpuOpcode_binary_sequential_type read_s0_rData_opcode;
+  reg        [3:0]    read_s0_rData_opcode;
   reg        [4:0]    read_s0_rData_rs1;
   reg        [4:0]    read_s0_rData_rs2;
   reg        [4:0]    read_s0_rData_rs3;
   reg        [4:0]    read_s0_rData_rd;
   reg        [1:0]    read_s0_rData_arg;
-  reg        `FpuRoundMode_opt_type read_s0_rData_roundMode;
-  wire                when_Stream_l342;
+  reg        [2:0]    read_s0_rData_roundMode;
+  wire                when_Stream_l368;
   wire                read_output_valid;
   wire                read_output_ready;
-  wire       `FpuOpcode_binary_sequential_type read_output_payload_opcode;
+  wire       [3:0]    read_output_payload_opcode;
   wire       [22:0]   read_output_payload_rs1_mantissa;
   wire       [8:0]    read_output_payload_rs1_exponent;
   wire                read_output_payload_rs1_sign;
@@ -7756,7 +7773,7 @@ module FpuCore (
   wire                read_output_payload_rs3_special;
   wire       [4:0]    read_output_payload_rd;
   wire       [1:0]    read_output_payload_arg;
-  wire       `FpuRoundMode_opt_type read_output_payload_roundMode;
+  wire       [2:0]    read_output_payload_roundMode;
   wire       [4:0]    _zz_read_rs_0_value_mantissa;
   wire                read_output_isStall;
   wire                _zz_read_rs_0_value_mantissa_1;
@@ -7783,7 +7800,7 @@ module FpuCore (
   wire       [33:0]   _zz_read_rs_2_value_mantissa_2;
   wire                decode_input_valid;
   reg                 decode_input_ready;
-  wire       `FpuOpcode_binary_sequential_type decode_input_payload_opcode;
+  wire       [3:0]    decode_input_payload_opcode;
   wire       [22:0]   decode_input_payload_rs1_mantissa;
   wire       [8:0]    decode_input_payload_rs1_exponent;
   wire                decode_input_payload_rs1_sign;
@@ -7798,19 +7815,19 @@ module FpuCore (
   wire                decode_input_payload_rs3_special;
   wire       [4:0]    decode_input_payload_rd;
   wire       [1:0]    decode_input_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_input_payload_roundMode;
+  wire       [2:0]    decode_input_payload_roundMode;
   wire                decode_loadHit;
   wire                decode_load_valid;
   wire                decode_load_ready;
   wire       [4:0]    decode_load_payload_rd;
   wire                decode_load_payload_i2f;
   wire       [1:0]    decode_load_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_payload_roundMode;
+  wire       [2:0]    decode_load_payload_roundMode;
   wire                when_FpuCore_l329;
   wire                decode_shortPipHit;
   wire                decode_shortPip_valid;
   reg                 decode_shortPip_ready;
-  wire       `FpuOpcode_binary_sequential_type decode_shortPip_payload_opcode;
+  wire       [3:0]    decode_shortPip_payload_opcode;
   wire       [22:0]   decode_shortPip_payload_rs1_mantissa;
   wire       [8:0]    decode_shortPip_payload_rs1_exponent;
   wire                decode_shortPip_payload_rs1_sign;
@@ -7822,7 +7839,7 @@ module FpuCore (
   wire       [4:0]    decode_shortPip_payload_rd;
   wire       [31:0]   decode_shortPip_payload_value;
   wire       [1:0]    decode_shortPip_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_shortPip_payload_roundMode;
+  wire       [2:0]    decode_shortPip_payload_roundMode;
   wire                when_FpuCore_l335;
   wire                decode_divSqrtHit;
   wire                decode_divSqrt_valid;
@@ -7837,7 +7854,7 @@ module FpuCore (
   wire                decode_divSqrt_payload_rs2_special;
   wire       [4:0]    decode_divSqrt_payload_rd;
   wire                decode_divSqrt_payload_div;
-  wire       `FpuRoundMode_opt_type decode_divSqrt_payload_roundMode;
+  wire       [2:0]    decode_divSqrt_payload_roundMode;
   wire                decode_divHit;
   wire                decode_div_valid;
   wire                decode_div_ready;
@@ -7850,7 +7867,7 @@ module FpuCore (
   wire                decode_div_payload_rs2_sign;
   wire                decode_div_payload_rs2_special;
   wire       [4:0]    decode_div_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_div_payload_roundMode;
+  wire       [2:0]    decode_div_payload_roundMode;
   wire                when_FpuCore_l351;
   wire                decode_sqrtHit;
   wire                decode_sqrt_valid;
@@ -7860,7 +7877,7 @@ module FpuCore (
   wire                decode_sqrt_payload_rs1_sign;
   wire                decode_sqrt_payload_rs1_special;
   wire       [4:0]    decode_sqrt_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_sqrt_payload_roundMode;
+  wire       [2:0]    decode_sqrt_payload_roundMode;
   wire                when_FpuCore_l359;
   wire                decode_fmaHit;
   wire                decode_mulHit;
@@ -7883,7 +7900,7 @@ module FpuCore (
   reg                 decode_mul_payload_divSqrt;
   reg                 decode_mul_payload_msb1;
   reg                 decode_mul_payload_msb2;
-  reg        `FpuRoundMode_opt_type decode_mul_payload_roundMode;
+  reg        [2:0]    decode_mul_payload_roundMode;
   wire                decode_divSqrtToMul_valid;
   wire                decode_divSqrtToMul_ready;
   wire       [22:0]   decode_divSqrtToMul_payload_rs1_mantissa;
@@ -7903,7 +7920,7 @@ module FpuCore (
   wire                decode_divSqrtToMul_payload_divSqrt;
   wire                decode_divSqrtToMul_payload_msb1;
   wire                decode_divSqrtToMul_payload_msb2;
-  wire       `FpuRoundMode_opt_type decode_divSqrtToMul_payload_roundMode;
+  wire       [2:0]    decode_divSqrtToMul_payload_roundMode;
   wire                when_FpuCore_l375;
   wire                when_FpuCore_l380;
   wire                decode_addHit;
@@ -7918,7 +7935,7 @@ module FpuCore (
   reg                 decode_add_payload_rs2_sign;
   reg                 decode_add_payload_rs2_special;
   reg        [4:0]    decode_add_payload_rd;
-  reg        `FpuRoundMode_opt_type decode_add_payload_roundMode;
+  reg        [2:0]    decode_add_payload_roundMode;
   reg                 decode_add_payload_needCommit;
   wire                decode_mulToAdd_valid;
   wire                decode_mulToAdd_ready;
@@ -7931,7 +7948,7 @@ module FpuCore (
   wire                decode_mulToAdd_payload_rs2_sign;
   wire                decode_mulToAdd_payload_rs2_special;
   wire       [4:0]    decode_mulToAdd_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_mulToAdd_payload_roundMode;
+  wire       [2:0]    decode_mulToAdd_payload_roundMode;
   wire                decode_mulToAdd_payload_needCommit;
   wire                when_FpuCore_l399;
   wire                when_FpuCore_l404;
@@ -7940,67 +7957,67 @@ module FpuCore (
   wire       [4:0]    decode_load_s2mPipe_payload_rd;
   wire                decode_load_s2mPipe_payload_i2f;
   wire       [1:0]    decode_load_s2mPipe_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_s2mPipe_payload_roundMode;
+  wire       [2:0]    decode_load_s2mPipe_payload_roundMode;
   reg                 decode_load_rValid;
   reg        [4:0]    decode_load_rData_rd;
   reg                 decode_load_rData_i2f;
   reg        [1:0]    decode_load_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_load_rData_roundMode;
-  wire       `FpuRoundMode_opt_type _zz_decode_load_s2mPipe_payload_roundMode;
+  reg        [2:0]    decode_load_rData_roundMode;
+  wire       [2:0]    _zz_decode_load_s2mPipe_payload_roundMode;
   wire                decode_load_s2mPipe_m2sPipe_valid;
   reg                 decode_load_s2mPipe_m2sPipe_ready;
   wire       [4:0]    decode_load_s2mPipe_m2sPipe_payload_rd;
   wire                decode_load_s2mPipe_m2sPipe_payload_i2f;
   wire       [1:0]    decode_load_s2mPipe_m2sPipe_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_s2mPipe_m2sPipe_payload_roundMode;
+  wire       [2:0]    decode_load_s2mPipe_m2sPipe_payload_roundMode;
   reg                 decode_load_s2mPipe_rValid;
   reg        [4:0]    decode_load_s2mPipe_rData_rd;
   reg                 decode_load_s2mPipe_rData_i2f;
   reg        [1:0]    decode_load_s2mPipe_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_load_s2mPipe_rData_roundMode;
-  wire                when_Stream_l342_1;
-  wire                decode_load_s2mPipe_m2sPipe_input_valid;
-  wire                decode_load_s2mPipe_m2sPipe_input_ready;
-  wire       [4:0]    decode_load_s2mPipe_m2sPipe_input_payload_rd;
-  wire                decode_load_s2mPipe_m2sPipe_input_payload_i2f;
-  wire       [1:0]    decode_load_s2mPipe_m2sPipe_input_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_load_s2mPipe_m2sPipe_input_payload_roundMode;
+  reg        [2:0]    decode_load_s2mPipe_rData_roundMode;
+  wire                when_Stream_l368_1;
+  wire                load_s0_input_valid;
+  wire                load_s0_input_ready;
+  wire       [4:0]    load_s0_input_payload_rd;
+  wire                load_s0_input_payload_i2f;
+  wire       [1:0]    load_s0_input_payload_arg;
+  wire       [2:0]    load_s0_input_payload_roundMode;
   reg                 decode_load_s2mPipe_m2sPipe_rValid;
   reg        [4:0]    decode_load_s2mPipe_m2sPipe_rData_rd;
   reg                 decode_load_s2mPipe_m2sPipe_rData_i2f;
   reg        [1:0]    decode_load_s2mPipe_m2sPipe_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_load_s2mPipe_m2sPipe_rData_roundMode;
-  wire                when_Stream_l342_2;
-  wire                when_Stream_l408;
+  reg        [2:0]    decode_load_s2mPipe_m2sPipe_rData_roundMode;
+  wire                when_Stream_l368_2;
+  wire                when_Stream_l438;
   reg                 load_s0_filtred_0_valid;
   reg                 load_s0_filtred_0_ready;
-  wire       `FpuOpcode_binary_sequential_type load_s0_filtred_0_payload_opcode;
+  wire       [3:0]    load_s0_filtred_0_payload_opcode;
   wire       [4:0]    load_s0_filtred_0_payload_rd;
   wire                load_s0_filtred_0_payload_write;
   wire       [31:0]   load_s0_filtred_0_payload_value;
   wire                load_s0_hazard;
-  wire                _zz_decode_load_s2mPipe_m2sPipe_input_ready;
+  wire                _zz_load_s0_input_ready;
   wire                load_s0_output_valid;
   reg                 load_s0_output_ready;
   wire       [4:0]    load_s0_output_payload_rd;
   wire       [31:0]   load_s0_output_payload_value;
   wire                load_s0_output_payload_i2f;
   wire       [1:0]    load_s0_output_payload_arg;
-  wire       `FpuRoundMode_opt_type load_s0_output_payload_roundMode;
-  wire                load_s0_output_input_valid;
-  wire                load_s0_output_input_ready;
-  wire       [4:0]    load_s0_output_input_payload_rd;
-  wire       [31:0]   load_s0_output_input_payload_value;
-  wire                load_s0_output_input_payload_i2f;
-  wire       [1:0]    load_s0_output_input_payload_arg;
-  wire       `FpuRoundMode_opt_type load_s0_output_input_payload_roundMode;
+  wire       [2:0]    load_s0_output_payload_roundMode;
+  wire                load_s1_input_valid;
+  wire                load_s1_input_ready;
+  wire       [4:0]    load_s1_input_payload_rd;
+  wire       [31:0]   load_s1_input_payload_value;
+  wire                load_s1_input_payload_i2f;
+  wire       [1:0]    load_s1_input_payload_arg;
+  wire       [2:0]    load_s1_input_payload_roundMode;
   reg                 load_s0_output_rValid;
   reg        [4:0]    load_s0_output_rData_rd;
   reg        [31:0]   load_s0_output_rData_value;
   reg                 load_s0_output_rData_i2f;
   reg        [1:0]    load_s0_output_rData_arg;
-  reg        `FpuRoundMode_opt_type load_s0_output_rData_roundMode;
-  wire                when_Stream_l342_3;
+  reg        [2:0]    load_s0_output_rData_roundMode;
+  wire                when_Stream_l368_3;
   reg                 load_s1_busy;
   wire       [22:0]   load_s1_f32_mantissa;
   wire       [7:0]    load_s1_f32_exponent;
@@ -8065,7 +8082,7 @@ module FpuCore (
   wire                _zz_load_s1_fsm_shift_by_31;
   wire                _zz_load_s1_fsm_shift_by_32;
   reg        [8:0]    load_s1_fsm_expOffset;
-  wire                load_s0_output_input_isStall;
+  wire                load_s1_input_isStall;
   wire                when_FpuCore_l551;
   wire       [23:0]   load_s1_i2fHigh;
   wire       [7:0]    load_s1_i2fLow;
@@ -8074,7 +8091,7 @@ module FpuCore (
   reg        [8:0]    load_s1_recoded_exponent;
   wire                load_s1_recoded_sign;
   reg                 load_s1_recoded_special;
-  wire                _zz_load_s0_output_input_ready;
+  wire                _zz_load_s1_input_ready;
   wire                load_s1_output_valid;
   reg                 load_s1_output_ready;
   wire       [4:0]    load_s1_output_payload_rd;
@@ -8083,27 +8100,27 @@ module FpuCore (
   reg                 load_s1_output_payload_value_sign;
   reg                 load_s1_output_payload_value_special;
   reg                 load_s1_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type load_s1_output_payload_roundMode;
+  wire       [2:0]    load_s1_output_payload_roundMode;
   wire                load_s1_output_payload_NV;
   wire                load_s1_output_payload_DZ;
   wire                when_FpuCore_l594;
-  wire                decode_shortPip_input_valid;
-  wire                decode_shortPip_input_ready;
-  wire       `FpuOpcode_binary_sequential_type decode_shortPip_input_payload_opcode;
-  wire       [22:0]   decode_shortPip_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_shortPip_input_payload_rs1_exponent;
-  wire                decode_shortPip_input_payload_rs1_sign;
-  wire                decode_shortPip_input_payload_rs1_special;
-  wire       [22:0]   decode_shortPip_input_payload_rs2_mantissa;
-  wire       [8:0]    decode_shortPip_input_payload_rs2_exponent;
-  wire                decode_shortPip_input_payload_rs2_sign;
-  wire                decode_shortPip_input_payload_rs2_special;
-  wire       [4:0]    decode_shortPip_input_payload_rd;
-  wire       [31:0]   decode_shortPip_input_payload_value;
-  wire       [1:0]    decode_shortPip_input_payload_arg;
-  wire       `FpuRoundMode_opt_type decode_shortPip_input_payload_roundMode;
+  wire                shortPip_input_valid;
+  wire                shortPip_input_ready;
+  wire       [3:0]    shortPip_input_payload_opcode;
+  wire       [22:0]   shortPip_input_payload_rs1_mantissa;
+  wire       [8:0]    shortPip_input_payload_rs1_exponent;
+  wire                shortPip_input_payload_rs1_sign;
+  wire                shortPip_input_payload_rs1_special;
+  wire       [22:0]   shortPip_input_payload_rs2_mantissa;
+  wire       [8:0]    shortPip_input_payload_rs2_exponent;
+  wire                shortPip_input_payload_rs2_sign;
+  wire                shortPip_input_payload_rs2_special;
+  wire       [4:0]    shortPip_input_payload_rd;
+  wire       [31:0]   shortPip_input_payload_value;
+  wire       [1:0]    shortPip_input_payload_arg;
+  wire       [2:0]    shortPip_input_payload_roundMode;
   reg                 decode_shortPip_rValid;
-  reg        `FpuOpcode_binary_sequential_type decode_shortPip_rData_opcode;
+  reg        [3:0]    decode_shortPip_rData_opcode;
   reg        [22:0]   decode_shortPip_rData_rs1_mantissa;
   reg        [8:0]    decode_shortPip_rData_rs1_exponent;
   reg                 decode_shortPip_rData_rs1_sign;
@@ -8115,8 +8132,8 @@ module FpuCore (
   reg        [4:0]    decode_shortPip_rData_rd;
   reg        [31:0]   decode_shortPip_rData_value;
   reg        [1:0]    decode_shortPip_rData_arg;
-  reg        `FpuRoundMode_opt_type decode_shortPip_rData_roundMode;
-  wire                when_Stream_l342_4;
+  reg        [2:0]    decode_shortPip_rData_roundMode;
+  wire                when_Stream_l368_4;
   wire                shortPip_toFpuRf;
   wire                shortPip_rfOutput_valid;
   wire                shortPip_rfOutput_ready;
@@ -8126,10 +8143,10 @@ module FpuCore (
   reg                 shortPip_rfOutput_payload_value_sign;
   reg                 shortPip_rfOutput_payload_value_special;
   wire                shortPip_rfOutput_payload_scrap;
-  wire       `FpuRoundMode_opt_type shortPip_rfOutput_payload_roundMode;
+  wire       [2:0]    shortPip_rfOutput_payload_roundMode;
   wire                shortPip_rfOutput_payload_NV;
   wire                shortPip_rfOutput_payload_DZ;
-  wire                decode_shortPip_input_fire;
+  wire                shortPip_input_fire;
   wire                when_FpuCore_l221;
   wire                shortPip_isCommited;
   wire                _zz_shortPip_rfOutput_ready;
@@ -8141,7 +8158,7 @@ module FpuCore (
   wire                shortPip_output_payload_value_sign;
   wire                shortPip_output_payload_value_special;
   wire                shortPip_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type shortPip_output_payload_roundMode;
+  wire       [2:0]    shortPip_output_payload_roundMode;
   wire                shortPip_output_payload_NV;
   wire                shortPip_output_payload_DZ;
   reg        [31:0]   shortPip_result;
@@ -8174,7 +8191,7 @@ module FpuCore (
   wire                when_FpuCore_l658;
   wire       [8:0]    _zz_shortPip_fsm_shift_by;
   wire       [5:0]    _zz_shortPip_fsm_shift_by_1;
-  wire                decode_shortPip_input_isStall;
+  wire                shortPip_input_isStall;
   wire                when_FpuCore_l672;
   reg                 shortPip_mantissaForced;
   reg                 shortPip_exponentForced;
@@ -8202,7 +8219,7 @@ module FpuCore (
   wire                when_FpuCore_l782;
   wire                when_FpuCore_l783;
   wire                when_FpuCore_l784;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   reg                 shortPip_rs1Smaller;
   wire                shortPip_minMaxSelectRs2;
   wire                shortPip_minMaxSelectNanQuiet;
@@ -8239,27 +8256,27 @@ module FpuCore (
   reg        [31:0]   shortPip_rspStreams_0_rData_value;
   reg                 shortPip_rspStreams_0_rData_NV;
   reg                 shortPip_rspStreams_0_rData_NX;
-  wire                when_Stream_l342_5;
-  wire                decode_mul_input_valid;
-  wire                decode_mul_input_ready;
-  wire       [22:0]   decode_mul_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_mul_input_payload_rs1_exponent;
-  wire                decode_mul_input_payload_rs1_sign;
-  wire                decode_mul_input_payload_rs1_special;
-  wire       [22:0]   decode_mul_input_payload_rs2_mantissa;
-  wire       [8:0]    decode_mul_input_payload_rs2_exponent;
-  wire                decode_mul_input_payload_rs2_sign;
-  wire                decode_mul_input_payload_rs2_special;
-  wire       [22:0]   decode_mul_input_payload_rs3_mantissa;
-  wire       [8:0]    decode_mul_input_payload_rs3_exponent;
-  wire                decode_mul_input_payload_rs3_sign;
-  wire                decode_mul_input_payload_rs3_special;
-  wire       [4:0]    decode_mul_input_payload_rd;
-  wire                decode_mul_input_payload_add;
-  wire                decode_mul_input_payload_divSqrt;
-  wire                decode_mul_input_payload_msb1;
-  wire                decode_mul_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type decode_mul_input_payload_roundMode;
+  wire                when_Stream_l368_5;
+  wire                mul_preMul_input_valid;
+  wire                mul_preMul_input_ready;
+  wire       [22:0]   mul_preMul_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_preMul_input_payload_rs1_exponent;
+  wire                mul_preMul_input_payload_rs1_sign;
+  wire                mul_preMul_input_payload_rs1_special;
+  wire       [22:0]   mul_preMul_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_preMul_input_payload_rs2_exponent;
+  wire                mul_preMul_input_payload_rs2_sign;
+  wire                mul_preMul_input_payload_rs2_special;
+  wire       [22:0]   mul_preMul_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_preMul_input_payload_rs3_exponent;
+  wire                mul_preMul_input_payload_rs3_sign;
+  wire                mul_preMul_input_payload_rs3_special;
+  wire       [4:0]    mul_preMul_input_payload_rd;
+  wire                mul_preMul_input_payload_add;
+  wire                mul_preMul_input_payload_divSqrt;
+  wire                mul_preMul_input_payload_msb1;
+  wire                mul_preMul_input_payload_msb2;
+  wire       [2:0]    mul_preMul_input_payload_roundMode;
   reg                 decode_mul_rValid;
   reg        [22:0]   decode_mul_rData_rs1_mantissa;
   reg        [8:0]    decode_mul_rData_rs1_exponent;
@@ -8278,8 +8295,8 @@ module FpuCore (
   reg                 decode_mul_rData_divSqrt;
   reg                 decode_mul_rData_msb1;
   reg                 decode_mul_rData_msb2;
-  reg        `FpuRoundMode_opt_type decode_mul_rData_roundMode;
-  wire                when_Stream_l342_6;
+  reg        [2:0]    decode_mul_rData_roundMode;
+  wire                when_Stream_l368_6;
   wire                mul_preMul_output_valid;
   reg                 mul_preMul_output_ready;
   wire       [22:0]   mul_preMul_output_payload_rs1_mantissa;
@@ -8299,29 +8316,29 @@ module FpuCore (
   wire                mul_preMul_output_payload_divSqrt;
   wire                mul_preMul_output_payload_msb1;
   wire                mul_preMul_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_preMul_output_payload_roundMode;
+  wire       [2:0]    mul_preMul_output_payload_roundMode;
   wire       [9:0]    mul_preMul_output_payload_exp;
-  wire                mul_preMul_output_input_valid;
-  wire                mul_preMul_output_input_ready;
-  wire       [22:0]   mul_preMul_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_preMul_output_input_payload_rs1_exponent;
-  wire                mul_preMul_output_input_payload_rs1_sign;
-  wire                mul_preMul_output_input_payload_rs1_special;
-  wire       [22:0]   mul_preMul_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_preMul_output_input_payload_rs2_exponent;
-  wire                mul_preMul_output_input_payload_rs2_sign;
-  wire                mul_preMul_output_input_payload_rs2_special;
-  wire       [22:0]   mul_preMul_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_preMul_output_input_payload_rs3_exponent;
-  wire                mul_preMul_output_input_payload_rs3_sign;
-  wire                mul_preMul_output_input_payload_rs3_special;
-  wire       [4:0]    mul_preMul_output_input_payload_rd;
-  wire                mul_preMul_output_input_payload_add;
-  wire                mul_preMul_output_input_payload_divSqrt;
-  wire                mul_preMul_output_input_payload_msb1;
-  wire                mul_preMul_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_preMul_output_input_payload_roundMode;
-  wire       [9:0]    mul_preMul_output_input_payload_exp;
+  wire                mul_mul_input_valid;
+  wire                mul_mul_input_ready;
+  wire       [22:0]   mul_mul_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_mul_input_payload_rs1_exponent;
+  wire                mul_mul_input_payload_rs1_sign;
+  wire                mul_mul_input_payload_rs1_special;
+  wire       [22:0]   mul_mul_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_mul_input_payload_rs2_exponent;
+  wire                mul_mul_input_payload_rs2_sign;
+  wire                mul_mul_input_payload_rs2_special;
+  wire       [22:0]   mul_mul_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_mul_input_payload_rs3_exponent;
+  wire                mul_mul_input_payload_rs3_sign;
+  wire                mul_mul_input_payload_rs3_special;
+  wire       [4:0]    mul_mul_input_payload_rd;
+  wire                mul_mul_input_payload_add;
+  wire                mul_mul_input_payload_divSqrt;
+  wire                mul_mul_input_payload_msb1;
+  wire                mul_mul_input_payload_msb2;
+  wire       [2:0]    mul_mul_input_payload_roundMode;
+  wire       [9:0]    mul_mul_input_payload_exp;
   reg                 mul_preMul_output_rValid;
   reg        [22:0]   mul_preMul_output_rData_rs1_mantissa;
   reg        [8:0]    mul_preMul_output_rData_rs1_exponent;
@@ -8340,9 +8357,9 @@ module FpuCore (
   reg                 mul_preMul_output_rData_divSqrt;
   reg                 mul_preMul_output_rData_msb1;
   reg                 mul_preMul_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_preMul_output_rData_roundMode;
+  reg        [2:0]    mul_preMul_output_rData_roundMode;
   reg        [9:0]    mul_preMul_output_rData_exp;
-  wire                when_Stream_l342_7;
+  wire                when_Stream_l368_7;
   wire                mul_mul_output_valid;
   reg                 mul_mul_output_ready;
   wire       [22:0]   mul_mul_output_payload_rs1_mantissa;
@@ -8362,7 +8379,7 @@ module FpuCore (
   wire                mul_mul_output_payload_divSqrt;
   wire                mul_mul_output_payload_msb1;
   wire                mul_mul_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_mul_output_payload_roundMode;
+  wire       [2:0]    mul_mul_output_payload_roundMode;
   wire       [9:0]    mul_mul_output_payload_exp;
   wire       [35:0]   mul_mul_output_payload_muls_0;
   wire       [23:0]   mul_mul_output_payload_muls_1;
@@ -8370,31 +8387,31 @@ module FpuCore (
   wire       [11:0]   mul_mul_output_payload_muls_3;
   wire       [23:0]   mul_mul_mulA;
   wire       [23:0]   mul_mul_mulB;
-  wire                mul_mul_output_input_valid;
-  wire                mul_mul_output_input_ready;
-  wire       [22:0]   mul_mul_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_mul_output_input_payload_rs1_exponent;
-  wire                mul_mul_output_input_payload_rs1_sign;
-  wire                mul_mul_output_input_payload_rs1_special;
-  wire       [22:0]   mul_mul_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_mul_output_input_payload_rs2_exponent;
-  wire                mul_mul_output_input_payload_rs2_sign;
-  wire                mul_mul_output_input_payload_rs2_special;
-  wire       [22:0]   mul_mul_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_mul_output_input_payload_rs3_exponent;
-  wire                mul_mul_output_input_payload_rs3_sign;
-  wire                mul_mul_output_input_payload_rs3_special;
-  wire       [4:0]    mul_mul_output_input_payload_rd;
-  wire                mul_mul_output_input_payload_add;
-  wire                mul_mul_output_input_payload_divSqrt;
-  wire                mul_mul_output_input_payload_msb1;
-  wire                mul_mul_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_mul_output_input_payload_roundMode;
-  wire       [9:0]    mul_mul_output_input_payload_exp;
-  wire       [35:0]   mul_mul_output_input_payload_muls_0;
-  wire       [23:0]   mul_mul_output_input_payload_muls_1;
-  wire       [23:0]   mul_mul_output_input_payload_muls_2;
-  wire       [11:0]   mul_mul_output_input_payload_muls_3;
+  wire                mul_sum1_input_valid;
+  wire                mul_sum1_input_ready;
+  wire       [22:0]   mul_sum1_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_sum1_input_payload_rs1_exponent;
+  wire                mul_sum1_input_payload_rs1_sign;
+  wire                mul_sum1_input_payload_rs1_special;
+  wire       [22:0]   mul_sum1_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_sum1_input_payload_rs2_exponent;
+  wire                mul_sum1_input_payload_rs2_sign;
+  wire                mul_sum1_input_payload_rs2_special;
+  wire       [22:0]   mul_sum1_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_sum1_input_payload_rs3_exponent;
+  wire                mul_sum1_input_payload_rs3_sign;
+  wire                mul_sum1_input_payload_rs3_special;
+  wire       [4:0]    mul_sum1_input_payload_rd;
+  wire                mul_sum1_input_payload_add;
+  wire                mul_sum1_input_payload_divSqrt;
+  wire                mul_sum1_input_payload_msb1;
+  wire                mul_sum1_input_payload_msb2;
+  wire       [2:0]    mul_sum1_input_payload_roundMode;
+  wire       [9:0]    mul_sum1_input_payload_exp;
+  wire       [35:0]   mul_sum1_input_payload_muls_0;
+  wire       [23:0]   mul_sum1_input_payload_muls_1;
+  wire       [23:0]   mul_sum1_input_payload_muls_2;
+  wire       [11:0]   mul_sum1_input_payload_muls_3;
   reg                 mul_mul_output_rValid;
   reg        [22:0]   mul_mul_output_rData_rs1_mantissa;
   reg        [8:0]    mul_mul_output_rData_rs1_exponent;
@@ -8413,13 +8430,13 @@ module FpuCore (
   reg                 mul_mul_output_rData_divSqrt;
   reg                 mul_mul_output_rData_msb1;
   reg                 mul_mul_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_mul_output_rData_roundMode;
+  reg        [2:0]    mul_mul_output_rData_roundMode;
   reg        [9:0]    mul_mul_output_rData_exp;
   reg        [35:0]   mul_mul_output_rData_muls_0;
   reg        [23:0]   mul_mul_output_rData_muls_1;
   reg        [23:0]   mul_mul_output_rData_muls_2;
   reg        [11:0]   mul_mul_output_rData_muls_3;
-  wire                when_Stream_l342_8;
+  wire                when_Stream_l368_8;
   wire       [47:0]   mul_sum1_sum;
   wire                mul_sum1_output_valid;
   reg                 mul_sum1_output_ready;
@@ -8440,35 +8457,35 @@ module FpuCore (
   wire                mul_sum1_output_payload_divSqrt;
   wire                mul_sum1_output_payload_msb1;
   wire                mul_sum1_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum1_output_payload_roundMode;
+  wire       [2:0]    mul_sum1_output_payload_roundMode;
   wire       [9:0]    mul_sum1_output_payload_exp;
   wire       [23:0]   mul_sum1_output_payload_muls2_0;
   wire       [11:0]   mul_sum1_output_payload_muls2_1;
   wire       [47:0]   mul_sum1_output_payload_mulC2;
-  wire                mul_sum1_output_input_valid;
-  wire                mul_sum1_output_input_ready;
-  wire       [22:0]   mul_sum1_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_sum1_output_input_payload_rs1_exponent;
-  wire                mul_sum1_output_input_payload_rs1_sign;
-  wire                mul_sum1_output_input_payload_rs1_special;
-  wire       [22:0]   mul_sum1_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_sum1_output_input_payload_rs2_exponent;
-  wire                mul_sum1_output_input_payload_rs2_sign;
-  wire                mul_sum1_output_input_payload_rs2_special;
-  wire       [22:0]   mul_sum1_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_sum1_output_input_payload_rs3_exponent;
-  wire                mul_sum1_output_input_payload_rs3_sign;
-  wire                mul_sum1_output_input_payload_rs3_special;
-  wire       [4:0]    mul_sum1_output_input_payload_rd;
-  wire                mul_sum1_output_input_payload_add;
-  wire                mul_sum1_output_input_payload_divSqrt;
-  wire                mul_sum1_output_input_payload_msb1;
-  wire                mul_sum1_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum1_output_input_payload_roundMode;
-  wire       [9:0]    mul_sum1_output_input_payload_exp;
-  wire       [23:0]   mul_sum1_output_input_payload_muls2_0;
-  wire       [11:0]   mul_sum1_output_input_payload_muls2_1;
-  wire       [47:0]   mul_sum1_output_input_payload_mulC2;
+  wire                mul_sum2_input_valid;
+  wire                mul_sum2_input_ready;
+  wire       [22:0]   mul_sum2_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_sum2_input_payload_rs1_exponent;
+  wire                mul_sum2_input_payload_rs1_sign;
+  wire                mul_sum2_input_payload_rs1_special;
+  wire       [22:0]   mul_sum2_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_sum2_input_payload_rs2_exponent;
+  wire                mul_sum2_input_payload_rs2_sign;
+  wire                mul_sum2_input_payload_rs2_special;
+  wire       [22:0]   mul_sum2_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_sum2_input_payload_rs3_exponent;
+  wire                mul_sum2_input_payload_rs3_sign;
+  wire                mul_sum2_input_payload_rs3_special;
+  wire       [4:0]    mul_sum2_input_payload_rd;
+  wire                mul_sum2_input_payload_add;
+  wire                mul_sum2_input_payload_divSqrt;
+  wire                mul_sum2_input_payload_msb1;
+  wire                mul_sum2_input_payload_msb2;
+  wire       [2:0]    mul_sum2_input_payload_roundMode;
+  wire       [9:0]    mul_sum2_input_payload_exp;
+  wire       [23:0]   mul_sum2_input_payload_muls2_0;
+  wire       [11:0]   mul_sum2_input_payload_muls2_1;
+  wire       [47:0]   mul_sum2_input_payload_mulC2;
   reg                 mul_sum1_output_rValid;
   reg        [22:0]   mul_sum1_output_rData_rs1_mantissa;
   reg        [8:0]    mul_sum1_output_rData_rs1_exponent;
@@ -8487,17 +8504,17 @@ module FpuCore (
   reg                 mul_sum1_output_rData_divSqrt;
   reg                 mul_sum1_output_rData_msb1;
   reg                 mul_sum1_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_sum1_output_rData_roundMode;
+  reg        [2:0]    mul_sum1_output_rData_roundMode;
   reg        [9:0]    mul_sum1_output_rData_exp;
   reg        [23:0]   mul_sum1_output_rData_muls2_0;
   reg        [11:0]   mul_sum1_output_rData_muls2_1;
   reg        [47:0]   mul_sum1_output_rData_mulC2;
-  wire                when_Stream_l342_9;
+  wire                when_Stream_l368_9;
   wire       [47:0]   mul_sum2_sum;
-  wire                mul_sum1_output_input_fire;
+  wire                mul_sum2_input_fire;
   wire                when_FpuCore_l221_1;
   wire                mul_sum2_isCommited;
-  wire                _zz_mul_sum1_output_input_ready;
+  wire                _zz_mul_sum2_input_ready;
   wire                mul_sum2_output_valid;
   reg                 mul_sum2_output_ready;
   wire       [22:0]   mul_sum2_output_payload_rs1_mantissa;
@@ -8517,31 +8534,31 @@ module FpuCore (
   wire                mul_sum2_output_payload_divSqrt;
   wire                mul_sum2_output_payload_msb1;
   wire                mul_sum2_output_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum2_output_payload_roundMode;
+  wire       [2:0]    mul_sum2_output_payload_roundMode;
   wire       [9:0]    mul_sum2_output_payload_exp;
   wire       [47:0]   mul_sum2_output_payload_mulC;
-  wire                mul_sum2_output_input_valid;
-  wire                mul_sum2_output_input_ready;
-  wire       [22:0]   mul_sum2_output_input_payload_rs1_mantissa;
-  wire       [8:0]    mul_sum2_output_input_payload_rs1_exponent;
-  wire                mul_sum2_output_input_payload_rs1_sign;
-  wire                mul_sum2_output_input_payload_rs1_special;
-  wire       [22:0]   mul_sum2_output_input_payload_rs2_mantissa;
-  wire       [8:0]    mul_sum2_output_input_payload_rs2_exponent;
-  wire                mul_sum2_output_input_payload_rs2_sign;
-  wire                mul_sum2_output_input_payload_rs2_special;
-  wire       [22:0]   mul_sum2_output_input_payload_rs3_mantissa;
-  wire       [8:0]    mul_sum2_output_input_payload_rs3_exponent;
-  wire                mul_sum2_output_input_payload_rs3_sign;
-  wire                mul_sum2_output_input_payload_rs3_special;
-  wire       [4:0]    mul_sum2_output_input_payload_rd;
-  wire                mul_sum2_output_input_payload_add;
-  wire                mul_sum2_output_input_payload_divSqrt;
-  wire                mul_sum2_output_input_payload_msb1;
-  wire                mul_sum2_output_input_payload_msb2;
-  wire       `FpuRoundMode_opt_type mul_sum2_output_input_payload_roundMode;
-  wire       [9:0]    mul_sum2_output_input_payload_exp;
-  wire       [47:0]   mul_sum2_output_input_payload_mulC;
+  wire                mul_norm_input_valid;
+  wire                mul_norm_input_ready;
+  wire       [22:0]   mul_norm_input_payload_rs1_mantissa;
+  wire       [8:0]    mul_norm_input_payload_rs1_exponent;
+  wire                mul_norm_input_payload_rs1_sign;
+  wire                mul_norm_input_payload_rs1_special;
+  wire       [22:0]   mul_norm_input_payload_rs2_mantissa;
+  wire       [8:0]    mul_norm_input_payload_rs2_exponent;
+  wire                mul_norm_input_payload_rs2_sign;
+  wire                mul_norm_input_payload_rs2_special;
+  wire       [22:0]   mul_norm_input_payload_rs3_mantissa;
+  wire       [8:0]    mul_norm_input_payload_rs3_exponent;
+  wire                mul_norm_input_payload_rs3_sign;
+  wire                mul_norm_input_payload_rs3_special;
+  wire       [4:0]    mul_norm_input_payload_rd;
+  wire                mul_norm_input_payload_add;
+  wire                mul_norm_input_payload_divSqrt;
+  wire                mul_norm_input_payload_msb1;
+  wire                mul_norm_input_payload_msb2;
+  wire       [2:0]    mul_norm_input_payload_roundMode;
+  wire       [9:0]    mul_norm_input_payload_exp;
+  wire       [47:0]   mul_norm_input_payload_mulC;
   reg                 mul_sum2_output_rValid;
   reg        [22:0]   mul_sum2_output_rData_rs1_mantissa;
   reg        [8:0]    mul_sum2_output_rData_rs1_exponent;
@@ -8560,10 +8577,10 @@ module FpuCore (
   reg                 mul_sum2_output_rData_divSqrt;
   reg                 mul_sum2_output_rData_msb1;
   reg                 mul_sum2_output_rData_msb2;
-  reg        `FpuRoundMode_opt_type mul_sum2_output_rData_roundMode;
+  reg        [2:0]    mul_sum2_output_rData_roundMode;
   reg        [9:0]    mul_sum2_output_rData_exp;
   reg        [47:0]   mul_sum2_output_rData_mulC;
-  wire                when_Stream_l342_10;
+  wire                when_Stream_l368_10;
   wire       [25:0]   mul_norm_mulHigh;
   wire       [21:0]   mul_norm_mulLow;
   reg                 mul_norm_scrap;
@@ -8595,7 +8612,7 @@ module FpuCore (
   wire                mul_result_output_payload_value_sign;
   wire                mul_result_output_payload_value_special;
   wire                mul_result_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type mul_result_output_payload_roundMode;
+  wire       [2:0]    mul_result_output_payload_roundMode;
   wire                mul_result_output_payload_NV;
   wire                mul_result_output_payload_DZ;
   wire                mul_result_mulToAdd_valid;
@@ -8609,7 +8626,7 @@ module FpuCore (
   wire                mul_result_mulToAdd_payload_rs2_sign;
   wire                mul_result_mulToAdd_payload_rs2_special;
   wire       [4:0]    mul_result_mulToAdd_payload_rd;
-  wire       `FpuRoundMode_opt_type mul_result_mulToAdd_payload_roundMode;
+  wire       [2:0]    mul_result_mulToAdd_payload_roundMode;
   wire                mul_result_mulToAdd_payload_needCommit;
   wire                mul_result_mulToAdd_m2sPipe_valid;
   wire                mul_result_mulToAdd_m2sPipe_ready;
@@ -8622,7 +8639,7 @@ module FpuCore (
   wire                mul_result_mulToAdd_m2sPipe_payload_rs2_sign;
   wire                mul_result_mulToAdd_m2sPipe_payload_rs2_special;
   wire       [4:0]    mul_result_mulToAdd_m2sPipe_payload_rd;
-  wire       `FpuRoundMode_opt_type mul_result_mulToAdd_m2sPipe_payload_roundMode;
+  wire       [2:0]    mul_result_mulToAdd_m2sPipe_payload_roundMode;
   wire                mul_result_mulToAdd_m2sPipe_payload_needCommit;
   reg                 mul_result_mulToAdd_rValid;
   reg        [24:0]   mul_result_mulToAdd_rData_rs1_mantissa;
@@ -8634,23 +8651,23 @@ module FpuCore (
   reg                 mul_result_mulToAdd_rData_rs2_sign;
   reg                 mul_result_mulToAdd_rData_rs2_special;
   reg        [4:0]    mul_result_mulToAdd_rData_rd;
-  reg        `FpuRoundMode_opt_type mul_result_mulToAdd_rData_roundMode;
+  reg        [2:0]    mul_result_mulToAdd_rData_roundMode;
   reg                 mul_result_mulToAdd_rData_needCommit;
-  wire                when_Stream_l342_11;
-  wire                decode_div_input_valid;
-  wire                decode_div_input_ready;
-  wire       [22:0]   decode_div_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_div_input_payload_rs1_exponent;
-  wire                decode_div_input_payload_rs1_sign;
-  wire                decode_div_input_payload_rs1_special;
-  wire       [22:0]   decode_div_input_payload_rs2_mantissa;
-  wire       [8:0]    decode_div_input_payload_rs2_exponent;
-  wire                decode_div_input_payload_rs2_sign;
-  wire                decode_div_input_payload_rs2_special;
-  wire       [4:0]    decode_div_input_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_div_input_payload_roundMode;
+  wire                when_Stream_l368_11;
+  wire                div_input_valid;
+  wire                div_input_ready;
+  wire       [22:0]   div_input_payload_rs1_mantissa;
+  wire       [8:0]    div_input_payload_rs1_exponent;
+  wire                div_input_payload_rs1_sign;
+  wire                div_input_payload_rs1_special;
+  wire       [22:0]   div_input_payload_rs2_mantissa;
+  wire       [8:0]    div_input_payload_rs2_exponent;
+  wire                div_input_payload_rs2_sign;
+  wire                div_input_payload_rs2_special;
+  wire       [4:0]    div_input_payload_rd;
+  wire       [2:0]    div_input_payload_roundMode;
   reg                 decode_div_rValid;
-  wire                decode_div_input_fire;
+  wire                div_input_fire;
   reg        [22:0]   decode_div_rData_rs1_mantissa;
   reg        [8:0]    decode_div_rData_rs1_exponent;
   reg                 decode_div_rData_rs1_sign;
@@ -8660,12 +8677,12 @@ module FpuCore (
   reg                 decode_div_rData_rs2_sign;
   reg                 decode_div_rData_rs2_special;
   reg        [4:0]    decode_div_rData_rd;
-  reg        `FpuRoundMode_opt_type decode_div_rData_roundMode;
+  reg        [2:0]    decode_div_rData_roundMode;
   reg                 div_haltIt;
-  wire                decode_div_input_fire_1;
+  wire                div_input_fire_1;
   wire                when_FpuCore_l221_2;
   reg                 div_isCommited;
-  wire                _zz_decode_div_input_ready;
+  wire                _zz_div_input_ready;
   wire                div_output_valid;
   wire                div_output_ready;
   wire       [4:0]    div_output_payload_rd;
@@ -8674,7 +8691,7 @@ module FpuCore (
   wire                div_output_payload_value_sign;
   reg                 div_output_payload_value_special;
   wire                div_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type div_output_payload_roundMode;
+  wire       [2:0]    div_output_payload_roundMode;
   reg                 div_output_payload_NV;
   wire                div_output_payload_DZ;
   wire       [25:0]   div_dividerResult;
@@ -8696,27 +8713,27 @@ module FpuCore (
   wire                div_forceZero;
   wire                when_FpuCore_l1089;
   wire                when_FpuCore_l1093;
-  wire                decode_sqrt_input_valid;
-  wire                decode_sqrt_input_ready;
-  wire       [22:0]   decode_sqrt_input_payload_rs1_mantissa;
-  wire       [8:0]    decode_sqrt_input_payload_rs1_exponent;
-  wire                decode_sqrt_input_payload_rs1_sign;
-  wire                decode_sqrt_input_payload_rs1_special;
-  wire       [4:0]    decode_sqrt_input_payload_rd;
-  wire       `FpuRoundMode_opt_type decode_sqrt_input_payload_roundMode;
+  wire                sqrt_input_valid;
+  wire                sqrt_input_ready;
+  wire       [22:0]   sqrt_input_payload_rs1_mantissa;
+  wire       [8:0]    sqrt_input_payload_rs1_exponent;
+  wire                sqrt_input_payload_rs1_sign;
+  wire                sqrt_input_payload_rs1_special;
+  wire       [4:0]    sqrt_input_payload_rd;
+  wire       [2:0]    sqrt_input_payload_roundMode;
   reg                 decode_sqrt_rValid;
-  wire                decode_sqrt_input_fire;
+  wire                sqrt_input_fire;
   reg        [22:0]   decode_sqrt_rData_rs1_mantissa;
   reg        [8:0]    decode_sqrt_rData_rs1_exponent;
   reg                 decode_sqrt_rData_rs1_sign;
   reg                 decode_sqrt_rData_rs1_special;
   reg        [4:0]    decode_sqrt_rData_rd;
-  reg        `FpuRoundMode_opt_type decode_sqrt_rData_roundMode;
+  reg        [2:0]    decode_sqrt_rData_roundMode;
   reg                 sqrt_haltIt;
-  wire                decode_sqrt_input_fire_1;
+  wire                sqrt_input_fire_1;
   wire                when_FpuCore_l221_3;
   reg                 sqrt_isCommited;
-  wire                _zz_decode_sqrt_input_ready;
+  wire                _zz_sqrt_input_ready;
   wire                sqrt_output_valid;
   wire                sqrt_output_ready;
   wire       [4:0]    sqrt_output_payload_rd;
@@ -8725,7 +8742,7 @@ module FpuCore (
   wire                sqrt_output_payload_value_sign;
   reg                 sqrt_output_payload_value_special;
   wire                sqrt_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type sqrt_output_payload_roundMode;
+  wire       [2:0]    sqrt_output_payload_roundMode;
   reg                 sqrt_output_payload_NV;
   wire                sqrt_output_payload_DZ;
   wire                sqrt_needShift;
@@ -8749,7 +8766,7 @@ module FpuCore (
   wire                add_preShifter_input_payload_rs2_sign;
   wire                add_preShifter_input_payload_rs2_special;
   wire       [4:0]    add_preShifter_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_preShifter_input_payload_roundMode;
+  wire       [2:0]    add_preShifter_input_payload_roundMode;
   wire                add_preShifter_input_payload_needCommit;
   wire                add_preShifter_output_valid;
   reg                 add_preShifter_output_ready;
@@ -8762,7 +8779,7 @@ module FpuCore (
   wire                add_preShifter_output_payload_rs2_sign;
   wire                add_preShifter_output_payload_rs2_special;
   wire       [4:0]    add_preShifter_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_preShifter_output_payload_roundMode;
+  wire       [2:0]    add_preShifter_output_payload_roundMode;
   wire                add_preShifter_output_payload_needCommit;
   wire                add_preShifter_output_payload_absRs1Bigger;
   wire                add_preShifter_output_payload_rs1ExponentBigger;
@@ -8771,21 +8788,21 @@ module FpuCore (
   wire                add_preShifter_rs1ExponentEqual;
   wire                add_preShifter_rs1MantissaBigger;
   wire                add_preShifter_absRs1Bigger;
-  wire                add_preShifter_output_input_valid;
-  wire                add_preShifter_output_input_ready;
-  wire       [24:0]   add_preShifter_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_preShifter_output_input_payload_rs1_exponent;
-  wire                add_preShifter_output_input_payload_rs1_sign;
-  wire                add_preShifter_output_input_payload_rs1_special;
-  wire       [24:0]   add_preShifter_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_preShifter_output_input_payload_rs2_exponent;
-  wire                add_preShifter_output_input_payload_rs2_sign;
-  wire                add_preShifter_output_input_payload_rs2_special;
-  wire       [4:0]    add_preShifter_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_preShifter_output_input_payload_roundMode;
-  wire                add_preShifter_output_input_payload_needCommit;
-  wire                add_preShifter_output_input_payload_absRs1Bigger;
-  wire                add_preShifter_output_input_payload_rs1ExponentBigger;
+  wire                add_shifter_input_valid;
+  wire                add_shifter_input_ready;
+  wire       [24:0]   add_shifter_input_payload_rs1_mantissa;
+  wire       [8:0]    add_shifter_input_payload_rs1_exponent;
+  wire                add_shifter_input_payload_rs1_sign;
+  wire                add_shifter_input_payload_rs1_special;
+  wire       [24:0]   add_shifter_input_payload_rs2_mantissa;
+  wire       [8:0]    add_shifter_input_payload_rs2_exponent;
+  wire                add_shifter_input_payload_rs2_sign;
+  wire                add_shifter_input_payload_rs2_special;
+  wire       [4:0]    add_shifter_input_payload_rd;
+  wire       [2:0]    add_shifter_input_payload_roundMode;
+  wire                add_shifter_input_payload_needCommit;
+  wire                add_shifter_input_payload_absRs1Bigger;
+  wire                add_shifter_input_payload_rs1ExponentBigger;
   reg                 add_preShifter_output_rValid;
   reg        [24:0]   add_preShifter_output_rData_rs1_mantissa;
   reg        [8:0]    add_preShifter_output_rData_rs1_exponent;
@@ -8796,11 +8813,11 @@ module FpuCore (
   reg                 add_preShifter_output_rData_rs2_sign;
   reg                 add_preShifter_output_rData_rs2_special;
   reg        [4:0]    add_preShifter_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_preShifter_output_rData_roundMode;
+  reg        [2:0]    add_preShifter_output_rData_roundMode;
   reg                 add_preShifter_output_rData_needCommit;
   reg                 add_preShifter_output_rData_absRs1Bigger;
   reg                 add_preShifter_output_rData_rs1ExponentBigger;
-  wire                when_Stream_l342_12;
+  wire                when_Stream_l368_12;
   wire                add_shifter_output_valid;
   reg                 add_shifter_output_ready;
   wire       [24:0]   add_shifter_output_payload_rs1_mantissa;
@@ -8812,7 +8829,7 @@ module FpuCore (
   wire                add_shifter_output_payload_rs2_sign;
   wire                add_shifter_output_payload_rs2_special;
   wire       [4:0]    add_shifter_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_shifter_output_payload_roundMode;
+  wire       [2:0]    add_shifter_output_payload_roundMode;
   wire                add_shifter_output_payload_needCommit;
   wire                add_shifter_output_payload_xSign;
   wire                add_shifter_output_payload_ySign;
@@ -8837,26 +8854,26 @@ module FpuCore (
   wire                when_FpuCore_l1419_3;
   wire                when_FpuCore_l1419_4;
   wire                when_FpuCore_l1424;
-  wire                add_shifter_output_input_valid;
-  wire                add_shifter_output_input_ready;
-  wire       [24:0]   add_shifter_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_shifter_output_input_payload_rs1_exponent;
-  wire                add_shifter_output_input_payload_rs1_sign;
-  wire                add_shifter_output_input_payload_rs1_special;
-  wire       [24:0]   add_shifter_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_shifter_output_input_payload_rs2_exponent;
-  wire                add_shifter_output_input_payload_rs2_sign;
-  wire                add_shifter_output_input_payload_rs2_special;
-  wire       [4:0]    add_shifter_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_shifter_output_input_payload_roundMode;
-  wire                add_shifter_output_input_payload_needCommit;
-  wire                add_shifter_output_input_payload_xSign;
-  wire                add_shifter_output_input_payload_ySign;
-  wire       [25:0]   add_shifter_output_input_payload_xMantissa;
-  wire       [25:0]   add_shifter_output_input_payload_yMantissa;
-  wire       [8:0]    add_shifter_output_input_payload_xyExponent;
-  wire                add_shifter_output_input_payload_xySign;
-  wire                add_shifter_output_input_payload_roundingScrap;
+  wire                add_math_input_valid;
+  wire                add_math_input_ready;
+  wire       [24:0]   add_math_input_payload_rs1_mantissa;
+  wire       [8:0]    add_math_input_payload_rs1_exponent;
+  wire                add_math_input_payload_rs1_sign;
+  wire                add_math_input_payload_rs1_special;
+  wire       [24:0]   add_math_input_payload_rs2_mantissa;
+  wire       [8:0]    add_math_input_payload_rs2_exponent;
+  wire                add_math_input_payload_rs2_sign;
+  wire                add_math_input_payload_rs2_special;
+  wire       [4:0]    add_math_input_payload_rd;
+  wire       [2:0]    add_math_input_payload_roundMode;
+  wire                add_math_input_payload_needCommit;
+  wire                add_math_input_payload_xSign;
+  wire                add_math_input_payload_ySign;
+  wire       [25:0]   add_math_input_payload_xMantissa;
+  wire       [25:0]   add_math_input_payload_yMantissa;
+  wire       [8:0]    add_math_input_payload_xyExponent;
+  wire                add_math_input_payload_xySign;
+  wire                add_math_input_payload_roundingScrap;
   reg                 add_shifter_output_rValid;
   reg        [24:0]   add_shifter_output_rData_rs1_mantissa;
   reg        [8:0]    add_shifter_output_rData_rs1_exponent;
@@ -8867,7 +8884,7 @@ module FpuCore (
   reg                 add_shifter_output_rData_rs2_sign;
   reg                 add_shifter_output_rData_rs2_special;
   reg        [4:0]    add_shifter_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_shifter_output_rData_roundMode;
+  reg        [2:0]    add_shifter_output_rData_roundMode;
   reg                 add_shifter_output_rData_needCommit;
   reg                 add_shifter_output_rData_xSign;
   reg                 add_shifter_output_rData_ySign;
@@ -8876,7 +8893,7 @@ module FpuCore (
   reg        [8:0]    add_shifter_output_rData_xyExponent;
   reg                 add_shifter_output_rData_xySign;
   reg                 add_shifter_output_rData_roundingScrap;
-  wire                when_Stream_l342_13;
+  wire                when_Stream_l368_13;
   wire                add_math_output_valid;
   reg                 add_math_output_ready;
   wire       [24:0]   add_math_output_payload_rs1_mantissa;
@@ -8888,7 +8905,7 @@ module FpuCore (
   wire                add_math_output_payload_rs2_sign;
   wire                add_math_output_payload_rs2_special;
   wire       [4:0]    add_math_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_math_output_payload_roundMode;
+  wire       [2:0]    add_math_output_payload_roundMode;
   wire                add_math_output_payload_needCommit;
   wire                add_math_output_payload_xSign;
   wire                add_math_output_payload_ySign;
@@ -8900,27 +8917,27 @@ module FpuCore (
   wire       [26:0]   add_math_output_payload_xyMantissa;
   wire       [26:0]   add_math_xSigned;
   wire       [26:0]   add_math_ySigned;
-  wire                add_math_output_input_valid;
-  wire                add_math_output_input_ready;
-  wire       [24:0]   add_math_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_math_output_input_payload_rs1_exponent;
-  wire                add_math_output_input_payload_rs1_sign;
-  wire                add_math_output_input_payload_rs1_special;
-  wire       [24:0]   add_math_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_math_output_input_payload_rs2_exponent;
-  wire                add_math_output_input_payload_rs2_sign;
-  wire                add_math_output_input_payload_rs2_special;
-  wire       [4:0]    add_math_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_math_output_input_payload_roundMode;
-  wire                add_math_output_input_payload_needCommit;
-  wire                add_math_output_input_payload_xSign;
-  wire                add_math_output_input_payload_ySign;
-  wire       [25:0]   add_math_output_input_payload_xMantissa;
-  wire       [25:0]   add_math_output_input_payload_yMantissa;
-  wire       [8:0]    add_math_output_input_payload_xyExponent;
-  wire                add_math_output_input_payload_xySign;
-  wire                add_math_output_input_payload_roundingScrap;
-  wire       [26:0]   add_math_output_input_payload_xyMantissa;
+  wire                add_oh_input_valid;
+  wire                add_oh_input_ready;
+  wire       [24:0]   add_oh_input_payload_rs1_mantissa;
+  wire       [8:0]    add_oh_input_payload_rs1_exponent;
+  wire                add_oh_input_payload_rs1_sign;
+  wire                add_oh_input_payload_rs1_special;
+  wire       [24:0]   add_oh_input_payload_rs2_mantissa;
+  wire       [8:0]    add_oh_input_payload_rs2_exponent;
+  wire                add_oh_input_payload_rs2_sign;
+  wire                add_oh_input_payload_rs2_special;
+  wire       [4:0]    add_oh_input_payload_rd;
+  wire       [2:0]    add_oh_input_payload_roundMode;
+  wire                add_oh_input_payload_needCommit;
+  wire                add_oh_input_payload_xSign;
+  wire                add_oh_input_payload_ySign;
+  wire       [25:0]   add_oh_input_payload_xMantissa;
+  wire       [25:0]   add_oh_input_payload_yMantissa;
+  wire       [8:0]    add_oh_input_payload_xyExponent;
+  wire                add_oh_input_payload_xySign;
+  wire                add_oh_input_payload_roundingScrap;
+  wire       [26:0]   add_oh_input_payload_xyMantissa;
   reg                 add_math_output_rValid;
   reg        [24:0]   add_math_output_rData_rs1_mantissa;
   reg        [8:0]    add_math_output_rData_rs1_exponent;
@@ -8931,7 +8948,7 @@ module FpuCore (
   reg                 add_math_output_rData_rs2_sign;
   reg                 add_math_output_rData_rs2_special;
   reg        [4:0]    add_math_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_math_output_rData_roundMode;
+  reg        [2:0]    add_math_output_rData_roundMode;
   reg                 add_math_output_rData_needCommit;
   reg                 add_math_output_rData_xSign;
   reg                 add_math_output_rData_ySign;
@@ -8941,11 +8958,11 @@ module FpuCore (
   reg                 add_math_output_rData_xySign;
   reg                 add_math_output_rData_roundingScrap;
   reg        [26:0]   add_math_output_rData_xyMantissa;
-  wire                when_Stream_l342_14;
-  wire                add_math_output_input_fire;
+  wire                when_Stream_l368_14;
+  wire                add_oh_input_fire;
   wire                when_FpuCore_l221_4;
   wire                add_oh_isCommited;
-  wire                _zz_add_math_output_input_ready;
+  wire                _zz_add_oh_input_ready;
   wire                add_oh_output_valid;
   reg                 add_oh_output_ready;
   wire       [24:0]   add_oh_output_payload_rs1_mantissa;
@@ -8957,7 +8974,7 @@ module FpuCore (
   wire                add_oh_output_payload_rs2_sign;
   wire                add_oh_output_payload_rs2_special;
   wire       [4:0]    add_oh_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_oh_output_payload_roundMode;
+  wire       [2:0]    add_oh_output_payload_roundMode;
   wire                add_oh_output_payload_needCommit;
   wire                add_oh_output_payload_xSign;
   wire                add_oh_output_payload_ySign;
@@ -8997,28 +9014,28 @@ module FpuCore (
   wire                _zz_add_oh_shift_26;
   wire                _zz_add_oh_shift_27;
   wire       [4:0]    add_oh_shift;
-  wire                add_oh_output_input_valid;
-  wire                add_oh_output_input_ready;
-  wire       [24:0]   add_oh_output_input_payload_rs1_mantissa;
-  wire       [8:0]    add_oh_output_input_payload_rs1_exponent;
-  wire                add_oh_output_input_payload_rs1_sign;
-  wire                add_oh_output_input_payload_rs1_special;
-  wire       [24:0]   add_oh_output_input_payload_rs2_mantissa;
-  wire       [8:0]    add_oh_output_input_payload_rs2_exponent;
-  wire                add_oh_output_input_payload_rs2_sign;
-  wire                add_oh_output_input_payload_rs2_special;
-  wire       [4:0]    add_oh_output_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_oh_output_input_payload_roundMode;
-  wire                add_oh_output_input_payload_needCommit;
-  wire                add_oh_output_input_payload_xSign;
-  wire                add_oh_output_input_payload_ySign;
-  wire       [25:0]   add_oh_output_input_payload_xMantissa;
-  wire       [25:0]   add_oh_output_input_payload_yMantissa;
-  wire       [8:0]    add_oh_output_input_payload_xyExponent;
-  wire                add_oh_output_input_payload_xySign;
-  wire                add_oh_output_input_payload_roundingScrap;
-  wire       [26:0]   add_oh_output_input_payload_xyMantissa;
-  wire       [4:0]    add_oh_output_input_payload_shift;
+  wire                add_norm_input_valid;
+  wire                add_norm_input_ready;
+  wire       [24:0]   add_norm_input_payload_rs1_mantissa;
+  wire       [8:0]    add_norm_input_payload_rs1_exponent;
+  wire                add_norm_input_payload_rs1_sign;
+  wire                add_norm_input_payload_rs1_special;
+  wire       [24:0]   add_norm_input_payload_rs2_mantissa;
+  wire       [8:0]    add_norm_input_payload_rs2_exponent;
+  wire                add_norm_input_payload_rs2_sign;
+  wire                add_norm_input_payload_rs2_special;
+  wire       [4:0]    add_norm_input_payload_rd;
+  wire       [2:0]    add_norm_input_payload_roundMode;
+  wire                add_norm_input_payload_needCommit;
+  wire                add_norm_input_payload_xSign;
+  wire                add_norm_input_payload_ySign;
+  wire       [25:0]   add_norm_input_payload_xMantissa;
+  wire       [25:0]   add_norm_input_payload_yMantissa;
+  wire       [8:0]    add_norm_input_payload_xyExponent;
+  wire                add_norm_input_payload_xySign;
+  wire                add_norm_input_payload_roundingScrap;
+  wire       [26:0]   add_norm_input_payload_xyMantissa;
+  wire       [4:0]    add_norm_input_payload_shift;
   reg                 add_oh_output_rValid;
   reg        [24:0]   add_oh_output_rData_rs1_mantissa;
   reg        [8:0]    add_oh_output_rData_rs1_exponent;
@@ -9029,7 +9046,7 @@ module FpuCore (
   reg                 add_oh_output_rData_rs2_sign;
   reg                 add_oh_output_rData_rs2_special;
   reg        [4:0]    add_oh_output_rData_rd;
-  reg        `FpuRoundMode_opt_type add_oh_output_rData_roundMode;
+  reg        [2:0]    add_oh_output_rData_roundMode;
   reg                 add_oh_output_rData_needCommit;
   reg                 add_oh_output_rData_xSign;
   reg                 add_oh_output_rData_ySign;
@@ -9040,7 +9057,7 @@ module FpuCore (
   reg                 add_oh_output_rData_roundingScrap;
   reg        [26:0]   add_oh_output_rData_xyMantissa;
   reg        [4:0]    add_oh_output_rData_shift;
-  wire                when_Stream_l342_15;
+  wire                when_Stream_l368_15;
   wire                add_norm_output_valid;
   wire                add_norm_output_ready;
   wire       [24:0]   add_norm_output_payload_rs1_mantissa;
@@ -9052,7 +9069,7 @@ module FpuCore (
   wire                add_norm_output_payload_rs2_sign;
   wire                add_norm_output_payload_rs2_special;
   wire       [4:0]    add_norm_output_payload_rd;
-  wire       `FpuRoundMode_opt_type add_norm_output_payload_roundMode;
+  wire       [2:0]    add_norm_output_payload_roundMode;
   wire                add_norm_output_payload_needCommit;
   wire       [26:0]   add_norm_output_payload_mantissa;
   wire       [9:0]    add_norm_output_payload_exponent;
@@ -9074,7 +9091,7 @@ module FpuCore (
   wire                add_result_input_payload_rs2_sign;
   wire                add_result_input_payload_rs2_special;
   wire       [4:0]    add_result_input_payload_rd;
-  wire       `FpuRoundMode_opt_type add_result_input_payload_roundMode;
+  wire       [2:0]    add_result_input_payload_roundMode;
   wire                add_result_input_payload_needCommit;
   wire       [26:0]   add_result_input_payload_mantissa;
   wire       [9:0]    add_result_input_payload_exponent;
@@ -9093,7 +9110,7 @@ module FpuCore (
   reg                 add_result_output_payload_value_sign;
   reg                 add_result_output_payload_value_special;
   wire                add_result_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type add_result_output_payload_roundMode;
+  wire       [2:0]    add_result_output_payload_roundMode;
   wire                add_result_output_payload_NV;
   wire                add_result_output_payload_DZ;
   wire                when_FpuCore_l1513;
@@ -9106,7 +9123,7 @@ module FpuCore (
   wire                load_s1_output_m2sPipe_payload_value_sign;
   wire                load_s1_output_m2sPipe_payload_value_special;
   wire                load_s1_output_m2sPipe_payload_scrap;
-  wire       `FpuRoundMode_opt_type load_s1_output_m2sPipe_payload_roundMode;
+  wire       [2:0]    load_s1_output_m2sPipe_payload_roundMode;
   wire                load_s1_output_m2sPipe_payload_NV;
   wire                load_s1_output_m2sPipe_payload_DZ;
   reg                 load_s1_output_rValid;
@@ -9116,10 +9133,10 @@ module FpuCore (
   reg                 load_s1_output_rData_value_sign;
   reg                 load_s1_output_rData_value_special;
   reg                 load_s1_output_rData_scrap;
-  reg        `FpuRoundMode_opt_type load_s1_output_rData_roundMode;
+  reg        [2:0]    load_s1_output_rData_roundMode;
   reg                 load_s1_output_rData_NV;
   reg                 load_s1_output_rData_DZ;
-  wire                when_Stream_l342_16;
+  wire                when_Stream_l368_16;
   wire                shortPip_output_m2sPipe_valid;
   wire                shortPip_output_m2sPipe_ready;
   wire       [4:0]    shortPip_output_m2sPipe_payload_rd;
@@ -9128,7 +9145,7 @@ module FpuCore (
   wire                shortPip_output_m2sPipe_payload_value_sign;
   wire                shortPip_output_m2sPipe_payload_value_special;
   wire                shortPip_output_m2sPipe_payload_scrap;
-  wire       `FpuRoundMode_opt_type shortPip_output_m2sPipe_payload_roundMode;
+  wire       [2:0]    shortPip_output_m2sPipe_payload_roundMode;
   wire                shortPip_output_m2sPipe_payload_NV;
   wire                shortPip_output_m2sPipe_payload_DZ;
   reg                 shortPip_output_rValid;
@@ -9138,10 +9155,10 @@ module FpuCore (
   reg                 shortPip_output_rData_value_sign;
   reg                 shortPip_output_rData_value_special;
   reg                 shortPip_output_rData_scrap;
-  reg        `FpuRoundMode_opt_type shortPip_output_rData_roundMode;
+  reg        [2:0]    shortPip_output_rData_roundMode;
   reg                 shortPip_output_rData_NV;
   reg                 shortPip_output_rData_DZ;
-  wire                when_Stream_l342_17;
+  wire                when_Stream_l368_17;
   wire                merge_arbitrated_valid;
   wire       [4:0]    merge_arbitrated_payload_rd;
   wire       [23:0]   merge_arbitrated_payload_value_mantissa;
@@ -9149,7 +9166,7 @@ module FpuCore (
   wire                merge_arbitrated_payload_value_sign;
   wire                merge_arbitrated_payload_value_special;
   wire                merge_arbitrated_payload_scrap;
-  wire       `FpuRoundMode_opt_type merge_arbitrated_payload_roundMode;
+  wire       [2:0]    merge_arbitrated_payload_roundMode;
   wire                merge_arbitrated_payload_NV;
   wire                merge_arbitrated_payload_DZ;
   reg                 roundFront_input_valid;
@@ -9159,7 +9176,7 @@ module FpuCore (
   reg                 roundFront_input_payload_value_sign;
   reg                 roundFront_input_payload_value_special;
   reg                 roundFront_input_payload_scrap;
-  reg        `FpuRoundMode_opt_type roundFront_input_payload_roundMode;
+  reg        [2:0]    roundFront_input_payload_roundMode;
   reg                 roundFront_input_payload_NV;
   reg                 roundFront_input_payload_DZ;
   wire                roundFront_output_valid;
@@ -9169,7 +9186,7 @@ module FpuCore (
   wire                roundFront_output_payload_value_sign;
   wire                roundFront_output_payload_value_special;
   wire                roundFront_output_payload_scrap;
-  wire       `FpuRoundMode_opt_type roundFront_output_payload_roundMode;
+  wire       [2:0]    roundFront_output_payload_roundMode;
   wire                roundFront_output_payload_NV;
   wire                roundFront_output_payload_DZ;
   wire                roundFront_output_payload_mantissaIncrement;
@@ -9191,7 +9208,7 @@ module FpuCore (
   reg                 roundBack_input_payload_value_sign;
   reg                 roundBack_input_payload_value_special;
   reg                 roundBack_input_payload_scrap;
-  reg        `FpuRoundMode_opt_type roundBack_input_payload_roundMode;
+  reg        [2:0]    roundBack_input_payload_roundMode;
   reg                 roundBack_input_payload_NV;
   reg                 roundBack_input_payload_DZ;
   reg                 roundBack_input_payload_mantissaIncrement;
@@ -9270,15 +9287,15 @@ module FpuCore (
   reg [63:0] _zz_payload_opcode_string;
   reg [63:0] _zz_commitLogic_0_input_payload_opcode_string;
   reg [63:0] commitLogic_0_input_payload_opcode_string;
-  reg [63:0] io_port_0_cmd_input_payload_opcode_string;
-  reg [47:0] io_port_0_cmd_input_payload_format_string;
-  reg [23:0] io_port_0_cmd_input_payload_roundMode_string;
+  reg [63:0] scheduler_0_input_payload_opcode_string;
+  reg [47:0] scheduler_0_input_payload_format_string;
+  reg [23:0] scheduler_0_input_payload_roundMode_string;
   reg [63:0] io_port_0_cmd_rData_opcode_string;
   reg [47:0] io_port_0_cmd_rData_format_string;
   reg [23:0] io_port_0_cmd_rData_roundMode_string;
-  reg [63:0] _zz_io_port_0_cmd_input_payload_opcode_string;
-  reg [47:0] _zz_io_port_0_cmd_input_payload_format_string;
-  reg [23:0] _zz_io_port_0_cmd_input_payload_roundMode_string;
+  reg [63:0] _zz_scheduler_0_input_payload_opcode_string;
+  reg [47:0] _zz_scheduler_0_input_payload_format_string;
+  reg [23:0] _zz_scheduler_0_input_payload_roundMode_string;
   reg [63:0] scheduler_0_output_payload_opcode_string;
   reg [47:0] scheduler_0_output_payload_format_string;
   reg [23:0] scheduler_0_output_payload_roundMode_string;
@@ -9289,8 +9306,8 @@ module FpuCore (
   reg [23:0] cmdArbiter_output_payload_roundMode_string;
   reg [63:0] read_s0_payload_opcode_string;
   reg [23:0] read_s0_payload_roundMode_string;
-  reg [63:0] read_s0_s1_payload_opcode_string;
-  reg [23:0] read_s0_s1_payload_roundMode_string;
+  reg [63:0] read_s1_payload_opcode_string;
+  reg [23:0] read_s1_payload_roundMode_string;
   reg [63:0] read_s0_rData_opcode_string;
   reg [23:0] read_s0_rData_roundMode_string;
   reg [63:0] read_output_payload_opcode_string;
@@ -9312,55 +9329,55 @@ module FpuCore (
   reg [23:0] _zz_decode_load_s2mPipe_payload_roundMode_string;
   reg [23:0] decode_load_s2mPipe_m2sPipe_payload_roundMode_string;
   reg [23:0] decode_load_s2mPipe_rData_roundMode_string;
-  reg [23:0] decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string;
+  reg [23:0] load_s0_input_payload_roundMode_string;
   reg [23:0] decode_load_s2mPipe_m2sPipe_rData_roundMode_string;
   reg [63:0] load_s0_filtred_0_payload_opcode_string;
   reg [23:0] load_s0_output_payload_roundMode_string;
-  reg [23:0] load_s0_output_input_payload_roundMode_string;
+  reg [23:0] load_s1_input_payload_roundMode_string;
   reg [23:0] load_s0_output_rData_roundMode_string;
   reg [23:0] load_s1_output_payload_roundMode_string;
-  reg [63:0] decode_shortPip_input_payload_opcode_string;
-  reg [23:0] decode_shortPip_input_payload_roundMode_string;
+  reg [63:0] shortPip_input_payload_opcode_string;
+  reg [23:0] shortPip_input_payload_roundMode_string;
   reg [63:0] decode_shortPip_rData_opcode_string;
   reg [23:0] decode_shortPip_rData_roundMode_string;
   reg [23:0] shortPip_rfOutput_payload_roundMode_string;
   reg [23:0] shortPip_output_payload_roundMode_string;
-  reg [23:0] decode_mul_input_payload_roundMode_string;
+  reg [23:0] mul_preMul_input_payload_roundMode_string;
   reg [23:0] decode_mul_rData_roundMode_string;
   reg [23:0] mul_preMul_output_payload_roundMode_string;
-  reg [23:0] mul_preMul_output_input_payload_roundMode_string;
+  reg [23:0] mul_mul_input_payload_roundMode_string;
   reg [23:0] mul_preMul_output_rData_roundMode_string;
   reg [23:0] mul_mul_output_payload_roundMode_string;
-  reg [23:0] mul_mul_output_input_payload_roundMode_string;
+  reg [23:0] mul_sum1_input_payload_roundMode_string;
   reg [23:0] mul_mul_output_rData_roundMode_string;
   reg [23:0] mul_sum1_output_payload_roundMode_string;
-  reg [23:0] mul_sum1_output_input_payload_roundMode_string;
+  reg [23:0] mul_sum2_input_payload_roundMode_string;
   reg [23:0] mul_sum1_output_rData_roundMode_string;
   reg [23:0] mul_sum2_output_payload_roundMode_string;
-  reg [23:0] mul_sum2_output_input_payload_roundMode_string;
+  reg [23:0] mul_norm_input_payload_roundMode_string;
   reg [23:0] mul_sum2_output_rData_roundMode_string;
   reg [23:0] mul_result_output_payload_roundMode_string;
   reg [23:0] mul_result_mulToAdd_payload_roundMode_string;
   reg [23:0] mul_result_mulToAdd_m2sPipe_payload_roundMode_string;
   reg [23:0] mul_result_mulToAdd_rData_roundMode_string;
-  reg [23:0] decode_div_input_payload_roundMode_string;
+  reg [23:0] div_input_payload_roundMode_string;
   reg [23:0] decode_div_rData_roundMode_string;
   reg [23:0] div_output_payload_roundMode_string;
-  reg [23:0] decode_sqrt_input_payload_roundMode_string;
+  reg [23:0] sqrt_input_payload_roundMode_string;
   reg [23:0] decode_sqrt_rData_roundMode_string;
   reg [23:0] sqrt_output_payload_roundMode_string;
   reg [23:0] add_preShifter_input_payload_roundMode_string;
   reg [23:0] add_preShifter_output_payload_roundMode_string;
-  reg [23:0] add_preShifter_output_input_payload_roundMode_string;
+  reg [23:0] add_shifter_input_payload_roundMode_string;
   reg [23:0] add_preShifter_output_rData_roundMode_string;
   reg [23:0] add_shifter_output_payload_roundMode_string;
-  reg [23:0] add_shifter_output_input_payload_roundMode_string;
+  reg [23:0] add_math_input_payload_roundMode_string;
   reg [23:0] add_shifter_output_rData_roundMode_string;
   reg [23:0] add_math_output_payload_roundMode_string;
-  reg [23:0] add_math_output_input_payload_roundMode_string;
+  reg [23:0] add_oh_input_payload_roundMode_string;
   reg [23:0] add_math_output_rData_roundMode_string;
   reg [23:0] add_oh_output_payload_roundMode_string;
-  reg [23:0] add_oh_output_input_payload_roundMode_string;
+  reg [23:0] add_norm_input_payload_roundMode_string;
   reg [23:0] add_oh_output_rData_roundMode_string;
   reg [23:0] add_norm_output_payload_roundMode_string;
   reg [23:0] add_result_input_payload_roundMode_string;
@@ -9375,7 +9392,7 @@ module FpuCore (
   reg [23:0] roundBack_input_payload_roundMode_string;
   `endif
 
-  (* ram_style = "block" *) reg [33:0] rf_ram [0:31];
+  (* no_rw_check , ram_style = "block" *) reg [33:0] rf_ram [0:31];
   (* ram_style = "distributed" *) reg [0:0] rf_scoreboards_0_target [0:31];
   (* ram_style = "distributed" *) reg [0:0] rf_scoreboards_0_hit [0:31];
   (* ram_style = "distributed" *) reg [0:0] rf_scoreboards_0_writes [0:31];
@@ -9426,7 +9443,7 @@ module FpuCore (
   assign _zz_load_s1_recoded_exponent_1 = ({1'b0,load_s1_passThroughFloat_exponent} - {1'b0,load_s1_fsm_expOffset});
   assign _zz_load_s1_recoded_exponent_2 = {1'd0, load_s1_recodedExpOffset};
   assign _zz_load_s1_output_payload_value_exponent = {4'd0, load_s1_fsm_shift_by};
-  assign _zz_shortPip_f32_exp = (decode_shortPip_input_payload_rs1_exponent - 9'h080);
+  assign _zz_shortPip_f32_exp = (shortPip_input_payload_rs1_exponent - 9'h080);
   assign _zz_shortPip_expInSubnormalRange = {1'd0, shortPip_expSubnormalThreshold};
   assign _zz_shortPip_fsm_shift_input_1 = (shortPip_fsm_shift_input >>> 6'h20);
   assign _zz_shortPip_fsm_shift_input_2 = (shortPip_fsm_shift_input_1 >>> 5'h10);
@@ -9437,17 +9454,17 @@ module FpuCore (
   assign _zz_shortPip_fsm_shift_by_2 = (((_zz_shortPip_fsm_shift_by < _zz_shortPip_fsm_shift_by_3) ? _zz_shortPip_fsm_shift_by : _zz_shortPip_fsm_shift_by_4) + 9'h0);
   assign _zz_shortPip_fsm_shift_by_3 = {3'd0, _zz_shortPip_fsm_shift_by_1};
   assign _zz_shortPip_fsm_shift_by_4 = {3'd0, _zz_shortPip_fsm_shift_by_1};
-  assign _zz_shortPip_fsm_shift_by_5 = (_zz_shortPip_fsm_shift_by_6 - decode_shortPip_input_payload_rs1_exponent);
+  assign _zz_shortPip_fsm_shift_by_5 = (_zz_shortPip_fsm_shift_by_6 - shortPip_input_payload_rs1_exponent);
   assign _zz_shortPip_fsm_shift_by_6 = {1'd0, shortPip_fsm_formatShiftOffset};
   assign _zz_shortPip_f2i_result_1 = (shortPip_f2i_resign ^ shortPip_f2i_increment);
   assign _zz_shortPip_f2i_result = {31'd0, _zz_shortPip_f2i_result_1};
-  assign _zz_mul_sum1_sum = {12'd0, mul_mul_output_input_payload_muls_0};
-  assign _zz_mul_sum1_sum_2 = ({18'd0,mul_mul_output_input_payload_muls_1} <<< 18);
+  assign _zz_mul_sum1_sum = {12'd0, mul_sum1_input_payload_muls_0};
+  assign _zz_mul_sum1_sum_2 = ({18'd0,mul_sum1_input_payload_muls_1} <<< 18);
   assign _zz_mul_sum1_sum_1 = {6'd0, _zz_mul_sum1_sum_2};
   assign _zz_mul_sum2_sum = (_zz_mul_sum2_sum_1 + _zz_mul_sum2_sum_3);
-  assign _zz_mul_sum2_sum_2 = ({18'd0,mul_sum1_output_input_payload_muls2_0} <<< 18);
+  assign _zz_mul_sum2_sum_2 = ({18'd0,mul_sum2_input_payload_muls2_0} <<< 18);
   assign _zz_mul_sum2_sum_1 = {6'd0, _zz_mul_sum2_sum_2};
-  assign _zz_mul_sum2_sum_4 = ({36'd0,mul_sum1_output_input_payload_muls2_1} <<< 36);
+  assign _zz_mul_sum2_sum_4 = ({36'd0,mul_sum2_input_payload_muls2_1} <<< 36);
   assign _zz_mul_sum2_sum_3 = _zz_mul_sum2_sum_4;
   assign _zz_mul_norm_exp_1 = mul_norm_needShift;
   assign _zz_mul_norm_exp = {9'd0, _zz_mul_norm_exp_1};
@@ -9455,15 +9472,15 @@ module FpuCore (
   assign _zz_mul_norm_output_exponent = (mul_norm_exp - 10'h0ff);
   assign _zz_div_exponent = (_zz_div_exponent_1 - _zz_div_exponent_3);
   assign _zz_div_exponent_1 = (_zz_div_exponent_2 + 11'h4ff);
-  assign _zz_div_exponent_2 = {2'd0, decode_div_input_payload_rs1_exponent};
-  assign _zz_div_exponent_3 = {2'd0, decode_div_input_payload_rs2_exponent};
+  assign _zz_div_exponent_2 = {2'd0, div_input_payload_rs1_exponent};
+  assign _zz_div_exponent_3 = {2'd0, div_input_payload_rs2_exponent};
   assign _zz_div_exponent_5 = div_needShift;
   assign _zz_div_exponent_4 = {10'd0, _zz_div_exponent_5};
   assign _zz_sqrt_exponent = (_zz_sqrt_exponent_1 + {1'b0,_zz_sqrt_exponent_3});
   assign _zz_sqrt_exponent_2 = {1'b0,7'h7f};
   assign _zz_sqrt_exponent_1 = {1'd0, _zz_sqrt_exponent_2};
-  assign _zz_sqrt_exponent_3 = (decode_sqrt_input_payload_rs1_exponent >>> 1);
-  assign _zz_sqrt_exponent_5 = decode_sqrt_input_payload_rs1_exponent[0];
+  assign _zz_sqrt_exponent_3 = (sqrt_input_payload_rs1_exponent >>> 1);
+  assign _zz_sqrt_exponent_5 = sqrt_input_payload_rs1_exponent[0];
   assign _zz_sqrt_exponent_4 = {8'd0, _zz_sqrt_exponent_5};
   assign _zz_add_shifter_shiftBy_1 = (_zz_add_shifter_shiftBy[9] ? _zz_add_shifter_shiftBy_2 : _zz_add_shifter_shiftBy);
   assign _zz_add_shifter_shiftBy_2 = (~ _zz_add_shifter_shiftBy);
@@ -9474,19 +9491,19 @@ module FpuCore (
   assign _zz_add_shifter_yMantissa_3 = (add_shifter_yMantissa_2 >>> 3'b100);
   assign _zz_add_shifter_yMantissa_4 = (add_shifter_yMantissa_3 >>> 2'b10);
   assign _zz_add_shifter_yMantissa_5 = (add_shifter_yMantissa_4 >>> 1'b1);
-  assign _zz_add_math_xSigned = ({add_shifter_output_input_payload_xSign,(add_shifter_output_input_payload_xSign ? (~ add_shifter_output_input_payload_xMantissa) : add_shifter_output_input_payload_xMantissa)} + _zz_add_math_xSigned_1);
-  assign _zz_add_math_xSigned_2 = add_shifter_output_input_payload_xSign;
+  assign _zz_add_math_xSigned = ({add_math_input_payload_xSign,(add_math_input_payload_xSign ? (~ add_math_input_payload_xMantissa) : add_math_input_payload_xMantissa)} + _zz_add_math_xSigned_1);
+  assign _zz_add_math_xSigned_2 = add_math_input_payload_xSign;
   assign _zz_add_math_xSigned_1 = {26'd0, _zz_add_math_xSigned_2};
-  assign _zz_add_math_ySigned = ({add_shifter_output_input_payload_ySign,(add_shifter_output_input_payload_ySign ? (~ add_shifter_output_input_payload_yMantissa) : add_shifter_output_input_payload_yMantissa)} + _zz_add_math_ySigned_1);
-  assign _zz_add_math_ySigned_2 = (add_shifter_output_input_payload_ySign && (! add_shifter_output_input_payload_roundingScrap));
+  assign _zz_add_math_ySigned = ({add_math_input_payload_ySign,(add_math_input_payload_ySign ? (~ add_math_input_payload_yMantissa) : add_math_input_payload_yMantissa)} + _zz_add_math_ySigned_1);
+  assign _zz_add_math_ySigned_2 = (add_math_input_payload_ySign && (! add_math_input_payload_roundingScrap));
   assign _zz_add_math_ySigned_1 = {26'd0, _zz_add_math_ySigned_2};
   assign _zz_add_math_output_payload_xyMantissa = _zz_add_math_output_payload_xyMantissa_1;
   assign _zz_add_math_output_payload_xyMantissa_1 = ($signed(_zz_add_math_output_payload_xyMantissa_2) + $signed(_zz_add_math_output_payload_xyMantissa_3));
   assign _zz_add_math_output_payload_xyMantissa_2 = {add_math_xSigned[26],add_math_xSigned};
   assign _zz_add_math_output_payload_xyMantissa_3 = {add_math_ySigned[26],add_math_ySigned};
   assign _zz__zz_add_oh_shift_1_1 = (_zz_add_oh_shift - 27'h0000001);
-  assign _zz_add_norm_output_payload_exponent = ({1'b0,add_oh_output_input_payload_xyExponent} - _zz_add_norm_output_payload_exponent_1);
-  assign _zz_add_norm_output_payload_exponent_2 = {1'b0,add_oh_output_input_payload_shift};
+  assign _zz_add_norm_output_payload_exponent = ({1'b0,add_norm_input_payload_xyExponent} - _zz_add_norm_output_payload_exponent_1);
+  assign _zz_add_norm_output_payload_exponent_2 = {1'b0,add_norm_input_payload_shift};
   assign _zz_add_norm_output_payload_exponent_1 = {4'd0, _zz_add_norm_output_payload_exponent_2};
   assign _zz_add_result_output_payload_value_mantissa = (add_result_input_payload_mantissa >>> 2);
   assign _zz_roundFront_expDif_1 = {1'b0,roundFront_expBase};
@@ -9509,10 +9526,10 @@ module FpuCore (
   assign _zz_rf_scoreboards_0_target_port = rf_scoreboards_0_targetWrite_payload_data;
   assign _zz_rf_scoreboards_0_hit_port = rf_scoreboards_0_hitWrite_payload_data;
   assign _zz_rf_scoreboards_0_writes_port = commitLogic_0_input_payload_write;
-  assign _zz_decode_shortPipHit = `FpuOpcode_binary_sequential_MIN_MAX;
-  assign _zz_decode_shortPipHit_1 = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_CMP);
-  assign _zz_decode_shortPipHit_2 = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_F2I);
-  assign _zz_decode_shortPipHit_3 = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_STORE);
+  assign _zz_decode_shortPipHit = FpuOpcode_MIN_MAX;
+  assign _zz_decode_shortPipHit_1 = (decode_input_payload_opcode == FpuOpcode_CMP);
+  assign _zz_decode_shortPipHit_2 = (decode_input_payload_opcode == FpuOpcode_F2I);
+  assign _zz_decode_shortPipHit_3 = (decode_input_payload_opcode == FpuOpcode_STORE);
   assign _zz__zz_load_s1_fsm_shift_by = load_s1_fsm_ohInput[9];
   assign _zz__zz_load_s1_fsm_shift_by_1 = load_s1_fsm_ohInput[10];
   assign _zz__zz_load_s1_fsm_shift_by_2 = {load_s1_fsm_ohInput[11],{load_s1_fsm_ohInput[12],{load_s1_fsm_ohInput[13],{load_s1_fsm_ohInput[14],{load_s1_fsm_ohInput[15],{load_s1_fsm_ohInput[16],{load_s1_fsm_ohInput[17],{load_s1_fsm_ohInput[18],{load_s1_fsm_ohInput[19],{_zz__zz_load_s1_fsm_shift_by_3,{_zz__zz_load_s1_fsm_shift_by_4,_zz__zz_load_s1_fsm_shift_by_5}}}}}}}}}}};
@@ -9567,20 +9584,20 @@ module FpuCore (
     end
   end
 
-  assign _zz_rf_scoreboards_0_target_port1 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rs1];
-  assign _zz_rf_scoreboards_0_target_port2 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rs2];
-  assign _zz_rf_scoreboards_0_target_port3 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rs3];
-  assign _zz_rf_scoreboards_0_target_port4 = rf_scoreboards_0_target[io_port_0_cmd_input_payload_rd];
+  assign _zz_rf_scoreboards_0_target_port1 = rf_scoreboards_0_target[scheduler_0_input_payload_rs1];
+  assign _zz_rf_scoreboards_0_target_port2 = rf_scoreboards_0_target[scheduler_0_input_payload_rs2];
+  assign _zz_rf_scoreboards_0_target_port3 = rf_scoreboards_0_target[scheduler_0_input_payload_rs3];
+  assign _zz_rf_scoreboards_0_target_port4 = rf_scoreboards_0_target[scheduler_0_input_payload_rd];
   always @(posedge clk) begin
     if(_zz_3) begin
       rf_scoreboards_0_hit[rf_scoreboards_0_hitWrite_payload_address] <= _zz_rf_scoreboards_0_hit_port;
     end
   end
 
-  assign _zz_rf_scoreboards_0_hit_port1 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rs1];
-  assign _zz_rf_scoreboards_0_hit_port2 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rs2];
-  assign _zz_rf_scoreboards_0_hit_port3 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rs3];
-  assign _zz_rf_scoreboards_0_hit_port4 = rf_scoreboards_0_hit[io_port_0_cmd_input_payload_rd];
+  assign _zz_rf_scoreboards_0_hit_port1 = rf_scoreboards_0_hit[scheduler_0_input_payload_rs1];
+  assign _zz_rf_scoreboards_0_hit_port2 = rf_scoreboards_0_hit[scheduler_0_input_payload_rs2];
+  assign _zz_rf_scoreboards_0_hit_port3 = rf_scoreboards_0_hit[scheduler_0_input_payload_rs3];
+  assign _zz_rf_scoreboards_0_hit_port4 = rf_scoreboards_0_hit[scheduler_0_input_payload_rd];
   assign _zz_rf_scoreboards_0_hit_port5 = rf_scoreboards_0_hit[writeback_input_payload_rd];
   always @(posedge clk) begin
     if(_zz_2) begin
@@ -9590,1540 +9607,1540 @@ module FpuCore (
 
   assign _zz_rf_scoreboards_0_writes_port1 = rf_scoreboards_0_writes[roundBack_input_payload_rd];
   StreamFork streamFork_1 (
-    .io_input_valid                 (io_port_0_commit_valid                    ), //i
-    .io_input_ready                 (streamFork_1_io_input_ready               ), //o
-    .io_input_payload_opcode        (io_port_0_commit_payload_opcode           ), //i
-    .io_input_payload_rd            (io_port_0_commit_payload_rd               ), //i
-    .io_input_payload_write         (io_port_0_commit_payload_write            ), //i
-    .io_input_payload_value         (io_port_0_commit_payload_value            ), //i
-    .io_outputs_0_valid             (streamFork_1_io_outputs_0_valid           ), //o
-    .io_outputs_0_ready             (commitFork_load_0_ready                   ), //i
-    .io_outputs_0_payload_opcode    (streamFork_1_io_outputs_0_payload_opcode  ), //o
-    .io_outputs_0_payload_rd        (streamFork_1_io_outputs_0_payload_rd      ), //o
-    .io_outputs_0_payload_write     (streamFork_1_io_outputs_0_payload_write   ), //o
-    .io_outputs_0_payload_value     (streamFork_1_io_outputs_0_payload_value   ), //o
-    .io_outputs_1_valid             (streamFork_1_io_outputs_1_valid           ), //o
-    .io_outputs_1_ready             (streamFork_1_io_outputs_1_ready           ), //i
-    .io_outputs_1_payload_opcode    (streamFork_1_io_outputs_1_payload_opcode  ), //o
-    .io_outputs_1_payload_rd        (streamFork_1_io_outputs_1_payload_rd      ), //o
-    .io_outputs_1_payload_write     (streamFork_1_io_outputs_1_payload_write   ), //o
-    .io_outputs_1_payload_value     (streamFork_1_io_outputs_1_payload_value   )  //o
+    .io_input_valid              (io_port_0_commit_valid                       ), //i
+    .io_input_ready              (streamFork_1_io_input_ready                  ), //o
+    .io_input_payload_opcode     (io_port_0_commit_payload_opcode[3:0]         ), //i
+    .io_input_payload_rd         (io_port_0_commit_payload_rd[4:0]             ), //i
+    .io_input_payload_write      (io_port_0_commit_payload_write               ), //i
+    .io_input_payload_value      (io_port_0_commit_payload_value[31:0]         ), //i
+    .io_outputs_0_valid          (streamFork_1_io_outputs_0_valid              ), //o
+    .io_outputs_0_ready          (commitFork_load_0_ready                      ), //i
+    .io_outputs_0_payload_opcode (streamFork_1_io_outputs_0_payload_opcode[3:0]), //o
+    .io_outputs_0_payload_rd     (streamFork_1_io_outputs_0_payload_rd[4:0]    ), //o
+    .io_outputs_0_payload_write  (streamFork_1_io_outputs_0_payload_write      ), //o
+    .io_outputs_0_payload_value  (streamFork_1_io_outputs_0_payload_value[31:0]), //o
+    .io_outputs_1_valid          (streamFork_1_io_outputs_1_valid              ), //o
+    .io_outputs_1_ready          (streamFork_1_io_outputs_1_ready              ), //i
+    .io_outputs_1_payload_opcode (streamFork_1_io_outputs_1_payload_opcode[3:0]), //o
+    .io_outputs_1_payload_rd     (streamFork_1_io_outputs_1_payload_rd[4:0]    ), //o
+    .io_outputs_1_payload_write  (streamFork_1_io_outputs_1_payload_write      ), //o
+    .io_outputs_1_payload_value  (streamFork_1_io_outputs_1_payload_value[31:0])  //o
   );
   StreamArbiter cmdArbiter_arbiter (
-    .io_inputs_0_valid                (scheduler_0_output_valid                        ), //i
-    .io_inputs_0_ready                (cmdArbiter_arbiter_io_inputs_0_ready            ), //o
-    .io_inputs_0_payload_opcode       (_zz_io_inputs_0_payload_opcode                  ), //i
-    .io_inputs_0_payload_arg          (scheduler_0_output_payload_arg                  ), //i
-    .io_inputs_0_payload_rs1          (scheduler_0_output_payload_rs1                  ), //i
-    .io_inputs_0_payload_rs2          (scheduler_0_output_payload_rs2                  ), //i
-    .io_inputs_0_payload_rs3          (scheduler_0_output_payload_rs3                  ), //i
-    .io_inputs_0_payload_rd           (scheduler_0_output_payload_rd                   ), //i
-    .io_inputs_0_payload_format       (_zz_io_inputs_0_payload_format                  ), //i
-    .io_inputs_0_payload_roundMode    (_zz_io_inputs_0_payload_roundMode               ), //i
-    .io_output_valid                  (cmdArbiter_arbiter_io_output_valid              ), //o
-    .io_output_ready                  (cmdArbiter_output_ready                         ), //i
-    .io_output_payload_opcode         (cmdArbiter_arbiter_io_output_payload_opcode     ), //o
-    .io_output_payload_arg            (cmdArbiter_arbiter_io_output_payload_arg        ), //o
-    .io_output_payload_rs1            (cmdArbiter_arbiter_io_output_payload_rs1        ), //o
-    .io_output_payload_rs2            (cmdArbiter_arbiter_io_output_payload_rs2        ), //o
-    .io_output_payload_rs3            (cmdArbiter_arbiter_io_output_payload_rs3        ), //o
-    .io_output_payload_rd             (cmdArbiter_arbiter_io_output_payload_rd         ), //o
-    .io_output_payload_format         (cmdArbiter_arbiter_io_output_payload_format     ), //o
-    .io_output_payload_roundMode      (cmdArbiter_arbiter_io_output_payload_roundMode  ), //o
-    .io_chosenOH                      (cmdArbiter_arbiter_io_chosenOH                  ), //o
-    .clk                              (clk                                             ), //i
-    .reset                            (reset                                           )  //i
+    .io_inputs_0_valid             (scheduler_0_output_valid                           ), //i
+    .io_inputs_0_ready             (cmdArbiter_arbiter_io_inputs_0_ready               ), //o
+    .io_inputs_0_payload_opcode    (_zz_io_inputs_0_payload_opcode[3:0]                ), //i
+    .io_inputs_0_payload_arg       (scheduler_0_output_payload_arg[1:0]                ), //i
+    .io_inputs_0_payload_rs1       (scheduler_0_output_payload_rs1[4:0]                ), //i
+    .io_inputs_0_payload_rs2       (scheduler_0_output_payload_rs2[4:0]                ), //i
+    .io_inputs_0_payload_rs3       (scheduler_0_output_payload_rs3[4:0]                ), //i
+    .io_inputs_0_payload_rd        (scheduler_0_output_payload_rd[4:0]                 ), //i
+    .io_inputs_0_payload_format    (_zz_io_inputs_0_payload_format                     ), //i
+    .io_inputs_0_payload_roundMode (_zz_io_inputs_0_payload_roundMode[2:0]             ), //i
+    .io_output_valid               (cmdArbiter_arbiter_io_output_valid                 ), //o
+    .io_output_ready               (cmdArbiter_output_ready                            ), //i
+    .io_output_payload_opcode      (cmdArbiter_arbiter_io_output_payload_opcode[3:0]   ), //o
+    .io_output_payload_arg         (cmdArbiter_arbiter_io_output_payload_arg[1:0]      ), //o
+    .io_output_payload_rs1         (cmdArbiter_arbiter_io_output_payload_rs1[4:0]      ), //o
+    .io_output_payload_rs2         (cmdArbiter_arbiter_io_output_payload_rs2[4:0]      ), //o
+    .io_output_payload_rs3         (cmdArbiter_arbiter_io_output_payload_rs3[4:0]      ), //o
+    .io_output_payload_rd          (cmdArbiter_arbiter_io_output_payload_rd[4:0]       ), //o
+    .io_output_payload_format      (cmdArbiter_arbiter_io_output_payload_format        ), //o
+    .io_output_payload_roundMode   (cmdArbiter_arbiter_io_output_payload_roundMode[2:0]), //o
+    .io_chosenOH                   (cmdArbiter_arbiter_io_chosenOH                     ), //o
+    .clk                           (clk                                                ), //i
+    .reset                         (reset                                              )  //i
   );
   FpuDiv div_divider (
-    .io_input_valid              (div_divider_io_input_valid            ), //i
-    .io_input_ready              (div_divider_io_input_ready            ), //o
-    .io_input_payload_a          (div_divider_io_input_payload_a        ), //i
-    .io_input_payload_b          (div_divider_io_input_payload_b        ), //i
-    .io_output_valid             (div_divider_io_output_valid           ), //o
-    .io_output_ready             (decode_div_input_ready                ), //i
-    .io_output_payload_result    (div_divider_io_output_payload_result  ), //o
-    .io_output_payload_remain    (div_divider_io_output_payload_remain  ), //o
-    .clk                         (clk                                   ), //i
-    .reset                       (reset                                 )  //i
+    .io_input_valid           (div_divider_io_input_valid                ), //i
+    .io_input_ready           (div_divider_io_input_ready                ), //o
+    .io_input_payload_a       (div_divider_io_input_payload_a[23:0]      ), //i
+    .io_input_payload_b       (div_divider_io_input_payload_b[23:0]      ), //i
+    .io_output_valid          (div_divider_io_output_valid               ), //o
+    .io_output_ready          (div_input_ready                           ), //i
+    .io_output_payload_result (div_divider_io_output_payload_result[26:0]), //o
+    .io_output_payload_remain (div_divider_io_output_payload_remain[24:0]), //o
+    .clk                      (clk                                       ), //i
+    .reset                    (reset                                     )  //i
   );
   FpuSqrt sqrt_sqrt (
-    .io_input_valid              (sqrt_sqrt_io_input_valid            ), //i
-    .io_input_ready              (sqrt_sqrt_io_input_ready            ), //o
-    .io_input_payload_a          (sqrt_sqrt_io_input_payload_a        ), //i
-    .io_output_valid             (sqrt_sqrt_io_output_valid           ), //o
-    .io_output_ready             (decode_sqrt_input_ready             ), //i
-    .io_output_payload_result    (sqrt_sqrt_io_output_payload_result  ), //o
-    .io_output_payload_remain    (sqrt_sqrt_io_output_payload_remain  ), //o
-    .clk                         (clk                                 ), //i
-    .reset                       (reset                               )  //i
+    .io_input_valid           (sqrt_sqrt_io_input_valid                ), //i
+    .io_input_ready           (sqrt_sqrt_io_input_ready                ), //o
+    .io_input_payload_a       (sqrt_sqrt_io_input_payload_a[24:0]      ), //i
+    .io_output_valid          (sqrt_sqrt_io_output_valid               ), //o
+    .io_output_ready          (sqrt_input_ready                        ), //i
+    .io_output_payload_result (sqrt_sqrt_io_output_payload_result[23:0]), //o
+    .io_output_payload_remain (sqrt_sqrt_io_output_payload_remain[27:0]), //o
+    .clk                      (clk                                     ), //i
+    .reset                    (reset                                   )  //i
   );
   StreamArbiter_1 streamArbiter_2 (
-    .io_inputs_0_valid                     (load_s1_output_m2sPipe_valid                      ), //i
-    .io_inputs_0_ready                     (streamArbiter_2_io_inputs_0_ready                 ), //o
-    .io_inputs_0_payload_rd                (load_s1_output_m2sPipe_payload_rd                 ), //i
-    .io_inputs_0_payload_value_mantissa    (load_s1_output_m2sPipe_payload_value_mantissa     ), //i
-    .io_inputs_0_payload_value_exponent    (load_s1_output_m2sPipe_payload_value_exponent     ), //i
-    .io_inputs_0_payload_value_sign        (load_s1_output_m2sPipe_payload_value_sign         ), //i
-    .io_inputs_0_payload_value_special     (load_s1_output_m2sPipe_payload_value_special      ), //i
-    .io_inputs_0_payload_scrap             (load_s1_output_m2sPipe_payload_scrap              ), //i
-    .io_inputs_0_payload_roundMode         (load_s1_output_m2sPipe_payload_roundMode          ), //i
-    .io_inputs_0_payload_NV                (load_s1_output_m2sPipe_payload_NV                 ), //i
-    .io_inputs_0_payload_DZ                (load_s1_output_m2sPipe_payload_DZ                 ), //i
-    .io_inputs_1_valid                     (sqrt_output_valid                                 ), //i
-    .io_inputs_1_ready                     (streamArbiter_2_io_inputs_1_ready                 ), //o
-    .io_inputs_1_payload_rd                (sqrt_output_payload_rd                            ), //i
-    .io_inputs_1_payload_value_mantissa    (sqrt_output_payload_value_mantissa                ), //i
-    .io_inputs_1_payload_value_exponent    (sqrt_output_payload_value_exponent                ), //i
-    .io_inputs_1_payload_value_sign        (sqrt_output_payload_value_sign                    ), //i
-    .io_inputs_1_payload_value_special     (sqrt_output_payload_value_special                 ), //i
-    .io_inputs_1_payload_scrap             (sqrt_output_payload_scrap                         ), //i
-    .io_inputs_1_payload_roundMode         (sqrt_output_payload_roundMode                     ), //i
-    .io_inputs_1_payload_NV                (sqrt_output_payload_NV                            ), //i
-    .io_inputs_1_payload_DZ                (sqrt_output_payload_DZ                            ), //i
-    .io_inputs_2_valid                     (div_output_valid                                  ), //i
-    .io_inputs_2_ready                     (streamArbiter_2_io_inputs_2_ready                 ), //o
-    .io_inputs_2_payload_rd                (div_output_payload_rd                             ), //i
-    .io_inputs_2_payload_value_mantissa    (div_output_payload_value_mantissa                 ), //i
-    .io_inputs_2_payload_value_exponent    (div_output_payload_value_exponent                 ), //i
-    .io_inputs_2_payload_value_sign        (div_output_payload_value_sign                     ), //i
-    .io_inputs_2_payload_value_special     (div_output_payload_value_special                  ), //i
-    .io_inputs_2_payload_scrap             (div_output_payload_scrap                          ), //i
-    .io_inputs_2_payload_roundMode         (div_output_payload_roundMode                      ), //i
-    .io_inputs_2_payload_NV                (div_output_payload_NV                             ), //i
-    .io_inputs_2_payload_DZ                (div_output_payload_DZ                             ), //i
-    .io_inputs_3_valid                     (add_result_output_valid                           ), //i
-    .io_inputs_3_ready                     (streamArbiter_2_io_inputs_3_ready                 ), //o
-    .io_inputs_3_payload_rd                (add_result_output_payload_rd                      ), //i
-    .io_inputs_3_payload_value_mantissa    (add_result_output_payload_value_mantissa          ), //i
-    .io_inputs_3_payload_value_exponent    (add_result_output_payload_value_exponent          ), //i
-    .io_inputs_3_payload_value_sign        (add_result_output_payload_value_sign              ), //i
-    .io_inputs_3_payload_value_special     (add_result_output_payload_value_special           ), //i
-    .io_inputs_3_payload_scrap             (add_result_output_payload_scrap                   ), //i
-    .io_inputs_3_payload_roundMode         (add_result_output_payload_roundMode               ), //i
-    .io_inputs_3_payload_NV                (add_result_output_payload_NV                      ), //i
-    .io_inputs_3_payload_DZ                (add_result_output_payload_DZ                      ), //i
-    .io_inputs_4_valid                     (mul_result_output_valid                           ), //i
-    .io_inputs_4_ready                     (streamArbiter_2_io_inputs_4_ready                 ), //o
-    .io_inputs_4_payload_rd                (mul_result_output_payload_rd                      ), //i
-    .io_inputs_4_payload_value_mantissa    (mul_result_output_payload_value_mantissa          ), //i
-    .io_inputs_4_payload_value_exponent    (mul_result_output_payload_value_exponent          ), //i
-    .io_inputs_4_payload_value_sign        (mul_result_output_payload_value_sign              ), //i
-    .io_inputs_4_payload_value_special     (mul_result_output_payload_value_special           ), //i
-    .io_inputs_4_payload_scrap             (mul_result_output_payload_scrap                   ), //i
-    .io_inputs_4_payload_roundMode         (mul_result_output_payload_roundMode               ), //i
-    .io_inputs_4_payload_NV                (mul_result_output_payload_NV                      ), //i
-    .io_inputs_4_payload_DZ                (mul_result_output_payload_DZ                      ), //i
-    .io_inputs_5_valid                     (shortPip_output_m2sPipe_valid                     ), //i
-    .io_inputs_5_ready                     (streamArbiter_2_io_inputs_5_ready                 ), //o
-    .io_inputs_5_payload_rd                (shortPip_output_m2sPipe_payload_rd                ), //i
-    .io_inputs_5_payload_value_mantissa    (shortPip_output_m2sPipe_payload_value_mantissa    ), //i
-    .io_inputs_5_payload_value_exponent    (shortPip_output_m2sPipe_payload_value_exponent    ), //i
-    .io_inputs_5_payload_value_sign        (shortPip_output_m2sPipe_payload_value_sign        ), //i
-    .io_inputs_5_payload_value_special     (shortPip_output_m2sPipe_payload_value_special     ), //i
-    .io_inputs_5_payload_scrap             (shortPip_output_m2sPipe_payload_scrap             ), //i
-    .io_inputs_5_payload_roundMode         (shortPip_output_m2sPipe_payload_roundMode         ), //i
-    .io_inputs_5_payload_NV                (shortPip_output_m2sPipe_payload_NV                ), //i
-    .io_inputs_5_payload_DZ                (shortPip_output_m2sPipe_payload_DZ                ), //i
-    .io_output_valid                       (streamArbiter_2_io_output_valid                   ), //o
-    .io_output_ready                       (1'b1                                              ), //i
-    .io_output_payload_rd                  (streamArbiter_2_io_output_payload_rd              ), //o
-    .io_output_payload_value_mantissa      (streamArbiter_2_io_output_payload_value_mantissa  ), //o
-    .io_output_payload_value_exponent      (streamArbiter_2_io_output_payload_value_exponent  ), //o
-    .io_output_payload_value_sign          (streamArbiter_2_io_output_payload_value_sign      ), //o
-    .io_output_payload_value_special       (streamArbiter_2_io_output_payload_value_special   ), //o
-    .io_output_payload_scrap               (streamArbiter_2_io_output_payload_scrap           ), //o
-    .io_output_payload_roundMode           (streamArbiter_2_io_output_payload_roundMode       ), //o
-    .io_output_payload_NV                  (streamArbiter_2_io_output_payload_NV              ), //o
-    .io_output_payload_DZ                  (streamArbiter_2_io_output_payload_DZ              ), //o
-    .io_chosen                             (streamArbiter_2_io_chosen                         ), //o
-    .io_chosenOH                           (streamArbiter_2_io_chosenOH                       ), //o
-    .clk                                   (clk                                               ), //i
-    .reset                                 (reset                                             )  //i
+    .io_inputs_0_valid                  (load_s1_output_m2sPipe_valid                          ), //i
+    .io_inputs_0_ready                  (streamArbiter_2_io_inputs_0_ready                     ), //o
+    .io_inputs_0_payload_rd             (load_s1_output_m2sPipe_payload_rd[4:0]                ), //i
+    .io_inputs_0_payload_value_mantissa (load_s1_output_m2sPipe_payload_value_mantissa[23:0]   ), //i
+    .io_inputs_0_payload_value_exponent (load_s1_output_m2sPipe_payload_value_exponent[8:0]    ), //i
+    .io_inputs_0_payload_value_sign     (load_s1_output_m2sPipe_payload_value_sign             ), //i
+    .io_inputs_0_payload_value_special  (load_s1_output_m2sPipe_payload_value_special          ), //i
+    .io_inputs_0_payload_scrap          (load_s1_output_m2sPipe_payload_scrap                  ), //i
+    .io_inputs_0_payload_roundMode      (load_s1_output_m2sPipe_payload_roundMode[2:0]         ), //i
+    .io_inputs_0_payload_NV             (load_s1_output_m2sPipe_payload_NV                     ), //i
+    .io_inputs_0_payload_DZ             (load_s1_output_m2sPipe_payload_DZ                     ), //i
+    .io_inputs_1_valid                  (sqrt_output_valid                                     ), //i
+    .io_inputs_1_ready                  (streamArbiter_2_io_inputs_1_ready                     ), //o
+    .io_inputs_1_payload_rd             (sqrt_output_payload_rd[4:0]                           ), //i
+    .io_inputs_1_payload_value_mantissa (sqrt_output_payload_value_mantissa[23:0]              ), //i
+    .io_inputs_1_payload_value_exponent (sqrt_output_payload_value_exponent[8:0]               ), //i
+    .io_inputs_1_payload_value_sign     (sqrt_output_payload_value_sign                        ), //i
+    .io_inputs_1_payload_value_special  (sqrt_output_payload_value_special                     ), //i
+    .io_inputs_1_payload_scrap          (sqrt_output_payload_scrap                             ), //i
+    .io_inputs_1_payload_roundMode      (sqrt_output_payload_roundMode[2:0]                    ), //i
+    .io_inputs_1_payload_NV             (sqrt_output_payload_NV                                ), //i
+    .io_inputs_1_payload_DZ             (sqrt_output_payload_DZ                                ), //i
+    .io_inputs_2_valid                  (div_output_valid                                      ), //i
+    .io_inputs_2_ready                  (streamArbiter_2_io_inputs_2_ready                     ), //o
+    .io_inputs_2_payload_rd             (div_output_payload_rd[4:0]                            ), //i
+    .io_inputs_2_payload_value_mantissa (div_output_payload_value_mantissa[23:0]               ), //i
+    .io_inputs_2_payload_value_exponent (div_output_payload_value_exponent[8:0]                ), //i
+    .io_inputs_2_payload_value_sign     (div_output_payload_value_sign                         ), //i
+    .io_inputs_2_payload_value_special  (div_output_payload_value_special                      ), //i
+    .io_inputs_2_payload_scrap          (div_output_payload_scrap                              ), //i
+    .io_inputs_2_payload_roundMode      (div_output_payload_roundMode[2:0]                     ), //i
+    .io_inputs_2_payload_NV             (div_output_payload_NV                                 ), //i
+    .io_inputs_2_payload_DZ             (div_output_payload_DZ                                 ), //i
+    .io_inputs_3_valid                  (add_result_output_valid                               ), //i
+    .io_inputs_3_ready                  (streamArbiter_2_io_inputs_3_ready                     ), //o
+    .io_inputs_3_payload_rd             (add_result_output_payload_rd[4:0]                     ), //i
+    .io_inputs_3_payload_value_mantissa (add_result_output_payload_value_mantissa[23:0]        ), //i
+    .io_inputs_3_payload_value_exponent (add_result_output_payload_value_exponent[8:0]         ), //i
+    .io_inputs_3_payload_value_sign     (add_result_output_payload_value_sign                  ), //i
+    .io_inputs_3_payload_value_special  (add_result_output_payload_value_special               ), //i
+    .io_inputs_3_payload_scrap          (add_result_output_payload_scrap                       ), //i
+    .io_inputs_3_payload_roundMode      (add_result_output_payload_roundMode[2:0]              ), //i
+    .io_inputs_3_payload_NV             (add_result_output_payload_NV                          ), //i
+    .io_inputs_3_payload_DZ             (add_result_output_payload_DZ                          ), //i
+    .io_inputs_4_valid                  (mul_result_output_valid                               ), //i
+    .io_inputs_4_ready                  (streamArbiter_2_io_inputs_4_ready                     ), //o
+    .io_inputs_4_payload_rd             (mul_result_output_payload_rd[4:0]                     ), //i
+    .io_inputs_4_payload_value_mantissa (mul_result_output_payload_value_mantissa[23:0]        ), //i
+    .io_inputs_4_payload_value_exponent (mul_result_output_payload_value_exponent[8:0]         ), //i
+    .io_inputs_4_payload_value_sign     (mul_result_output_payload_value_sign                  ), //i
+    .io_inputs_4_payload_value_special  (mul_result_output_payload_value_special               ), //i
+    .io_inputs_4_payload_scrap          (mul_result_output_payload_scrap                       ), //i
+    .io_inputs_4_payload_roundMode      (mul_result_output_payload_roundMode[2:0]              ), //i
+    .io_inputs_4_payload_NV             (mul_result_output_payload_NV                          ), //i
+    .io_inputs_4_payload_DZ             (mul_result_output_payload_DZ                          ), //i
+    .io_inputs_5_valid                  (shortPip_output_m2sPipe_valid                         ), //i
+    .io_inputs_5_ready                  (streamArbiter_2_io_inputs_5_ready                     ), //o
+    .io_inputs_5_payload_rd             (shortPip_output_m2sPipe_payload_rd[4:0]               ), //i
+    .io_inputs_5_payload_value_mantissa (shortPip_output_m2sPipe_payload_value_mantissa[23:0]  ), //i
+    .io_inputs_5_payload_value_exponent (shortPip_output_m2sPipe_payload_value_exponent[8:0]   ), //i
+    .io_inputs_5_payload_value_sign     (shortPip_output_m2sPipe_payload_value_sign            ), //i
+    .io_inputs_5_payload_value_special  (shortPip_output_m2sPipe_payload_value_special         ), //i
+    .io_inputs_5_payload_scrap          (shortPip_output_m2sPipe_payload_scrap                 ), //i
+    .io_inputs_5_payload_roundMode      (shortPip_output_m2sPipe_payload_roundMode[2:0]        ), //i
+    .io_inputs_5_payload_NV             (shortPip_output_m2sPipe_payload_NV                    ), //i
+    .io_inputs_5_payload_DZ             (shortPip_output_m2sPipe_payload_DZ                    ), //i
+    .io_output_valid                    (streamArbiter_2_io_output_valid                       ), //o
+    .io_output_ready                    (1'b1                                                  ), //i
+    .io_output_payload_rd               (streamArbiter_2_io_output_payload_rd[4:0]             ), //o
+    .io_output_payload_value_mantissa   (streamArbiter_2_io_output_payload_value_mantissa[23:0]), //o
+    .io_output_payload_value_exponent   (streamArbiter_2_io_output_payload_value_exponent[8:0] ), //o
+    .io_output_payload_value_sign       (streamArbiter_2_io_output_payload_value_sign          ), //o
+    .io_output_payload_value_special    (streamArbiter_2_io_output_payload_value_special       ), //o
+    .io_output_payload_scrap            (streamArbiter_2_io_output_payload_scrap               ), //o
+    .io_output_payload_roundMode        (streamArbiter_2_io_output_payload_roundMode[2:0]      ), //o
+    .io_output_payload_NV               (streamArbiter_2_io_output_payload_NV                  ), //o
+    .io_output_payload_DZ               (streamArbiter_2_io_output_payload_DZ                  ), //o
+    .io_chosen                          (streamArbiter_2_io_chosen[2:0]                        ), //o
+    .io_chosenOH                        (streamArbiter_2_io_chosenOH[5:0]                      ), //o
+    .clk                                (clk                                                   ), //i
+    .reset                              (reset                                                 )  //i
   );
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_port_0_cmd_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_cmd_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_cmd_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_cmd_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_cmd_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_cmd_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_cmd_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_cmd_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_cmd_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_cmd_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_cmd_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_cmd_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_cmd_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_cmd_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_cmd_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_cmd_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_cmd_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_port_0_cmd_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_port_0_cmd_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_port_0_cmd_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_port_0_cmd_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_port_0_cmd_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_port_0_cmd_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_port_0_cmd_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_port_0_cmd_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_port_0_cmd_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_port_0_cmd_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_port_0_cmd_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_port_0_cmd_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_port_0_cmd_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_port_0_cmd_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_port_0_cmd_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_port_0_cmd_payload_opcode_string = "FCVT_X_X";
       default : io_port_0_cmd_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_port_0_cmd_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_port_0_cmd_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_port_0_cmd_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_port_0_cmd_payload_format_string = "DOUBLE";
       default : io_port_0_cmd_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_port_0_cmd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_port_0_cmd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_port_0_cmd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_port_0_cmd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_port_0_cmd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_port_0_cmd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_port_0_cmd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_port_0_cmd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_port_0_cmd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_port_0_cmd_payload_roundMode_string = "RMM";
       default : io_port_0_cmd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_port_0_commit_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_commit_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_commit_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_commit_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_commit_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_commit_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_commit_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_commit_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_commit_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_commit_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_commit_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_commit_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_commit_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_commit_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_commit_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_commit_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_commit_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_port_0_commit_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_port_0_commit_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_port_0_commit_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_port_0_commit_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_port_0_commit_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_port_0_commit_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_port_0_commit_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_port_0_commit_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_port_0_commit_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_port_0_commit_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_port_0_commit_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_port_0_commit_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_port_0_commit_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_port_0_commit_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_port_0_commit_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_port_0_commit_payload_opcode_string = "FCVT_X_X";
       default : io_port_0_commit_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(commitFork_load_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : commitFork_load_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : commitFork_load_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : commitFork_load_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : commitFork_load_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : commitFork_load_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : commitFork_load_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : commitFork_load_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : commitFork_load_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : commitFork_load_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : commitFork_load_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : commitFork_load_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : commitFork_load_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : commitFork_load_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : commitFork_load_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : commitFork_load_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : commitFork_load_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : commitFork_load_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : commitFork_load_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : commitFork_load_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : commitFork_load_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : commitFork_load_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : commitFork_load_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : commitFork_load_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : commitFork_load_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : commitFork_load_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : commitFork_load_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : commitFork_load_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : commitFork_load_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : commitFork_load_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : commitFork_load_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : commitFork_load_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : commitFork_load_0_payload_opcode_string = "FCVT_X_X";
       default : commitFork_load_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(commitFork_commit_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : commitFork_commit_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : commitFork_commit_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : commitFork_commit_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : commitFork_commit_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : commitFork_commit_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : commitFork_commit_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : commitFork_commit_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : commitFork_commit_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : commitFork_commit_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : commitFork_commit_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : commitFork_commit_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : commitFork_commit_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : commitFork_commit_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : commitFork_commit_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : commitFork_commit_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : commitFork_commit_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : commitFork_commit_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : commitFork_commit_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : commitFork_commit_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : commitFork_commit_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : commitFork_commit_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : commitFork_commit_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : commitFork_commit_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : commitFork_commit_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : commitFork_commit_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : commitFork_commit_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : commitFork_commit_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : commitFork_commit_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : commitFork_commit_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : commitFork_commit_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : commitFork_commit_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : commitFork_commit_0_payload_opcode_string = "FCVT_X_X";
       default : commitFork_commit_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(streamFork_1_io_outputs_1_s2mPipe_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "FCVT_X_X";
       default : streamFork_1_io_outputs_1_s2mPipe_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(streamFork_1_io_outputs_1_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : streamFork_1_io_outputs_1_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : streamFork_1_io_outputs_1_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : streamFork_1_io_outputs_1_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : streamFork_1_io_outputs_1_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : streamFork_1_io_outputs_1_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : streamFork_1_io_outputs_1_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : streamFork_1_io_outputs_1_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : streamFork_1_io_outputs_1_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : streamFork_1_io_outputs_1_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : streamFork_1_io_outputs_1_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : streamFork_1_io_outputs_1_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : streamFork_1_io_outputs_1_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : streamFork_1_io_outputs_1_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : streamFork_1_io_outputs_1_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : streamFork_1_io_outputs_1_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : streamFork_1_io_outputs_1_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : streamFork_1_io_outputs_1_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : streamFork_1_io_outputs_1_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : streamFork_1_io_outputs_1_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : streamFork_1_io_outputs_1_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : streamFork_1_io_outputs_1_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : streamFork_1_io_outputs_1_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : streamFork_1_io_outputs_1_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : streamFork_1_io_outputs_1_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : streamFork_1_io_outputs_1_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : streamFork_1_io_outputs_1_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : streamFork_1_io_outputs_1_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : streamFork_1_io_outputs_1_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : streamFork_1_io_outputs_1_rData_opcode_string = "FCVT_X_X";
       default : streamFork_1_io_outputs_1_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_payload_opcode_string = "FCVT_X_X";
       default : _zz_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_commitLogic_0_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_commitLogic_0_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_commitLogic_0_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_commitLogic_0_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_commitLogic_0_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_commitLogic_0_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_commitLogic_0_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_commitLogic_0_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_commitLogic_0_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_commitLogic_0_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_commitLogic_0_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_commitLogic_0_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_commitLogic_0_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_commitLogic_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_commitLogic_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_commitLogic_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_commitLogic_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_commitLogic_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_commitLogic_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_commitLogic_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_commitLogic_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_commitLogic_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_commitLogic_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_commitLogic_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_commitLogic_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
       default : _zz_commitLogic_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(commitLogic_0_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : commitLogic_0_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : commitLogic_0_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : commitLogic_0_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : commitLogic_0_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : commitLogic_0_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : commitLogic_0_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : commitLogic_0_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : commitLogic_0_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : commitLogic_0_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : commitLogic_0_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : commitLogic_0_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : commitLogic_0_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : commitLogic_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : commitLogic_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : commitLogic_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : commitLogic_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : commitLogic_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : commitLogic_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : commitLogic_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : commitLogic_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : commitLogic_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : commitLogic_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : commitLogic_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : commitLogic_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : commitLogic_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : commitLogic_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : commitLogic_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : commitLogic_0_input_payload_opcode_string = "FCVT_X_X";
       default : commitLogic_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_cmd_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_cmd_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_cmd_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_cmd_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_cmd_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_cmd_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_cmd_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_cmd_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_cmd_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_cmd_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_cmd_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_cmd_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_cmd_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_cmd_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_cmd_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_cmd_input_payload_opcode_string = "FCVT_X_X";
-      default : io_port_0_cmd_input_payload_opcode_string = "????????";
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : scheduler_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : scheduler_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : scheduler_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : scheduler_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : scheduler_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : scheduler_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : scheduler_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : scheduler_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : scheduler_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : scheduler_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : scheduler_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : scheduler_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : scheduler_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : scheduler_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : scheduler_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : scheduler_0_input_payload_opcode_string = "FCVT_X_X";
+      default : scheduler_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(io_port_0_cmd_input_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_port_0_cmd_input_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_port_0_cmd_input_payload_format_string = "DOUBLE";
-      default : io_port_0_cmd_input_payload_format_string = "??????";
+    case(scheduler_0_input_payload_format)
+      FpuFormat_FLOAT : scheduler_0_input_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : scheduler_0_input_payload_format_string = "DOUBLE";
+      default : scheduler_0_input_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
-    case(io_port_0_cmd_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_port_0_cmd_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_port_0_cmd_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_port_0_cmd_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_port_0_cmd_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_port_0_cmd_input_payload_roundMode_string = "RMM";
-      default : io_port_0_cmd_input_payload_roundMode_string = "???";
+    case(scheduler_0_input_payload_roundMode)
+      FpuRoundMode_RNE : scheduler_0_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : scheduler_0_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : scheduler_0_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : scheduler_0_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : scheduler_0_input_payload_roundMode_string = "RMM";
+      default : scheduler_0_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_port_0_cmd_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_port_0_cmd_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_port_0_cmd_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_port_0_cmd_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_port_0_cmd_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_port_0_cmd_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_port_0_cmd_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_port_0_cmd_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_port_0_cmd_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_port_0_cmd_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_port_0_cmd_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_port_0_cmd_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_port_0_cmd_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_port_0_cmd_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_port_0_cmd_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_port_0_cmd_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_port_0_cmd_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_port_0_cmd_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_port_0_cmd_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_port_0_cmd_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_port_0_cmd_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_port_0_cmd_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_port_0_cmd_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_port_0_cmd_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_port_0_cmd_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_port_0_cmd_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_port_0_cmd_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_port_0_cmd_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_port_0_cmd_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_port_0_cmd_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_port_0_cmd_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_port_0_cmd_rData_opcode_string = "FCVT_X_X";
       default : io_port_0_cmd_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_rData_format)
-      `FpuFormat_binary_sequential_FLOAT : io_port_0_cmd_rData_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_port_0_cmd_rData_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_port_0_cmd_rData_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_port_0_cmd_rData_format_string = "DOUBLE";
       default : io_port_0_cmd_rData_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_port_0_cmd_rData_roundMode)
-      `FpuRoundMode_opt_RNE : io_port_0_cmd_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_port_0_cmd_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_port_0_cmd_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_port_0_cmd_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_port_0_cmd_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_port_0_cmd_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_port_0_cmd_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_port_0_cmd_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_port_0_cmd_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_port_0_cmd_rData_roundMode_string = "RMM";
       default : io_port_0_cmd_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_io_port_0_cmd_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_io_port_0_cmd_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_io_port_0_cmd_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_io_port_0_cmd_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_io_port_0_cmd_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_io_port_0_cmd_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_io_port_0_cmd_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_io_port_0_cmd_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_io_port_0_cmd_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_io_port_0_cmd_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_io_port_0_cmd_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_io_port_0_cmd_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_io_port_0_cmd_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_io_port_0_cmd_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_io_port_0_cmd_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_io_port_0_cmd_input_payload_opcode_string = "FCVT_X_X";
-      default : _zz_io_port_0_cmd_input_payload_opcode_string = "????????";
+    case(_zz_scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : _zz_scheduler_0_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_scheduler_0_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_scheduler_0_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_scheduler_0_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_scheduler_0_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_scheduler_0_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_scheduler_0_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_scheduler_0_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_scheduler_0_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_scheduler_0_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_scheduler_0_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_scheduler_0_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_scheduler_0_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_scheduler_0_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_scheduler_0_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_scheduler_0_input_payload_opcode_string = "FCVT_X_X";
+      default : _zz_scheduler_0_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_io_port_0_cmd_input_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : _zz_io_port_0_cmd_input_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : _zz_io_port_0_cmd_input_payload_format_string = "DOUBLE";
-      default : _zz_io_port_0_cmd_input_payload_format_string = "??????";
+    case(_zz_scheduler_0_input_payload_format)
+      FpuFormat_FLOAT : _zz_scheduler_0_input_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : _zz_scheduler_0_input_payload_format_string = "DOUBLE";
+      default : _zz_scheduler_0_input_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
-    case(_zz_io_port_0_cmd_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_port_0_cmd_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_port_0_cmd_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_port_0_cmd_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_port_0_cmd_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_port_0_cmd_input_payload_roundMode_string = "RMM";
-      default : _zz_io_port_0_cmd_input_payload_roundMode_string = "???";
+    case(_zz_scheduler_0_input_payload_roundMode)
+      FpuRoundMode_RNE : _zz_scheduler_0_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_scheduler_0_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_scheduler_0_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_scheduler_0_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_scheduler_0_input_payload_roundMode_string = "RMM";
+      default : _zz_scheduler_0_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(scheduler_0_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : scheduler_0_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : scheduler_0_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : scheduler_0_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : scheduler_0_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : scheduler_0_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : scheduler_0_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : scheduler_0_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : scheduler_0_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : scheduler_0_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : scheduler_0_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : scheduler_0_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : scheduler_0_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : scheduler_0_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : scheduler_0_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : scheduler_0_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : scheduler_0_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : scheduler_0_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : scheduler_0_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : scheduler_0_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : scheduler_0_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : scheduler_0_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : scheduler_0_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : scheduler_0_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : scheduler_0_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : scheduler_0_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : scheduler_0_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : scheduler_0_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : scheduler_0_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : scheduler_0_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : scheduler_0_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : scheduler_0_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : scheduler_0_output_payload_opcode_string = "FCVT_X_X";
       default : scheduler_0_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(scheduler_0_output_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : scheduler_0_output_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : scheduler_0_output_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : scheduler_0_output_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : scheduler_0_output_payload_format_string = "DOUBLE";
       default : scheduler_0_output_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(scheduler_0_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : scheduler_0_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : scheduler_0_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : scheduler_0_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : scheduler_0_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : scheduler_0_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : scheduler_0_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : scheduler_0_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : scheduler_0_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : scheduler_0_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : scheduler_0_output_payload_roundMode_string = "RMM";
       default : scheduler_0_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_io_inputs_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_io_inputs_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_io_inputs_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_io_inputs_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_io_inputs_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_io_inputs_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_io_inputs_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_io_inputs_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_io_inputs_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_io_inputs_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_io_inputs_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_io_inputs_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_io_inputs_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_io_inputs_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_io_inputs_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_io_inputs_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_io_inputs_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_io_inputs_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_io_inputs_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_io_inputs_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_io_inputs_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_io_inputs_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_io_inputs_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_io_inputs_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_io_inputs_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_io_inputs_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_io_inputs_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_io_inputs_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_io_inputs_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_io_inputs_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_io_inputs_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_io_inputs_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_io_inputs_0_payload_opcode_string = "FCVT_X_X";
       default : _zz_io_inputs_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_io_inputs_0_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : _zz_io_inputs_0_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : _zz_io_inputs_0_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : _zz_io_inputs_0_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : _zz_io_inputs_0_payload_format_string = "DOUBLE";
       default : _zz_io_inputs_0_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(_zz_io_inputs_0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_inputs_0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_inputs_0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_inputs_0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_inputs_0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_inputs_0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_io_inputs_0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_io_inputs_0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_io_inputs_0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_io_inputs_0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_io_inputs_0_payload_roundMode_string = "RMM";
       default : _zz_io_inputs_0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(cmdArbiter_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : cmdArbiter_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : cmdArbiter_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : cmdArbiter_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : cmdArbiter_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : cmdArbiter_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : cmdArbiter_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : cmdArbiter_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : cmdArbiter_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : cmdArbiter_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : cmdArbiter_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : cmdArbiter_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : cmdArbiter_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : cmdArbiter_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : cmdArbiter_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : cmdArbiter_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : cmdArbiter_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : cmdArbiter_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : cmdArbiter_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : cmdArbiter_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : cmdArbiter_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : cmdArbiter_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : cmdArbiter_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : cmdArbiter_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : cmdArbiter_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : cmdArbiter_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : cmdArbiter_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : cmdArbiter_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : cmdArbiter_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : cmdArbiter_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : cmdArbiter_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : cmdArbiter_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : cmdArbiter_output_payload_opcode_string = "FCVT_X_X";
       default : cmdArbiter_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(cmdArbiter_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : cmdArbiter_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : cmdArbiter_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : cmdArbiter_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : cmdArbiter_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : cmdArbiter_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : cmdArbiter_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : cmdArbiter_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : cmdArbiter_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : cmdArbiter_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : cmdArbiter_output_payload_roundMode_string = "RMM";
       default : cmdArbiter_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(read_s0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_s0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_s0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_s0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_s0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_s0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_s0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_s0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_s0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_s0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_s0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_s0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_s0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_s0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_s0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_s0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_s0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : read_s0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_s0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_s0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_s0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_s0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_s0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_s0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_s0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_s0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_s0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_s0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_s0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_s0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_s0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_s0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_s0_payload_opcode_string = "FCVT_X_X";
       default : read_s0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(read_s0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : read_s0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_s0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_s0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_s0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_s0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : read_s0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_s0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_s0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_s0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_s0_payload_roundMode_string = "RMM";
       default : read_s0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(read_s0_s1_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_s0_s1_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_s0_s1_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_s0_s1_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_s0_s1_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_s0_s1_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_s0_s1_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_s0_s1_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_s0_s1_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_s0_s1_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_s0_s1_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_s0_s1_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_s0_s1_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_s0_s1_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_s0_s1_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_s0_s1_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_s0_s1_payload_opcode_string = "FCVT_X_X";
-      default : read_s0_s1_payload_opcode_string = "????????";
+    case(read_s1_payload_opcode)
+      FpuOpcode_LOAD : read_s1_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_s1_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_s1_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_s1_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_s1_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_s1_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_s1_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_s1_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_s1_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_s1_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_s1_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_s1_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_s1_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_s1_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_s1_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_s1_payload_opcode_string = "FCVT_X_X";
+      default : read_s1_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(read_s0_s1_payload_roundMode)
-      `FpuRoundMode_opt_RNE : read_s0_s1_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_s0_s1_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_s0_s1_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_s0_s1_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_s0_s1_payload_roundMode_string = "RMM";
-      default : read_s0_s1_payload_roundMode_string = "???";
+    case(read_s1_payload_roundMode)
+      FpuRoundMode_RNE : read_s1_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_s1_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_s1_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_s1_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_s1_payload_roundMode_string = "RMM";
+      default : read_s1_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(read_s0_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_s0_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_s0_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_s0_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_s0_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_s0_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_s0_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_s0_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_s0_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_s0_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_s0_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_s0_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_s0_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_s0_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_s0_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_s0_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_s0_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : read_s0_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_s0_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_s0_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_s0_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_s0_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_s0_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_s0_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_s0_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_s0_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_s0_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_s0_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_s0_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_s0_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_s0_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_s0_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_s0_rData_opcode_string = "FCVT_X_X";
       default : read_s0_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(read_s0_rData_roundMode)
-      `FpuRoundMode_opt_RNE : read_s0_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_s0_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_s0_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_s0_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_s0_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : read_s0_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_s0_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_s0_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_s0_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_s0_rData_roundMode_string = "RMM";
       default : read_s0_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(read_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : read_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : read_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : read_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : read_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : read_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : read_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : read_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : read_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : read_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : read_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : read_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : read_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : read_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : read_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : read_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : read_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : read_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : read_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : read_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : read_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : read_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : read_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : read_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : read_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : read_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : read_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : read_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : read_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : read_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : read_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : read_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : read_output_payload_opcode_string = "FCVT_X_X";
       default : read_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(read_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : read_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : read_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : read_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : read_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : read_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : read_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : read_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : read_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : read_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : read_output_payload_roundMode_string = "RMM";
       default : read_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : decode_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : decode_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : decode_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : decode_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : decode_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : decode_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : decode_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : decode_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : decode_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_input_payload_opcode_string = "FCVT_X_X";
       default : decode_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_input_payload_roundMode_string = "RMM";
       default : decode_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_payload_roundMode_string = "RMM";
       default : decode_load_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_shortPip_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_shortPip_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_shortPip_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_shortPip_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_shortPip_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_shortPip_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_shortPip_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_shortPip_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_shortPip_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_shortPip_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_shortPip_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_shortPip_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_shortPip_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_shortPip_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_shortPip_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_shortPip_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_shortPip_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : decode_shortPip_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : decode_shortPip_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : decode_shortPip_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : decode_shortPip_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : decode_shortPip_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : decode_shortPip_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : decode_shortPip_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : decode_shortPip_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : decode_shortPip_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_shortPip_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_shortPip_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_shortPip_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_shortPip_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_shortPip_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_shortPip_payload_opcode_string = "FCVT_X_X";
       default : decode_shortPip_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_shortPip_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_shortPip_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_shortPip_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_shortPip_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_shortPip_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_shortPip_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_shortPip_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_shortPip_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_shortPip_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_shortPip_payload_roundMode_string = "RMM";
       default : decode_shortPip_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_divSqrt_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_divSqrt_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_divSqrt_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_divSqrt_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_divSqrt_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_divSqrt_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_divSqrt_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_divSqrt_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_divSqrt_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_divSqrt_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_divSqrt_payload_roundMode_string = "RMM";
       default : decode_divSqrt_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_div_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_div_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_div_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_div_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_div_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_div_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_div_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_div_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_div_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_div_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_div_payload_roundMode_string = "RMM";
       default : decode_div_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_sqrt_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_sqrt_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_sqrt_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_sqrt_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_sqrt_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_sqrt_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_sqrt_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_sqrt_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_sqrt_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_sqrt_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_sqrt_payload_roundMode_string = "RMM";
       default : decode_sqrt_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_mul_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mul_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mul_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mul_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mul_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mul_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_mul_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_mul_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_mul_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_mul_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_mul_payload_roundMode_string = "RMM";
       default : decode_mul_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_divSqrtToMul_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_divSqrtToMul_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_divSqrtToMul_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_divSqrtToMul_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_divSqrtToMul_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_divSqrtToMul_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_divSqrtToMul_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_divSqrtToMul_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_divSqrtToMul_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_divSqrtToMul_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_divSqrtToMul_payload_roundMode_string = "RMM";
       default : decode_divSqrtToMul_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_add_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_add_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_add_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_add_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_add_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_add_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_add_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_add_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_add_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_add_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_add_payload_roundMode_string = "RMM";
       default : decode_add_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_mulToAdd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mulToAdd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mulToAdd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mulToAdd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mulToAdd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mulToAdd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_mulToAdd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_mulToAdd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_mulToAdd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_mulToAdd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_mulToAdd_payload_roundMode_string = "RMM";
       default : decode_mulToAdd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_payload_roundMode_string = "RMM";
       default : decode_load_s2mPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_rData_roundMode_string = "RMM";
       default : decode_load_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_load_s2mPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_decode_load_s2mPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_decode_load_s2mPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_decode_load_s2mPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_decode_load_s2mPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_decode_load_s2mPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_decode_load_s2mPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_decode_load_s2mPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_decode_load_s2mPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_decode_load_s2mPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_decode_load_s2mPipe_payload_roundMode_string = "RMM";
       default : _zz_decode_load_s2mPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "RMM";
       default : decode_load_s2mPipe_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_rData_roundMode_string = "RMM";
       default : decode_load_s2mPipe_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_load_s2mPipe_m2sPipe_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "RMM";
-      default : decode_load_s2mPipe_m2sPipe_input_payload_roundMode_string = "???";
+    case(load_s0_input_payload_roundMode)
+      FpuRoundMode_RNE : load_s0_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s0_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s0_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s0_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s0_input_payload_roundMode_string = "RMM";
+      default : load_s0_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_load_s2mPipe_m2sPipe_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "RMM";
       default : decode_load_s2mPipe_m2sPipe_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s0_filtred_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : load_s0_filtred_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : load_s0_filtred_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : load_s0_filtred_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : load_s0_filtred_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : load_s0_filtred_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : load_s0_filtred_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : load_s0_filtred_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : load_s0_filtred_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : load_s0_filtred_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : load_s0_filtred_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : load_s0_filtred_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : load_s0_filtred_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : load_s0_filtred_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : load_s0_filtred_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : load_s0_filtred_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : load_s0_filtred_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : load_s0_filtred_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : load_s0_filtred_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : load_s0_filtred_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : load_s0_filtred_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : load_s0_filtred_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : load_s0_filtred_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : load_s0_filtred_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : load_s0_filtred_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : load_s0_filtred_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : load_s0_filtred_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : load_s0_filtred_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : load_s0_filtred_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : load_s0_filtred_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : load_s0_filtred_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : load_s0_filtred_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : load_s0_filtred_0_payload_opcode_string = "FCVT_X_X";
       default : load_s0_filtred_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(load_s0_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s0_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s0_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s0_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s0_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s0_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s0_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s0_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s0_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s0_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s0_output_payload_roundMode_string = "RMM";
       default : load_s0_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(load_s0_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s0_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s0_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s0_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s0_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s0_output_input_payload_roundMode_string = "RMM";
-      default : load_s0_output_input_payload_roundMode_string = "???";
+    case(load_s1_input_payload_roundMode)
+      FpuRoundMode_RNE : load_s1_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_input_payload_roundMode_string = "RMM";
+      default : load_s1_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s0_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : load_s0_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s0_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s0_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s0_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s0_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s0_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s0_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s0_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s0_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s0_output_rData_roundMode_string = "RMM";
       default : load_s0_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s1_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s1_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s1_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s1_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s1_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s1_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s1_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_output_payload_roundMode_string = "RMM";
       default : load_s1_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_shortPip_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_shortPip_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_shortPip_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_shortPip_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_shortPip_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_shortPip_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_shortPip_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_shortPip_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_shortPip_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_shortPip_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_shortPip_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_shortPip_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_shortPip_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_shortPip_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_shortPip_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_shortPip_input_payload_opcode_string = "FCVT_X_X";
-      default : decode_shortPip_input_payload_opcode_string = "????????";
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_LOAD : shortPip_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : shortPip_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : shortPip_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : shortPip_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : shortPip_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : shortPip_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : shortPip_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : shortPip_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : shortPip_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : shortPip_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : shortPip_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : shortPip_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : shortPip_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : shortPip_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : shortPip_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : shortPip_input_payload_opcode_string = "FCVT_X_X";
+      default : shortPip_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
-    case(decode_shortPip_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_shortPip_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_shortPip_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_shortPip_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_shortPip_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_shortPip_input_payload_roundMode_string = "RMM";
-      default : decode_shortPip_input_payload_roundMode_string = "???";
+    case(shortPip_input_payload_roundMode)
+      FpuRoundMode_RNE : shortPip_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_input_payload_roundMode_string = "RMM";
+      default : shortPip_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_rData_opcode)
-      `FpuOpcode_binary_sequential_LOAD : decode_shortPip_rData_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : decode_shortPip_rData_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : decode_shortPip_rData_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : decode_shortPip_rData_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : decode_shortPip_rData_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : decode_shortPip_rData_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : decode_shortPip_rData_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : decode_shortPip_rData_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : decode_shortPip_rData_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : decode_shortPip_rData_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : decode_shortPip_rData_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : decode_shortPip_rData_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : decode_shortPip_rData_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : decode_shortPip_rData_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : decode_shortPip_rData_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : decode_shortPip_rData_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : decode_shortPip_rData_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : decode_shortPip_rData_opcode_string = "STORE   ";
+      FpuOpcode_MUL : decode_shortPip_rData_opcode_string = "MUL     ";
+      FpuOpcode_ADD : decode_shortPip_rData_opcode_string = "ADD     ";
+      FpuOpcode_FMA : decode_shortPip_rData_opcode_string = "FMA     ";
+      FpuOpcode_I2F : decode_shortPip_rData_opcode_string = "I2F     ";
+      FpuOpcode_F2I : decode_shortPip_rData_opcode_string = "F2I     ";
+      FpuOpcode_CMP : decode_shortPip_rData_opcode_string = "CMP     ";
+      FpuOpcode_DIV : decode_shortPip_rData_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : decode_shortPip_rData_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : decode_shortPip_rData_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : decode_shortPip_rData_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : decode_shortPip_rData_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : decode_shortPip_rData_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : decode_shortPip_rData_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : decode_shortPip_rData_opcode_string = "FCVT_X_X";
       default : decode_shortPip_rData_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_shortPip_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_shortPip_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_shortPip_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_shortPip_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_shortPip_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_shortPip_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_shortPip_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_shortPip_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_shortPip_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_shortPip_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_shortPip_rData_roundMode_string = "RMM";
       default : decode_shortPip_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_rfOutput_payload_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_rfOutput_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_rfOutput_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_rfOutput_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_rfOutput_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_rfOutput_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_rfOutput_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_rfOutput_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_rfOutput_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_rfOutput_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_rfOutput_payload_roundMode_string = "RMM";
       default : shortPip_rfOutput_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_output_payload_roundMode_string = "RMM";
       default : shortPip_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_mul_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mul_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mul_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mul_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mul_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mul_input_payload_roundMode_string = "RMM";
-      default : decode_mul_input_payload_roundMode_string = "???";
+    case(mul_preMul_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_preMul_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_preMul_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_preMul_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_preMul_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_preMul_input_payload_roundMode_string = "RMM";
+      default : mul_preMul_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_mul_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_mul_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_mul_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_mul_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_mul_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_mul_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_mul_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_mul_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_mul_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_mul_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_mul_rData_roundMode_string = "RMM";
       default : decode_mul_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_preMul_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_preMul_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_preMul_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_preMul_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_preMul_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_preMul_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_preMul_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_preMul_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_preMul_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_preMul_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_preMul_output_payload_roundMode_string = "RMM";
       default : mul_preMul_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_preMul_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_preMul_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_preMul_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_preMul_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_preMul_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_preMul_output_input_payload_roundMode_string = "RMM";
-      default : mul_preMul_output_input_payload_roundMode_string = "???";
+    case(mul_mul_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_mul_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_mul_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_mul_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_mul_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_mul_input_payload_roundMode_string = "RMM";
+      default : mul_mul_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_preMul_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_preMul_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_preMul_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_preMul_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_preMul_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_preMul_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_preMul_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_preMul_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_preMul_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_preMul_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_preMul_output_rData_roundMode_string = "RMM";
       default : mul_preMul_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_mul_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_mul_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_mul_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_mul_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_mul_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_mul_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_mul_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_mul_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_mul_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_mul_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_mul_output_payload_roundMode_string = "RMM";
       default : mul_mul_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_mul_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_mul_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_mul_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_mul_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_mul_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_mul_output_input_payload_roundMode_string = "RMM";
-      default : mul_mul_output_input_payload_roundMode_string = "???";
+    case(mul_sum1_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_sum1_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum1_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum1_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum1_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum1_input_payload_roundMode_string = "RMM";
+      default : mul_sum1_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_mul_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_mul_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_mul_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_mul_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_mul_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_mul_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_mul_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_mul_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_mul_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_mul_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_mul_output_rData_roundMode_string = "RMM";
       default : mul_mul_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum1_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum1_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum1_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum1_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum1_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum1_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum1_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum1_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum1_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum1_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum1_output_payload_roundMode_string = "RMM";
       default : mul_sum1_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_sum1_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum1_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum1_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum1_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum1_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum1_output_input_payload_roundMode_string = "RMM";
-      default : mul_sum1_output_input_payload_roundMode_string = "???";
+    case(mul_sum2_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_sum2_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum2_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum2_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum2_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum2_input_payload_roundMode_string = "RMM";
+      default : mul_sum2_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum1_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum1_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum1_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum1_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum1_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum1_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum1_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum1_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum1_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum1_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum1_output_rData_roundMode_string = "RMM";
       default : mul_sum1_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum2_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum2_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum2_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum2_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum2_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum2_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum2_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum2_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum2_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum2_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum2_output_payload_roundMode_string = "RMM";
       default : mul_sum2_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(mul_sum2_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum2_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum2_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum2_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum2_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum2_output_input_payload_roundMode_string = "RMM";
-      default : mul_sum2_output_input_payload_roundMode_string = "???";
+    case(mul_norm_input_payload_roundMode)
+      FpuRoundMode_RNE : mul_norm_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_norm_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_norm_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_norm_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_norm_input_payload_roundMode_string = "RMM";
+      default : mul_norm_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_sum2_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_sum2_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_sum2_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_sum2_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_sum2_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_sum2_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_sum2_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_sum2_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_sum2_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_sum2_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_sum2_output_rData_roundMode_string = "RMM";
       default : mul_sum2_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_output_payload_roundMode_string = "RMM";
       default : mul_result_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_mulToAdd_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_mulToAdd_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_mulToAdd_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_mulToAdd_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_mulToAdd_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_mulToAdd_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_mulToAdd_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_mulToAdd_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_mulToAdd_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_mulToAdd_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_mulToAdd_payload_roundMode_string = "RMM";
       default : mul_result_mulToAdd_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_mulToAdd_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "RMM";
       default : mul_result_mulToAdd_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(mul_result_mulToAdd_rData_roundMode)
-      `FpuRoundMode_opt_RNE : mul_result_mulToAdd_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : mul_result_mulToAdd_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : mul_result_mulToAdd_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : mul_result_mulToAdd_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : mul_result_mulToAdd_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : mul_result_mulToAdd_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : mul_result_mulToAdd_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : mul_result_mulToAdd_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : mul_result_mulToAdd_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : mul_result_mulToAdd_rData_roundMode_string = "RMM";
       default : mul_result_mulToAdd_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_div_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_div_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_div_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_div_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_div_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_div_input_payload_roundMode_string = "RMM";
-      default : decode_div_input_payload_roundMode_string = "???";
+    case(div_input_payload_roundMode)
+      FpuRoundMode_RNE : div_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : div_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : div_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : div_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : div_input_payload_roundMode_string = "RMM";
+      default : div_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_div_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_div_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_div_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_div_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_div_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_div_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_div_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_div_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_div_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_div_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_div_rData_roundMode_string = "RMM";
       default : decode_div_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(div_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : div_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : div_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : div_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : div_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : div_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : div_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : div_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : div_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : div_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : div_output_payload_roundMode_string = "RMM";
       default : div_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(decode_sqrt_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : decode_sqrt_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_sqrt_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_sqrt_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_sqrt_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_sqrt_input_payload_roundMode_string = "RMM";
-      default : decode_sqrt_input_payload_roundMode_string = "???";
+    case(sqrt_input_payload_roundMode)
+      FpuRoundMode_RNE : sqrt_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : sqrt_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : sqrt_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : sqrt_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : sqrt_input_payload_roundMode_string = "RMM";
+      default : sqrt_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_sqrt_rData_roundMode)
-      `FpuRoundMode_opt_RNE : decode_sqrt_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : decode_sqrt_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : decode_sqrt_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : decode_sqrt_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : decode_sqrt_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : decode_sqrt_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : decode_sqrt_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : decode_sqrt_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : decode_sqrt_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : decode_sqrt_rData_roundMode_string = "RMM";
       default : decode_sqrt_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(sqrt_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : sqrt_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : sqrt_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : sqrt_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : sqrt_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : sqrt_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : sqrt_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : sqrt_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : sqrt_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : sqrt_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : sqrt_output_payload_roundMode_string = "RMM";
       default : sqrt_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_preShifter_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_preShifter_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_preShifter_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_preShifter_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_preShifter_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_preShifter_input_payload_roundMode_string = "RMM";
       default : add_preShifter_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_preShifter_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_preShifter_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_preShifter_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_preShifter_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_preShifter_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_preShifter_output_payload_roundMode_string = "RMM";
       default : add_preShifter_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_preShifter_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_output_input_payload_roundMode_string = "RMM";
-      default : add_preShifter_output_input_payload_roundMode_string = "???";
+    case(add_shifter_input_payload_roundMode)
+      FpuRoundMode_RNE : add_shifter_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_shifter_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_shifter_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_shifter_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_shifter_input_payload_roundMode_string = "RMM";
+      default : add_shifter_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_preShifter_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_preShifter_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_preShifter_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_preShifter_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_preShifter_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_preShifter_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_preShifter_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_preShifter_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_preShifter_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_preShifter_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_preShifter_output_rData_roundMode_string = "RMM";
       default : add_preShifter_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_shifter_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_shifter_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_shifter_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_shifter_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_shifter_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_shifter_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_shifter_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_shifter_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_shifter_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_shifter_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_shifter_output_payload_roundMode_string = "RMM";
       default : add_shifter_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_shifter_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_shifter_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_shifter_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_shifter_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_shifter_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_shifter_output_input_payload_roundMode_string = "RMM";
-      default : add_shifter_output_input_payload_roundMode_string = "???";
+    case(add_math_input_payload_roundMode)
+      FpuRoundMode_RNE : add_math_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_math_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_math_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_math_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_math_input_payload_roundMode_string = "RMM";
+      default : add_math_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_shifter_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_shifter_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_shifter_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_shifter_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_shifter_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_shifter_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_shifter_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_shifter_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_shifter_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_shifter_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_shifter_output_rData_roundMode_string = "RMM";
       default : add_shifter_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_math_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_math_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_math_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_math_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_math_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_math_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_math_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_math_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_math_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_math_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_math_output_payload_roundMode_string = "RMM";
       default : add_math_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_math_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_math_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_math_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_math_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_math_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_math_output_input_payload_roundMode_string = "RMM";
-      default : add_math_output_input_payload_roundMode_string = "???";
+    case(add_oh_input_payload_roundMode)
+      FpuRoundMode_RNE : add_oh_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_oh_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_oh_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_oh_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_oh_input_payload_roundMode_string = "RMM";
+      default : add_oh_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_math_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_math_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_math_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_math_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_math_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_math_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_math_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_math_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_math_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_math_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_math_output_rData_roundMode_string = "RMM";
       default : add_math_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_oh_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_oh_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_oh_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_oh_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_oh_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_oh_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_oh_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_oh_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_oh_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_oh_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_oh_output_payload_roundMode_string = "RMM";
       default : add_oh_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
-    case(add_oh_output_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_oh_output_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_oh_output_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_oh_output_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_oh_output_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_oh_output_input_payload_roundMode_string = "RMM";
-      default : add_oh_output_input_payload_roundMode_string = "???";
+    case(add_norm_input_payload_roundMode)
+      FpuRoundMode_RNE : add_norm_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_norm_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_norm_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_norm_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_norm_input_payload_roundMode_string = "RMM";
+      default : add_norm_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_oh_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : add_oh_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_oh_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_oh_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_oh_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_oh_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_oh_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_oh_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_oh_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_oh_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_oh_output_rData_roundMode_string = "RMM";
       default : add_oh_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_norm_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_norm_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_norm_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_norm_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_norm_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_norm_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_norm_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_norm_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_norm_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_norm_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_norm_output_payload_roundMode_string = "RMM";
       default : add_norm_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_result_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_result_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_result_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_result_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_result_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_result_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_result_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_result_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_result_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_result_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_result_input_payload_roundMode_string = "RMM";
       default : add_result_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(add_result_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : add_result_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : add_result_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : add_result_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : add_result_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : add_result_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : add_result_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : add_result_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : add_result_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : add_result_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : add_result_output_payload_roundMode_string = "RMM";
       default : add_result_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s1_output_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : load_s1_output_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s1_output_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s1_output_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s1_output_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s1_output_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s1_output_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_output_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_output_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_output_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_output_m2sPipe_payload_roundMode_string = "RMM";
       default : load_s1_output_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(load_s1_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : load_s1_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : load_s1_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : load_s1_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : load_s1_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : load_s1_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : load_s1_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : load_s1_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : load_s1_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : load_s1_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : load_s1_output_rData_roundMode_string = "RMM";
       default : load_s1_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_output_m2sPipe_payload_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_output_m2sPipe_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_output_m2sPipe_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_output_m2sPipe_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_output_m2sPipe_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_output_m2sPipe_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_output_m2sPipe_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_output_m2sPipe_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_output_m2sPipe_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_output_m2sPipe_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_output_m2sPipe_payload_roundMode_string = "RMM";
       default : shortPip_output_m2sPipe_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(shortPip_output_rData_roundMode)
-      `FpuRoundMode_opt_RNE : shortPip_output_rData_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : shortPip_output_rData_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : shortPip_output_rData_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : shortPip_output_rData_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : shortPip_output_rData_roundMode_string = "RMM";
+      FpuRoundMode_RNE : shortPip_output_rData_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : shortPip_output_rData_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : shortPip_output_rData_roundMode_string = "RDN";
+      FpuRoundMode_RUP : shortPip_output_rData_roundMode_string = "RUP";
+      FpuRoundMode_RMM : shortPip_output_rData_roundMode_string = "RMM";
       default : shortPip_output_rData_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(merge_arbitrated_payload_roundMode)
-      `FpuRoundMode_opt_RNE : merge_arbitrated_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : merge_arbitrated_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : merge_arbitrated_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : merge_arbitrated_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : merge_arbitrated_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : merge_arbitrated_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : merge_arbitrated_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : merge_arbitrated_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : merge_arbitrated_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : merge_arbitrated_payload_roundMode_string = "RMM";
       default : merge_arbitrated_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(roundFront_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : roundFront_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : roundFront_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : roundFront_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : roundFront_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : roundFront_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : roundFront_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : roundFront_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : roundFront_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : roundFront_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : roundFront_input_payload_roundMode_string = "RMM";
       default : roundFront_input_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(roundFront_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : roundFront_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : roundFront_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : roundFront_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : roundFront_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : roundFront_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : roundFront_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : roundFront_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : roundFront_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : roundFront_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : roundFront_output_payload_roundMode_string = "RMM";
       default : roundFront_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : roundBack_input_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : roundBack_input_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : roundBack_input_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : roundBack_input_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : roundBack_input_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : roundBack_input_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : roundBack_input_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : roundBack_input_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : roundBack_input_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : roundBack_input_payload_roundMode_string = "RMM";
       default : roundBack_input_payload_roundMode_string = "???";
     endcase
   end
@@ -11252,7 +11269,7 @@ module FpuCore (
   always @(*) begin
     rf_scoreboards_0_targetWrite_payload_address = rf_init_counter[4:0];
     if(when_FpuCore_l261) begin
-      rf_scoreboards_0_targetWrite_payload_address = io_port_0_cmd_input_payload_rd;
+      rf_scoreboards_0_targetWrite_payload_address = scheduler_0_input_payload_rd;
     end
   end
 
@@ -11305,8 +11322,8 @@ module FpuCore (
   assign commitFork_commit_0_payload_rd = streamFork_1_io_outputs_1_s2mPipe_payload_rd;
   assign commitFork_commit_0_payload_write = streamFork_1_io_outputs_1_s2mPipe_payload_write;
   assign commitFork_commit_0_payload_value = streamFork_1_io_outputs_1_s2mPipe_payload_value;
-  assign commitLogic_0_pending_full = (commitLogic_0_pending_counter == 4'b1111);
-  assign commitLogic_0_pending_notEmpty = (commitLogic_0_pending_counter != 4'b0000);
+  assign commitLogic_0_pending_full = (&commitLogic_0_pending_counter);
+  assign commitLogic_0_pending_notEmpty = (|commitLogic_0_pending_counter);
   always @(*) begin
     commitLogic_0_pending_inc = 1'b0;
     if(when_FpuCore_l265) begin
@@ -11321,8 +11338,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_add_full = (commitLogic_0_add_counter == 4'b1111);
-  assign commitLogic_0_add_notEmpty = (commitLogic_0_add_counter != 4'b0000);
+  assign commitLogic_0_add_full = (&commitLogic_0_add_counter);
+  assign commitLogic_0_add_notEmpty = (|commitLogic_0_add_counter);
   always @(*) begin
     commitLogic_0_add_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11339,8 +11356,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_mul_full = (commitLogic_0_mul_counter == 4'b1111);
-  assign commitLogic_0_mul_notEmpty = (commitLogic_0_mul_counter != 4'b0000);
+  assign commitLogic_0_mul_full = (&commitLogic_0_mul_counter);
+  assign commitLogic_0_mul_notEmpty = (|commitLogic_0_mul_counter);
   always @(*) begin
     commitLogic_0_mul_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11357,8 +11374,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_div_full = (commitLogic_0_div_counter == 4'b1111);
-  assign commitLogic_0_div_notEmpty = (commitLogic_0_div_counter != 4'b0000);
+  assign commitLogic_0_div_full = (&commitLogic_0_div_counter);
+  assign commitLogic_0_div_notEmpty = (|commitLogic_0_div_counter);
   always @(*) begin
     commitLogic_0_div_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11375,8 +11392,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_sqrt_full = (commitLogic_0_sqrt_counter == 4'b1111);
-  assign commitLogic_0_sqrt_notEmpty = (commitLogic_0_sqrt_counter != 4'b0000);
+  assign commitLogic_0_sqrt_full = (&commitLogic_0_sqrt_counter);
+  assign commitLogic_0_sqrt_notEmpty = (|commitLogic_0_sqrt_counter);
   always @(*) begin
     commitLogic_0_sqrt_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11393,8 +11410,8 @@ module FpuCore (
     end
   end
 
-  assign commitLogic_0_short_full = (commitLogic_0_short_counter == 4'b1111);
-  assign commitLogic_0_short_notEmpty = (commitLogic_0_short_counter != 4'b0000);
+  assign commitLogic_0_short_full = (&commitLogic_0_short_counter);
+  assign commitLogic_0_short_notEmpty = (|commitLogic_0_short_counter);
   always @(*) begin
     commitLogic_0_short_inc = 1'b0;
     if(commitLogic_0_input_valid) begin
@@ -11419,66 +11436,66 @@ module FpuCore (
   assign commitLogic_0_input_payload_rd = commitFork_commit_0_payload_rd;
   assign commitLogic_0_input_payload_write = commitFork_commit_0_payload_write;
   assign commitLogic_0_input_payload_value = commitFork_commit_0_payload_value;
-  assign when_FpuCore_l208 = ((commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_ADD) != 1'b0);
-  assign when_FpuCore_l209 = ({(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_FMA),(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_MUL)} != 2'b00);
-  assign when_FpuCore_l210 = ((commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_DIV) != 1'b0);
-  assign when_FpuCore_l211 = ((commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_SQRT) != 1'b0);
-  assign when_FpuCore_l212 = ({(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX),(commitLogic_0_input_payload_opcode == `FpuOpcode_binary_sequential_SGNJ)}} != 3'b000);
+  assign when_FpuCore_l208 = ((commitLogic_0_input_payload_opcode == FpuOpcode_ADD) != 1'b0);
+  assign when_FpuCore_l209 = ({(commitLogic_0_input_payload_opcode == FpuOpcode_FMA),(commitLogic_0_input_payload_opcode == FpuOpcode_MUL)} != 2'b00);
+  assign when_FpuCore_l210 = ((commitLogic_0_input_payload_opcode == FpuOpcode_DIV) != 1'b0);
+  assign when_FpuCore_l211 = ((commitLogic_0_input_payload_opcode == FpuOpcode_SQRT) != 1'b0);
+  assign when_FpuCore_l212 = ({(commitLogic_0_input_payload_opcode == FpuOpcode_FCVT_X_X),{(commitLogic_0_input_payload_opcode == FpuOpcode_MIN_MAX),(commitLogic_0_input_payload_opcode == FpuOpcode_SGNJ)}} != 3'b000);
   assign io_port_0_cmd_ready = (! io_port_0_cmd_rValid);
-  assign io_port_0_cmd_input_valid = (io_port_0_cmd_valid || io_port_0_cmd_rValid);
-  assign _zz_io_port_0_cmd_input_payload_opcode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_opcode : io_port_0_cmd_payload_opcode);
-  assign _zz_io_port_0_cmd_input_payload_format = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_format : io_port_0_cmd_payload_format);
-  assign _zz_io_port_0_cmd_input_payload_roundMode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_roundMode : io_port_0_cmd_payload_roundMode);
-  assign io_port_0_cmd_input_payload_opcode = _zz_io_port_0_cmd_input_payload_opcode;
-  assign io_port_0_cmd_input_payload_arg = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_arg : io_port_0_cmd_payload_arg);
-  assign io_port_0_cmd_input_payload_rs1 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs1 : io_port_0_cmd_payload_rs1);
-  assign io_port_0_cmd_input_payload_rs2 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs2 : io_port_0_cmd_payload_rs2);
-  assign io_port_0_cmd_input_payload_rs3 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs3 : io_port_0_cmd_payload_rs3);
-  assign io_port_0_cmd_input_payload_rd = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rd : io_port_0_cmd_payload_rd);
-  assign io_port_0_cmd_input_payload_format = _zz_io_port_0_cmd_input_payload_format;
-  assign io_port_0_cmd_input_payload_roundMode = _zz_io_port_0_cmd_input_payload_roundMode;
+  assign scheduler_0_input_valid = (io_port_0_cmd_valid || io_port_0_cmd_rValid);
+  assign _zz_scheduler_0_input_payload_opcode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_opcode : io_port_0_cmd_payload_opcode);
+  assign _zz_scheduler_0_input_payload_format = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_format : io_port_0_cmd_payload_format);
+  assign _zz_scheduler_0_input_payload_roundMode = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_roundMode : io_port_0_cmd_payload_roundMode);
+  assign scheduler_0_input_payload_opcode = _zz_scheduler_0_input_payload_opcode;
+  assign scheduler_0_input_payload_arg = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_arg : io_port_0_cmd_payload_arg);
+  assign scheduler_0_input_payload_rs1 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs1 : io_port_0_cmd_payload_rs1);
+  assign scheduler_0_input_payload_rs2 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs2 : io_port_0_cmd_payload_rs2);
+  assign scheduler_0_input_payload_rs3 = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rs3 : io_port_0_cmd_payload_rs3);
+  assign scheduler_0_input_payload_rd = (io_port_0_cmd_rValid ? io_port_0_cmd_rData_rd : io_port_0_cmd_payload_rd);
+  assign scheduler_0_input_payload_format = _zz_scheduler_0_input_payload_format;
+  assign scheduler_0_input_payload_roundMode = _zz_scheduler_0_input_payload_roundMode;
   always @(*) begin
     scheduler_0_useRs1 = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
         scheduler_0_useRs1 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
         scheduler_0_useRs1 = 1'b1;
       end
       default : begin
@@ -11489,44 +11506,44 @@ module FpuCore (
 
   always @(*) begin
     scheduler_0_useRs2 = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         scheduler_0_useRs2 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
       end
       default : begin
       end
@@ -11535,37 +11552,37 @@ module FpuCore (
 
   always @(*) begin
     scheduler_0_useRs3 = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRs3 = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
       end
       default : begin
       end
@@ -11574,46 +11591,46 @@ module FpuCore (
 
   always @(*) begin
     scheduler_0_useRd = 1'b0;
-    case(io_port_0_cmd_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : begin
+    case(scheduler_0_input_payload_opcode)
+      FpuOpcode_LOAD : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_STORE : begin
+      FpuOpcode_STORE : begin
       end
-      `FpuOpcode_binary_sequential_ADD : begin
+      FpuOpcode_ADD : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_MUL : begin
+      FpuOpcode_MUL : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_DIV : begin
+      FpuOpcode_DIV : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_SQRT : begin
+      FpuOpcode_SQRT : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMA : begin
+      FpuOpcode_FMA : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_I2F : begin
+      FpuOpcode_I2F : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
       end
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+      FpuOpcode_MIN_MAX : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
       end
-      `FpuOpcode_binary_sequential_FMV_W_X : begin
+      FpuOpcode_FMV_W_X : begin
         scheduler_0_useRd = 1'b1;
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
       end
       default : begin
         scheduler_0_useRd = 1'b1;
@@ -11638,25 +11655,25 @@ module FpuCore (
   assign scheduler_0_hits_2 = (scheduler_0_useRs3 && scheduler_0_rfBusy_2);
   assign scheduler_0_hits_3 = (scheduler_0_useRd && scheduler_0_rfBusy_3);
   assign scheduler_0_hazard = ((({scheduler_0_hits_3,{scheduler_0_hits_2,{scheduler_0_hits_1,scheduler_0_hits_0}}} != 4'b0000) || (! rf_init_done)) || commitLogic_0_pending_full);
-  assign _zz_io_port_0_cmd_input_ready = (! scheduler_0_hazard);
-  assign scheduler_0_output_valid = (io_port_0_cmd_input_valid && _zz_io_port_0_cmd_input_ready);
-  assign io_port_0_cmd_input_ready = (scheduler_0_output_ready && _zz_io_port_0_cmd_input_ready);
-  assign scheduler_0_output_payload_opcode = io_port_0_cmd_input_payload_opcode;
-  assign scheduler_0_output_payload_arg = io_port_0_cmd_input_payload_arg;
+  assign _zz_scheduler_0_input_ready = (! scheduler_0_hazard);
+  assign scheduler_0_output_valid = (scheduler_0_input_valid && _zz_scheduler_0_input_ready);
+  assign scheduler_0_input_ready = (scheduler_0_output_ready && _zz_scheduler_0_input_ready);
+  assign scheduler_0_output_payload_opcode = scheduler_0_input_payload_opcode;
+  assign scheduler_0_output_payload_arg = scheduler_0_input_payload_arg;
   always @(*) begin
-    scheduler_0_output_payload_rs1 = io_port_0_cmd_input_payload_rs1;
+    scheduler_0_output_payload_rs1 = scheduler_0_input_payload_rs1;
     if(when_FpuCore_l258) begin
-      scheduler_0_output_payload_rs1 = io_port_0_cmd_input_payload_rs2;
+      scheduler_0_output_payload_rs1 = scheduler_0_input_payload_rs2;
     end
   end
 
-  assign scheduler_0_output_payload_rs2 = io_port_0_cmd_input_payload_rs2;
-  assign scheduler_0_output_payload_rs3 = io_port_0_cmd_input_payload_rs3;
-  assign scheduler_0_output_payload_rd = io_port_0_cmd_input_payload_rd;
-  assign scheduler_0_output_payload_format = io_port_0_cmd_input_payload_format;
-  assign scheduler_0_output_payload_roundMode = io_port_0_cmd_input_payload_roundMode;
-  assign when_FpuCore_l258 = (io_port_0_cmd_input_payload_opcode == `FpuOpcode_binary_sequential_STORE);
-  assign when_FpuCore_l261 = (io_port_0_cmd_input_valid && rf_init_done);
+  assign scheduler_0_output_payload_rs2 = scheduler_0_input_payload_rs2;
+  assign scheduler_0_output_payload_rs3 = scheduler_0_input_payload_rs3;
+  assign scheduler_0_output_payload_rd = scheduler_0_input_payload_rd;
+  assign scheduler_0_output_payload_format = scheduler_0_input_payload_format;
+  assign scheduler_0_output_payload_roundMode = scheduler_0_input_payload_roundMode;
+  assign when_FpuCore_l258 = (scheduler_0_input_payload_opcode == FpuOpcode_STORE);
+  assign when_FpuCore_l261 = (scheduler_0_input_valid && rf_init_done);
   assign scheduler_0_output_fire = (scheduler_0_output_valid && scheduler_0_output_ready);
   assign when_FpuCore_l265 = (scheduler_0_output_fire && scheduler_0_useRd);
   assign scheduler_0_output_ready = cmdArbiter_arbiter_io_inputs_0_ready;
@@ -11681,23 +11698,23 @@ module FpuCore (
   assign read_s0_payload_arg = cmdArbiter_output_payload_arg;
   assign read_s0_payload_roundMode = cmdArbiter_output_payload_roundMode;
   always @(*) begin
-    read_s0_ready = read_s0_s1_ready;
-    if(when_Stream_l342) begin
+    read_s0_ready = read_s1_ready;
+    if(when_Stream_l368) begin
       read_s0_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! read_s0_s1_valid);
-  assign read_s0_s1_valid = read_s0_rValid;
-  assign read_s0_s1_payload_opcode = read_s0_rData_opcode;
-  assign read_s0_s1_payload_rs1 = read_s0_rData_rs1;
-  assign read_s0_s1_payload_rs2 = read_s0_rData_rs2;
-  assign read_s0_s1_payload_rs3 = read_s0_rData_rs3;
-  assign read_s0_s1_payload_rd = read_s0_rData_rd;
-  assign read_s0_s1_payload_arg = read_s0_rData_arg;
-  assign read_s0_s1_payload_roundMode = read_s0_rData_roundMode;
-  assign read_output_valid = read_s0_s1_valid;
-  assign read_s0_s1_ready = read_output_ready;
+  assign when_Stream_l368 = (! read_s1_valid);
+  assign read_s1_valid = read_s0_rValid;
+  assign read_s1_payload_opcode = read_s0_rData_opcode;
+  assign read_s1_payload_rs1 = read_s0_rData_rs1;
+  assign read_s1_payload_rs2 = read_s0_rData_rs2;
+  assign read_s1_payload_rs3 = read_s0_rData_rs3;
+  assign read_s1_payload_rd = read_s0_rData_rd;
+  assign read_s1_payload_arg = read_s0_rData_arg;
+  assign read_s1_payload_roundMode = read_s0_rData_roundMode;
+  assign read_output_valid = read_s1_valid;
+  assign read_s1_ready = read_output_ready;
   assign _zz_read_rs_0_value_mantissa = read_s0_payload_rs1;
   assign read_output_isStall = (read_output_valid && (! read_output_ready));
   assign _zz_read_rs_0_value_mantissa_1 = (! read_output_isStall);
@@ -11722,10 +11739,10 @@ module FpuCore (
   assign read_rs_2_value_exponent = _zz_read_rs_2_value_mantissa_2[31 : 23];
   assign read_rs_2_value_sign = _zz_read_rs_2_value_mantissa_2[32];
   assign read_rs_2_value_special = _zz_read_rs_2_value_mantissa_2[33];
-  assign read_output_payload_opcode = read_s0_s1_payload_opcode;
-  assign read_output_payload_arg = read_s0_s1_payload_arg;
-  assign read_output_payload_roundMode = read_s0_s1_payload_roundMode;
-  assign read_output_payload_rd = read_s0_s1_payload_rd;
+  assign read_output_payload_opcode = read_s1_payload_opcode;
+  assign read_output_payload_arg = read_s1_payload_arg;
+  assign read_output_payload_roundMode = read_s1_payload_roundMode;
+  assign read_output_payload_rd = read_s1_payload_rd;
   assign read_output_payload_rs1_mantissa = read_rs_0_value_mantissa;
   assign read_output_payload_rs1_exponent = read_rs_0_value_exponent;
   assign read_output_payload_rs1_sign = read_rs_0_value_sign;
@@ -11778,14 +11795,14 @@ module FpuCore (
     end
   end
 
-  assign decode_loadHit = ({(decode_input_payload_opcode == `FpuOpcode_binary_sequential_I2F),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FMV_W_X),(decode_input_payload_opcode == `FpuOpcode_binary_sequential_LOAD)}} != 3'b000);
+  assign decode_loadHit = ({(decode_input_payload_opcode == FpuOpcode_I2F),{(decode_input_payload_opcode == FpuOpcode_FMV_W_X),(decode_input_payload_opcode == FpuOpcode_LOAD)}} != 3'b000);
   assign decode_load_valid = (decode_input_valid && decode_loadHit);
   assign when_FpuCore_l329 = (decode_loadHit && decode_load_ready);
   assign decode_load_payload_rd = decode_input_payload_rd;
   assign decode_load_payload_arg = decode_input_payload_arg;
   assign decode_load_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_load_payload_i2f = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_I2F);
-  assign decode_shortPipHit = ({(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FCLASS),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_FMV_X_W),{(decode_input_payload_opcode == `FpuOpcode_binary_sequential_SGNJ),{(decode_input_payload_opcode == _zz_decode_shortPipHit),{_zz_decode_shortPipHit_1,{_zz_decode_shortPipHit_2,_zz_decode_shortPipHit_3}}}}}}} != 8'h0);
+  assign decode_load_payload_i2f = (decode_input_payload_opcode == FpuOpcode_I2F);
+  assign decode_shortPipHit = ({(decode_input_payload_opcode == FpuOpcode_FCVT_X_X),{(decode_input_payload_opcode == FpuOpcode_FCLASS),{(decode_input_payload_opcode == FpuOpcode_FMV_X_W),{(decode_input_payload_opcode == FpuOpcode_SGNJ),{(decode_input_payload_opcode == _zz_decode_shortPipHit),{_zz_decode_shortPipHit_1,{_zz_decode_shortPipHit_2,_zz_decode_shortPipHit_3}}}}}}} != 8'h0);
   assign when_FpuCore_l335 = (decode_shortPipHit && decode_shortPip_ready);
   assign decode_shortPip_valid = (decode_input_valid && decode_shortPipHit);
   assign decode_shortPip_payload_opcode = decode_input_payload_opcode;
@@ -11800,8 +11817,8 @@ module FpuCore (
   assign decode_shortPip_payload_rd = decode_input_payload_rd;
   assign decode_shortPip_payload_arg = decode_input_payload_arg;
   assign decode_shortPip_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_divSqrtHit = ((decode_input_payload_opcode == `FpuOpcode_binary_sequential_DIV) || (decode_input_payload_opcode == `FpuOpcode_binary_sequential_SQRT));
-  assign decode_divHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_DIV);
+  assign decode_divSqrtHit = ((decode_input_payload_opcode == FpuOpcode_DIV) || (decode_input_payload_opcode == FpuOpcode_SQRT));
+  assign decode_divHit = (decode_input_payload_opcode == FpuOpcode_DIV);
   assign when_FpuCore_l351 = (decode_divHit && decode_div_ready);
   assign decode_div_valid = (decode_input_valid && decode_divHit);
   assign decode_div_payload_rs1_mantissa = decode_input_payload_rs1_mantissa;
@@ -11814,7 +11831,7 @@ module FpuCore (
   assign decode_div_payload_rs2_special = decode_input_payload_rs2_special;
   assign decode_div_payload_rd = decode_input_payload_rd;
   assign decode_div_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_sqrtHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_SQRT);
+  assign decode_sqrtHit = (decode_input_payload_opcode == FpuOpcode_SQRT);
   assign when_FpuCore_l359 = (decode_sqrtHit && decode_sqrt_ready);
   assign decode_sqrt_valid = (decode_input_valid && decode_sqrtHit);
   assign decode_sqrt_payload_rs1_mantissa = decode_input_payload_rs1_mantissa;
@@ -11823,8 +11840,8 @@ module FpuCore (
   assign decode_sqrt_payload_rs1_special = decode_input_payload_rs1_special;
   assign decode_sqrt_payload_rd = decode_input_payload_rd;
   assign decode_sqrt_payload_roundMode = decode_input_payload_roundMode;
-  assign decode_fmaHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_FMA);
-  assign decode_mulHit = ((decode_input_payload_opcode == `FpuOpcode_binary_sequential_MUL) || decode_fmaHit);
+  assign decode_fmaHit = (decode_input_payload_opcode == FpuOpcode_FMA);
+  assign decode_mulHit = ((decode_input_payload_opcode == FpuOpcode_MUL) || decode_fmaHit);
   assign decode_divSqrtToMul_valid = 1'b0;
   assign decode_divSqrtToMul_payload_rs1_mantissa = 23'bxxxxxxxxxxxxxxxxxxxxxxx;
   assign decode_divSqrtToMul_payload_rs1_exponent = 9'bxxxxxxxxx;
@@ -11976,7 +11993,7 @@ module FpuCore (
   end
 
   assign when_FpuCore_l380 = (! decode_divSqrtToMul_valid);
-  assign decode_addHit = (decode_input_payload_opcode == `FpuOpcode_binary_sequential_ADD);
+  assign decode_addHit = (decode_input_payload_opcode == FpuOpcode_ADD);
   assign when_FpuCore_l399 = ((decode_addHit && decode_add_ready) && (! decode_mulToAdd_valid));
   assign decode_add_valid = ((decode_input_valid && decode_addHit) || decode_mulToAdd_valid);
   assign decode_mulToAdd_ready = decode_add_ready;
@@ -12067,41 +12084,41 @@ module FpuCore (
   assign decode_load_s2mPipe_payload_roundMode = _zz_decode_load_s2mPipe_payload_roundMode;
   always @(*) begin
     decode_load_s2mPipe_ready = decode_load_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342_1) begin
+    if(when_Stream_l368_1) begin
       decode_load_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_1 = (! decode_load_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368_1 = (! decode_load_s2mPipe_m2sPipe_valid);
   assign decode_load_s2mPipe_m2sPipe_valid = decode_load_s2mPipe_rValid;
   assign decode_load_s2mPipe_m2sPipe_payload_rd = decode_load_s2mPipe_rData_rd;
   assign decode_load_s2mPipe_m2sPipe_payload_i2f = decode_load_s2mPipe_rData_i2f;
   assign decode_load_s2mPipe_m2sPipe_payload_arg = decode_load_s2mPipe_rData_arg;
   assign decode_load_s2mPipe_m2sPipe_payload_roundMode = decode_load_s2mPipe_rData_roundMode;
   always @(*) begin
-    decode_load_s2mPipe_m2sPipe_ready = decode_load_s2mPipe_m2sPipe_input_ready;
-    if(when_Stream_l342_2) begin
+    decode_load_s2mPipe_m2sPipe_ready = load_s0_input_ready;
+    if(when_Stream_l368_2) begin
       decode_load_s2mPipe_m2sPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_2 = (! decode_load_s2mPipe_m2sPipe_input_valid);
-  assign decode_load_s2mPipe_m2sPipe_input_valid = decode_load_s2mPipe_m2sPipe_rValid;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_rd = decode_load_s2mPipe_m2sPipe_rData_rd;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_i2f = decode_load_s2mPipe_m2sPipe_rData_i2f;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_arg = decode_load_s2mPipe_m2sPipe_rData_arg;
-  assign decode_load_s2mPipe_m2sPipe_input_payload_roundMode = decode_load_s2mPipe_m2sPipe_rData_roundMode;
-  assign when_Stream_l408 = (! ({(commitFork_load_0_payload_opcode == `FpuOpcode_binary_sequential_I2F),{(commitFork_load_0_payload_opcode == `FpuOpcode_binary_sequential_FMV_W_X),(commitFork_load_0_payload_opcode == `FpuOpcode_binary_sequential_LOAD)}} != 3'b000));
+  assign when_Stream_l368_2 = (! load_s0_input_valid);
+  assign load_s0_input_valid = decode_load_s2mPipe_m2sPipe_rValid;
+  assign load_s0_input_payload_rd = decode_load_s2mPipe_m2sPipe_rData_rd;
+  assign load_s0_input_payload_i2f = decode_load_s2mPipe_m2sPipe_rData_i2f;
+  assign load_s0_input_payload_arg = decode_load_s2mPipe_m2sPipe_rData_arg;
+  assign load_s0_input_payload_roundMode = decode_load_s2mPipe_m2sPipe_rData_roundMode;
+  assign when_Stream_l438 = (! ({(commitFork_load_0_payload_opcode == FpuOpcode_I2F),{(commitFork_load_0_payload_opcode == FpuOpcode_FMV_W_X),(commitFork_load_0_payload_opcode == FpuOpcode_LOAD)}} != 3'b000));
   always @(*) begin
     load_s0_filtred_0_valid = commitFork_load_0_valid;
-    if(when_Stream_l408) begin
+    if(when_Stream_l438) begin
       load_s0_filtred_0_valid = 1'b0;
     end
   end
 
   always @(*) begin
     commitFork_load_0_ready = load_s0_filtred_0_ready;
-    if(when_Stream_l408) begin
+    if(when_Stream_l438) begin
       commitFork_load_0_ready = 1'b1;
     end
   end
@@ -12111,35 +12128,35 @@ module FpuCore (
   assign load_s0_filtred_0_payload_write = commitFork_load_0_payload_write;
   assign load_s0_filtred_0_payload_value = commitFork_load_0_payload_value;
   assign load_s0_hazard = (! load_s0_filtred_0_valid);
-  assign _zz_decode_load_s2mPipe_m2sPipe_input_ready = (! load_s0_hazard);
-  assign decode_load_s2mPipe_m2sPipe_input_ready = (load_s0_output_ready && _zz_decode_load_s2mPipe_m2sPipe_input_ready);
-  assign load_s0_output_valid = (decode_load_s2mPipe_m2sPipe_input_valid && _zz_decode_load_s2mPipe_m2sPipe_input_ready);
+  assign _zz_load_s0_input_ready = (! load_s0_hazard);
+  assign load_s0_input_ready = (load_s0_output_ready && _zz_load_s0_input_ready);
+  assign load_s0_output_valid = (load_s0_input_valid && _zz_load_s0_input_ready);
   always @(*) begin
     load_s0_filtred_0_ready = 1'b0;
     if(_zz_when[0]) begin
-      load_s0_filtred_0_ready = (decode_load_s2mPipe_m2sPipe_input_valid && load_s0_output_ready);
+      load_s0_filtred_0_ready = (load_s0_input_valid && load_s0_output_ready);
     end
   end
 
-  assign load_s0_output_payload_rd = decode_load_s2mPipe_m2sPipe_input_payload_rd;
+  assign load_s0_output_payload_rd = load_s0_input_payload_rd;
   assign load_s0_output_payload_value = load_s0_filtred_0_payload_value;
-  assign load_s0_output_payload_i2f = decode_load_s2mPipe_m2sPipe_input_payload_i2f;
-  assign load_s0_output_payload_arg = decode_load_s2mPipe_m2sPipe_input_payload_arg;
-  assign load_s0_output_payload_roundMode = decode_load_s2mPipe_m2sPipe_input_payload_roundMode;
+  assign load_s0_output_payload_i2f = load_s0_input_payload_i2f;
+  assign load_s0_output_payload_arg = load_s0_input_payload_arg;
+  assign load_s0_output_payload_roundMode = load_s0_input_payload_roundMode;
   always @(*) begin
-    load_s0_output_ready = load_s0_output_input_ready;
-    if(when_Stream_l342_3) begin
+    load_s0_output_ready = load_s1_input_ready;
+    if(when_Stream_l368_3) begin
       load_s0_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_3 = (! load_s0_output_input_valid);
-  assign load_s0_output_input_valid = load_s0_output_rValid;
-  assign load_s0_output_input_payload_rd = load_s0_output_rData_rd;
-  assign load_s0_output_input_payload_value = load_s0_output_rData_value;
-  assign load_s0_output_input_payload_i2f = load_s0_output_rData_i2f;
-  assign load_s0_output_input_payload_arg = load_s0_output_rData_arg;
-  assign load_s0_output_input_payload_roundMode = load_s0_output_rData_roundMode;
+  assign when_Stream_l368_3 = (! load_s1_input_valid);
+  assign load_s1_input_valid = load_s0_output_rValid;
+  assign load_s1_input_payload_rd = load_s0_output_rData_rd;
+  assign load_s1_input_payload_value = load_s0_output_rData_value;
+  assign load_s1_input_payload_i2f = load_s0_output_rData_i2f;
+  assign load_s1_input_payload_arg = load_s0_output_rData_arg;
+  assign load_s1_input_payload_roundMode = load_s0_output_rData_roundMode;
   always @(*) begin
     load_s1_busy = 1'b0;
     if(when_FpuCore_l529) begin
@@ -12147,9 +12164,9 @@ module FpuCore (
     end
   end
 
-  assign load_s1_f32_mantissa = load_s0_output_input_payload_value[22 : 0];
-  assign load_s1_f32_exponent = load_s0_output_input_payload_value[30 : 23];
-  assign load_s1_f32_sign = load_s0_output_input_payload_value[31];
+  assign load_s1_f32_mantissa = load_s1_input_payload_value[22 : 0];
+  assign load_s1_f32_exponent = load_s1_input_payload_value[30 : 23];
+  assign load_s1_f32_sign = load_s1_input_payload_value[31];
   assign load_s1_passThroughFloat_special = 1'b0;
   assign load_s1_passThroughFloat_sign = load_s1_f32_sign;
   assign load_s1_passThroughFloat_exponent = {1'd0, load_s1_f32_exponent};
@@ -12157,7 +12174,7 @@ module FpuCore (
   assign load_s1_recodedExpOffset = 9'h080;
   assign load_s1_manZero = (load_s1_passThroughFloat_mantissa == 23'h0);
   assign load_s1_expZero = (load_s1_passThroughFloat_exponent == 9'h0);
-  assign load_s1_expOne = (load_s1_passThroughFloat_exponent[7 : 0] == 8'hff);
+  assign load_s1_expOne = (&load_s1_passThroughFloat_exponent[7 : 0]);
   assign load_s1_isZero = (load_s1_expZero && load_s1_manZero);
   assign load_s1_isSubnormal = (load_s1_expZero && (! load_s1_manZero));
   assign load_s1_isInfinity = (load_s1_expOne && load_s1_manZero);
@@ -12165,22 +12182,22 @@ module FpuCore (
   always @(*) begin
     load_s1_fsm_ohInput = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     if(when_FpuCore_l508) begin
-      load_s1_fsm_ohInput = ({9'd0,load_s0_output_input_payload_value[22 : 0]} <<< 9);
+      load_s1_fsm_ohInput = ({9'd0,load_s1_input_payload_value[22 : 0]} <<< 9);
     end else begin
-      load_s1_fsm_ohInput[31 : 0] = load_s0_output_input_payload_value[31 : 0];
+      load_s1_fsm_ohInput[31 : 0] = load_s1_input_payload_value[31 : 0];
     end
   end
 
-  assign when_FpuCore_l508 = (! load_s0_output_input_payload_i2f);
+  assign when_FpuCore_l508 = (! load_s1_input_payload_i2f);
   always @(*) begin
     load_s1_fsm_shift_input = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
     load_s1_fsm_shift_input = (load_s1_fsm_ohInput <<< 1);
   end
 
   assign when_FpuCore_l525 = (! load_s1_fsm_done);
-  assign when_FpuCore_l529 = ((load_s0_output_input_valid && (load_s0_output_input_payload_i2f || load_s1_isSubnormal)) && (! load_s1_fsm_done));
-  assign when_FpuCore_l532 = (((load_s0_output_input_payload_i2f && (! load_s1_fsm_patched)) && load_s0_output_input_payload_value[31]) && load_s0_output_input_payload_arg[0]);
-  assign _zz_load_s0_output_rData_value = load_s0_output_input_payload_value;
+  assign when_FpuCore_l529 = ((load_s1_input_valid && (load_s1_input_payload_i2f || load_s1_isSubnormal)) && (! load_s1_fsm_done));
+  assign when_FpuCore_l532 = (((load_s1_input_payload_i2f && (! load_s1_fsm_patched)) && load_s1_input_payload_value[31]) && load_s1_input_payload_arg[0]);
+  assign _zz_load_s0_output_rData_value = load_s1_input_payload_value;
   assign _zz_load_s0_output_rData_value_1 = 1'b1;
   assign _zz_load_s1_fsm_shift_by = {load_s1_fsm_ohInput[0],{load_s1_fsm_ohInput[1],{load_s1_fsm_ohInput[2],{load_s1_fsm_ohInput[3],{load_s1_fsm_ohInput[4],{load_s1_fsm_ohInput[5],{load_s1_fsm_ohInput[6],{load_s1_fsm_ohInput[7],{load_s1_fsm_ohInput[8],{_zz__zz_load_s1_fsm_shift_by,{_zz__zz_load_s1_fsm_shift_by_1,_zz__zz_load_s1_fsm_shift_by_2}}}}}}}}}}};
   assign _zz_load_s1_fsm_shift_by_1 = (_zz_load_s1_fsm_shift_by & (~ _zz__zz_load_s1_fsm_shift_by_1_1));
@@ -12222,8 +12239,8 @@ module FpuCore (
     end
   end
 
-  assign load_s0_output_input_isStall = (load_s0_output_input_valid && (! load_s0_output_input_ready));
-  assign when_FpuCore_l551 = (! load_s0_output_input_isStall);
+  assign load_s1_input_isStall = (load_s1_input_valid && (! load_s1_input_ready));
+  assign when_FpuCore_l551 = (! load_s1_input_isStall);
   assign load_s1_i2fHigh = load_s1_fsm_shift_output[31 : 8];
   assign load_s1_i2fLow = load_s1_fsm_shift_output[7 : 0];
   assign load_s1_scrap = (load_s1_i2fLow != 8'h0);
@@ -12256,21 +12273,21 @@ module FpuCore (
     end
   end
 
-  assign _zz_load_s0_output_input_ready = (! load_s1_busy);
-  assign load_s0_output_input_ready = (load_s1_output_ready && _zz_load_s0_output_input_ready);
-  assign load_s1_output_valid = (load_s0_output_input_valid && _zz_load_s0_output_input_ready);
-  assign load_s1_output_payload_roundMode = load_s0_output_input_payload_roundMode;
-  assign load_s1_output_payload_rd = load_s0_output_input_payload_rd;
+  assign _zz_load_s1_input_ready = (! load_s1_busy);
+  assign load_s1_input_ready = (load_s1_output_ready && _zz_load_s1_input_ready);
+  assign load_s1_output_valid = (load_s1_input_valid && _zz_load_s1_input_ready);
+  assign load_s1_output_payload_roundMode = load_s1_input_payload_roundMode;
+  assign load_s1_output_payload_rd = load_s1_input_payload_rd;
   always @(*) begin
     load_s1_output_payload_value_sign = load_s1_recoded_sign;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_value_sign = load_s1_fsm_patched;
     end
   end
 
   always @(*) begin
     load_s1_output_payload_value_exponent = load_s1_recoded_exponent;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_value_exponent = (9'h11e - _zz_load_s1_output_payload_value_exponent);
       if(load_s1_fsm_i2fZero) begin
         load_s1_output_payload_value_exponent[1 : 0] = 2'b00;
@@ -12287,7 +12304,7 @@ module FpuCore (
 
   always @(*) begin
     load_s1_output_payload_value_special = load_s1_recoded_special;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_value_special = 1'b0;
       if(load_s1_fsm_i2fZero) begin
         load_s1_output_payload_value_special = 1'b1;
@@ -12297,39 +12314,39 @@ module FpuCore (
 
   always @(*) begin
     load_s1_output_payload_scrap = 1'b0;
-    if(load_s0_output_input_payload_i2f) begin
+    if(load_s1_input_payload_i2f) begin
       load_s1_output_payload_scrap = load_s1_scrap;
     end
   end
 
   assign load_s1_output_payload_NV = 1'b0;
   assign load_s1_output_payload_DZ = 1'b0;
-  assign when_FpuCore_l594 = (load_s0_output_input_payload_i2f || load_s1_isSubnormal);
+  assign when_FpuCore_l594 = (load_s1_input_payload_i2f || load_s1_isSubnormal);
   always @(*) begin
-    decode_shortPip_ready = decode_shortPip_input_ready;
-    if(when_Stream_l342_4) begin
+    decode_shortPip_ready = shortPip_input_ready;
+    if(when_Stream_l368_4) begin
       decode_shortPip_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_4 = (! decode_shortPip_input_valid);
-  assign decode_shortPip_input_valid = decode_shortPip_rValid;
-  assign decode_shortPip_input_payload_opcode = decode_shortPip_rData_opcode;
-  assign decode_shortPip_input_payload_rs1_mantissa = decode_shortPip_rData_rs1_mantissa;
-  assign decode_shortPip_input_payload_rs1_exponent = decode_shortPip_rData_rs1_exponent;
-  assign decode_shortPip_input_payload_rs1_sign = decode_shortPip_rData_rs1_sign;
-  assign decode_shortPip_input_payload_rs1_special = decode_shortPip_rData_rs1_special;
-  assign decode_shortPip_input_payload_rs2_mantissa = decode_shortPip_rData_rs2_mantissa;
-  assign decode_shortPip_input_payload_rs2_exponent = decode_shortPip_rData_rs2_exponent;
-  assign decode_shortPip_input_payload_rs2_sign = decode_shortPip_rData_rs2_sign;
-  assign decode_shortPip_input_payload_rs2_special = decode_shortPip_rData_rs2_special;
-  assign decode_shortPip_input_payload_rd = decode_shortPip_rData_rd;
-  assign decode_shortPip_input_payload_value = decode_shortPip_rData_value;
-  assign decode_shortPip_input_payload_arg = decode_shortPip_rData_arg;
-  assign decode_shortPip_input_payload_roundMode = decode_shortPip_rData_roundMode;
-  assign shortPip_toFpuRf = ({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_SGNJ),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX)}} != 3'b000);
-  assign decode_shortPip_input_fire = (decode_shortPip_input_valid && decode_shortPip_input_ready);
-  assign when_FpuCore_l221 = ((decode_shortPip_input_fire && shortPip_toFpuRf) && 1'b1);
+  assign when_Stream_l368_4 = (! shortPip_input_valid);
+  assign shortPip_input_valid = decode_shortPip_rValid;
+  assign shortPip_input_payload_opcode = decode_shortPip_rData_opcode;
+  assign shortPip_input_payload_rs1_mantissa = decode_shortPip_rData_rs1_mantissa;
+  assign shortPip_input_payload_rs1_exponent = decode_shortPip_rData_rs1_exponent;
+  assign shortPip_input_payload_rs1_sign = decode_shortPip_rData_rs1_sign;
+  assign shortPip_input_payload_rs1_special = decode_shortPip_rData_rs1_special;
+  assign shortPip_input_payload_rs2_mantissa = decode_shortPip_rData_rs2_mantissa;
+  assign shortPip_input_payload_rs2_exponent = decode_shortPip_rData_rs2_exponent;
+  assign shortPip_input_payload_rs2_sign = decode_shortPip_rData_rs2_sign;
+  assign shortPip_input_payload_rs2_special = decode_shortPip_rData_rs2_special;
+  assign shortPip_input_payload_rd = decode_shortPip_rData_rd;
+  assign shortPip_input_payload_value = decode_shortPip_rData_value;
+  assign shortPip_input_payload_arg = decode_shortPip_rData_arg;
+  assign shortPip_input_payload_roundMode = decode_shortPip_rData_roundMode;
+  assign shortPip_toFpuRf = ({(shortPip_input_payload_opcode == FpuOpcode_FCVT_X_X),{(shortPip_input_payload_opcode == FpuOpcode_SGNJ),(shortPip_input_payload_opcode == FpuOpcode_MIN_MAX)}} != 3'b000);
+  assign shortPip_input_fire = (shortPip_input_valid && shortPip_input_ready);
+  assign when_FpuCore_l221 = ((shortPip_input_fire && shortPip_toFpuRf) && 1'b1);
   assign shortPip_isCommited = commitLogic_0_short_notEmpty;
   assign _zz_shortPip_rfOutput_ready = (! (! shortPip_isCommited));
   assign shortPip_output_valid = (shortPip_rfOutput_valid && _zz_shortPip_rfOutput_ready);
@@ -12345,20 +12362,20 @@ module FpuCore (
   assign shortPip_output_payload_DZ = shortPip_rfOutput_payload_DZ;
   always @(*) begin
     shortPip_result = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_STORE : begin
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_STORE : begin
         shortPip_result = shortPip_recodedResult;
       end
-      `FpuOpcode_binary_sequential_FMV_X_W : begin
+      FpuOpcode_FMV_X_W : begin
         shortPip_result = shortPip_recodedResult;
       end
-      `FpuOpcode_binary_sequential_F2I : begin
+      FpuOpcode_F2I : begin
         shortPip_result[31 : 0] = shortPip_f2i_result;
       end
-      `FpuOpcode_binary_sequential_CMP : begin
+      FpuOpcode_CMP : begin
         shortPip_result[31 : 0] = {31'd0, shortPip_cmpResult};
       end
-      `FpuOpcode_binary_sequential_FCLASS : begin
+      FpuOpcode_FCLASS : begin
         shortPip_result[31 : 0] = shortPip_fclassResult;
       end
       default : begin
@@ -12374,9 +12391,9 @@ module FpuCore (
   end
 
   assign shortPip_f32_exp = _zz_shortPip_f32_exp[7:0];
-  assign shortPip_f32_man = decode_shortPip_input_payload_rs1_mantissa[22 : 0];
+  assign shortPip_f32_man = shortPip_input_payload_rs1_mantissa[22 : 0];
   always @(*) begin
-    shortPip_recodedResult = {{decode_shortPip_input_payload_rs1_sign,shortPip_f32_exp},shortPip_f32_man};
+    shortPip_recodedResult = {{shortPip_input_payload_rs1_sign,shortPip_f32_exp},shortPip_f32_man};
     if(shortPip_isSubnormal) begin
       shortPip_recodedResult[22 : 0] = shortPip_fsm_shift_output[22 : 0];
     end
@@ -12393,16 +12410,16 @@ module FpuCore (
   end
 
   assign shortPip_expSubnormalThreshold = 8'h80;
-  assign shortPip_expInSubnormalRange = (decode_shortPip_input_payload_rs1_exponent <= _zz_shortPip_expInSubnormalRange);
-  assign shortPip_isSubnormal = ((! decode_shortPip_input_payload_rs1_special) && shortPip_expInSubnormalRange);
-  assign shortPip_isNormal = ((! decode_shortPip_input_payload_rs1_special) && (! shortPip_expInSubnormalRange));
-  assign shortPip_fsm_f2iShift = (decode_shortPip_input_payload_rs1_exponent - 9'h0ff);
-  assign shortPip_fsm_isF2i = (decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_F2I);
-  assign shortPip_fsm_needRecoding = (({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_STORE),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_FMV_X_W)} != 2'b00) && shortPip_isSubnormal);
-  assign shortPip_fsm_isZero = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign shortPip_expInSubnormalRange = (shortPip_input_payload_rs1_exponent <= _zz_shortPip_expInSubnormalRange);
+  assign shortPip_isSubnormal = ((! shortPip_input_payload_rs1_special) && shortPip_expInSubnormalRange);
+  assign shortPip_isNormal = ((! shortPip_input_payload_rs1_special) && (! shortPip_expInSubnormalRange));
+  assign shortPip_fsm_f2iShift = (shortPip_input_payload_rs1_exponent - 9'h0ff);
+  assign shortPip_fsm_isF2i = (shortPip_input_payload_opcode == FpuOpcode_F2I);
+  assign shortPip_fsm_needRecoding = (({(shortPip_input_payload_opcode == FpuOpcode_STORE),(shortPip_input_payload_opcode == FpuOpcode_FMV_X_W)} != 2'b00) && shortPip_isSubnormal);
+  assign shortPip_fsm_isZero = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
   always @(*) begin
     shortPip_fsm_shift_input = 33'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    shortPip_fsm_shift_input = ({9'd0,{(! shortPip_fsm_isZero),decode_shortPip_input_payload_rs1_mantissa}} <<< 9);
+    shortPip_fsm_shift_input = ({9'd0,{(! shortPip_fsm_isZero),shortPip_input_payload_rs1_mantissa}} <<< 9);
   end
 
   assign when_FpuCore_l646 = (shortPip_fsm_shift_by[5] && (shortPip_fsm_shift_input[31 : 0] != 32'h0));
@@ -12413,14 +12430,14 @@ module FpuCore (
   assign when_FpuCore_l646_5 = (shortPip_fsm_shift_by[0] && (shortPip_fsm_shift_input_5[0 : 0] != 1'b0));
   assign when_FpuCore_l652 = (! shortPip_fsm_done);
   assign shortPip_fsm_formatShiftOffset = 8'h8a;
-  assign when_FpuCore_l658 = ((decode_shortPip_input_valid && (shortPip_fsm_needRecoding || shortPip_fsm_isF2i)) && (! shortPip_fsm_done));
-  assign _zz_shortPip_fsm_shift_by = (9'h11e - decode_shortPip_input_payload_rs1_exponent);
+  assign when_FpuCore_l658 = ((shortPip_input_valid && (shortPip_fsm_needRecoding || shortPip_fsm_isF2i)) && (! shortPip_fsm_done));
+  assign _zz_shortPip_fsm_shift_by = (9'h11e - shortPip_input_payload_rs1_exponent);
   assign _zz_shortPip_fsm_shift_by_1 = 6'h21;
-  assign decode_shortPip_input_isStall = (decode_shortPip_input_valid && (! decode_shortPip_input_ready));
-  assign when_FpuCore_l672 = (! decode_shortPip_input_isStall);
+  assign shortPip_input_isStall = (shortPip_input_valid && (! shortPip_input_ready));
+  assign when_FpuCore_l672 = (! shortPip_input_isStall);
   always @(*) begin
     shortPip_mantissaForced = 1'b0;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_mantissaForced = 1'b1;
@@ -12441,7 +12458,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_exponentForced = 1'b0;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_exponentForced = 1'b1;
@@ -12463,7 +12480,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_mantissaForcedValue = 1'bx;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_mantissaForcedValue = 1'b0;
@@ -12484,7 +12501,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_exponentForcedValue = 1'bx;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b00 : begin
           shortPip_exponentForcedValue = 1'b0;
@@ -12506,7 +12523,7 @@ module FpuCore (
 
   always @(*) begin
     shortPip_cononicalForced = 1'b0;
-    if(decode_shortPip_input_payload_rs1_special) begin
+    if(shortPip_input_payload_rs1_special) begin
       case(switch_FpuCore_l686)
         2'b10 : begin
           if(when_FpuCore_l702) begin
@@ -12519,13 +12536,13 @@ module FpuCore (
     end
   end
 
-  assign switch_FpuCore_l686 = decode_shortPip_input_payload_rs1_exponent[1 : 0];
-  assign when_FpuCore_l702 = decode_shortPip_input_payload_rs1_exponent[2];
+  assign switch_FpuCore_l686 = shortPip_input_payload_rs1_exponent[1 : 0];
+  assign when_FpuCore_l702 = shortPip_input_payload_rs1_exponent[2];
   always @(*) begin
     shortPip_rspNv = 1'b0;
     if(!shortPip_f2i_isZero) begin
       if(when_FpuCore_l767) begin
-        shortPip_rspNv = (((decode_shortPip_input_valid && (decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_F2I)) && shortPip_fsm_done) && (! shortPip_f2i_isZero));
+        shortPip_rspNv = (((shortPip_input_valid && (shortPip_input_payload_opcode == FpuOpcode_F2I)) && shortPip_fsm_done) && (! shortPip_f2i_isZero));
       end
     end
     if(shortPip_NV) begin
@@ -12537,27 +12554,27 @@ module FpuCore (
     shortPip_rspNx = 1'b0;
     if(!shortPip_f2i_isZero) begin
       if(!when_FpuCore_l767) begin
-        shortPip_rspNx = (((decode_shortPip_input_valid && (decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_F2I)) && shortPip_fsm_done) && (shortPip_f2i_round != 2'b00));
+        shortPip_rspNx = (((shortPip_input_valid && (shortPip_input_payload_opcode == FpuOpcode_F2I)) && shortPip_fsm_done) && (shortPip_f2i_round != 2'b00));
       end
     end
   end
 
   assign shortPip_f2i_unsigned = (shortPip_fsm_shift_output[32 : 0] >>> 1);
-  assign shortPip_f2i_resign = (decode_shortPip_input_payload_arg[0] && decode_shortPip_input_payload_rs1_sign);
+  assign shortPip_f2i_resign = (shortPip_input_payload_arg[0] && shortPip_input_payload_rs1_sign);
   assign shortPip_f2i_round = {shortPip_fsm_shift_output[0],shortPip_fsm_shift_scrap};
   always @(*) begin
-    case(decode_shortPip_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+    case(shortPip_input_payload_roundMode)
+      FpuRoundMode_RNE : begin
         shortPip_f2i_increment = (shortPip_f2i_round[1] && (shortPip_f2i_round[0] || shortPip_f2i_unsigned[0]));
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         shortPip_f2i_increment = 1'b0;
       end
-      `FpuRoundMode_opt_RDN : begin
-        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && decode_shortPip_input_payload_rs1_sign);
+      FpuRoundMode_RDN : begin
+        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && shortPip_input_payload_rs1_sign);
       end
-      `FpuRoundMode_opt_RUP : begin
-        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && (! decode_shortPip_input_payload_rs1_sign));
+      FpuRoundMode_RUP : begin
+        shortPip_f2i_increment = ((shortPip_f2i_round != 2'b00) && (! shortPip_input_payload_rs1_sign));
       end
       default : begin
         shortPip_f2i_increment = shortPip_f2i_round[1];
@@ -12572,25 +12589,25 @@ module FpuCore (
     end else begin
       if(when_FpuCore_l767) begin
         shortPip_f2i_result = (shortPip_f2i_overflow ? 32'hffffffff : 32'h0);
-        shortPip_f2i_result[31] = (decode_shortPip_input_payload_arg[0] ^ shortPip_f2i_overflow);
+        shortPip_f2i_result[31] = (shortPip_input_payload_arg[0] ^ shortPip_f2i_overflow);
       end
     end
   end
 
-  assign shortPip_f2i_overflow = (((((decode_shortPip_input_payload_arg[0] ? 9'h11d : 9'h11e) < decode_shortPip_input_payload_rs1_exponent) || (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (! decode_shortPip_input_payload_rs1_sign)) || (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
-  assign shortPip_f2i_underflow = (((((9'h11e < decode_shortPip_input_payload_rs1_exponent) || ((decode_shortPip_input_payload_arg[0] && shortPip_f2i_unsigned[31]) && ((shortPip_f2i_unsigned[30 : 0] != 31'h0) || shortPip_f2i_increment))) || ((! decode_shortPip_input_payload_arg[0]) && ((shortPip_f2i_unsigned != 32'h0) || shortPip_f2i_increment))) || (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && decode_shortPip_input_payload_rs1_sign);
-  assign shortPip_f2i_isZero = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign shortPip_f2i_overflow = (((((shortPip_input_payload_arg[0] ? 9'h11d : 9'h11e) < shortPip_input_payload_rs1_exponent) || (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (! shortPip_input_payload_rs1_sign)) || (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
+  assign shortPip_f2i_underflow = (((((9'h11e < shortPip_input_payload_rs1_exponent) || ((shortPip_input_payload_arg[0] && shortPip_f2i_unsigned[31]) && ((shortPip_f2i_unsigned[30 : 0] != 31'h0) || shortPip_f2i_increment))) || ((! shortPip_input_payload_arg[0]) && ((shortPip_f2i_unsigned != 32'h0) || shortPip_f2i_increment))) || (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && shortPip_input_payload_rs1_sign);
+  assign shortPip_f2i_isZero = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
   assign when_FpuCore_l767 = (shortPip_f2i_underflow || shortPip_f2i_overflow);
-  assign shortPip_bothZero = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign shortPip_bothZero = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00)));
   always @(*) begin
-    shortPip_rs1Equal = ((((decode_shortPip_input_payload_rs1_mantissa == decode_shortPip_input_payload_rs2_mantissa) && (decode_shortPip_input_payload_rs1_exponent == decode_shortPip_input_payload_rs2_exponent)) && (decode_shortPip_input_payload_rs1_sign == decode_shortPip_input_payload_rs2_sign)) && (decode_shortPip_input_payload_rs1_special == decode_shortPip_input_payload_rs2_special));
+    shortPip_rs1Equal = ((((shortPip_input_payload_rs1_mantissa == shortPip_input_payload_rs2_mantissa) && (shortPip_input_payload_rs1_exponent == shortPip_input_payload_rs2_exponent)) && (shortPip_input_payload_rs1_sign == shortPip_input_payload_rs2_sign)) && (shortPip_input_payload_rs1_special == shortPip_input_payload_rs2_special));
     if(when_FpuCore_l784) begin
       shortPip_rs1Equal = 1'b1;
     end
   end
 
   always @(*) begin
-    shortPip_rs1AbsSmaller = ({decode_shortPip_input_payload_rs1_exponent,decode_shortPip_input_payload_rs1_mantissa} < {decode_shortPip_input_payload_rs2_exponent,decode_shortPip_input_payload_rs2_mantissa});
+    shortPip_rs1AbsSmaller = ({shortPip_input_payload_rs1_exponent,shortPip_input_payload_rs1_mantissa} < {shortPip_input_payload_rs2_exponent,shortPip_input_payload_rs2_mantissa});
     if(when_FpuCore_l780) begin
       shortPip_rs1AbsSmaller = 1'b1;
     end
@@ -12605,14 +12622,14 @@ module FpuCore (
     end
   end
 
-  assign when_FpuCore_l780 = (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01));
-  assign when_FpuCore_l781 = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
-  assign when_FpuCore_l782 = (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00));
-  assign when_FpuCore_l783 = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
-  assign when_FpuCore_l784 = (((decode_shortPip_input_payload_rs1_sign == decode_shortPip_input_payload_rs2_sign) && (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01)));
-  assign switch_Misc_l200 = {decode_shortPip_input_payload_rs1_sign,decode_shortPip_input_payload_rs2_sign};
+  assign when_FpuCore_l780 = (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01));
+  assign when_FpuCore_l781 = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign when_FpuCore_l782 = (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b00));
+  assign when_FpuCore_l783 = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
+  assign when_FpuCore_l784 = (((shortPip_input_payload_rs1_sign == shortPip_input_payload_rs2_sign) && (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01))) && (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign switch_Misc_l210 = {shortPip_input_payload_rs1_sign,shortPip_input_payload_rs2_sign};
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         shortPip_rs1Smaller = shortPip_rs1AbsSmaller;
       end
@@ -12628,51 +12645,51 @@ module FpuCore (
     endcase
   end
 
-  assign shortPip_minMaxSelectRs2 = (! (((shortPip_rs1Smaller ^ decode_shortPip_input_payload_arg[0]) && (! (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)))) || (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10))));
-  assign shortPip_minMaxSelectNanQuiet = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
+  assign shortPip_minMaxSelectRs2 = (! (((shortPip_rs1Smaller ^ shortPip_input_payload_arg[0]) && (! (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)))) || (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10))));
+  assign shortPip_minMaxSelectNanQuiet = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
   always @(*) begin
-    shortPip_cmpResult = (((shortPip_rs1Smaller && (! shortPip_bothZero)) && (! decode_shortPip_input_payload_arg[1])) || ((shortPip_rs1Equal || shortPip_bothZero) && (! decode_shortPip_input_payload_arg[0])));
+    shortPip_cmpResult = (((shortPip_rs1Smaller && (! shortPip_bothZero)) && (! shortPip_input_payload_arg[1])) || ((shortPip_rs1Equal || shortPip_bothZero) && (! shortPip_input_payload_arg[0])));
     if(when_FpuCore_l796) begin
       shortPip_cmpResult = 1'b0;
     end
   end
 
-  assign when_FpuCore_l796 = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
-  assign shortPip_sgnjRs1Sign = decode_shortPip_input_payload_rs1_sign;
-  assign shortPip_sgnjRs2Sign = decode_shortPip_input_payload_rs2_sign;
-  assign shortPip_sgnjResult = (((shortPip_sgnjRs1Sign && decode_shortPip_input_payload_arg[1]) ^ shortPip_sgnjRs2Sign) ^ decode_shortPip_input_payload_arg[0]);
+  assign when_FpuCore_l796 = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)));
+  assign shortPip_sgnjRs1Sign = shortPip_input_payload_rs1_sign;
+  assign shortPip_sgnjRs2Sign = shortPip_input_payload_rs2_sign;
+  assign shortPip_sgnjResult = (((shortPip_sgnjRs1Sign && shortPip_input_payload_arg[1]) ^ shortPip_sgnjRs2Sign) ^ shortPip_input_payload_arg[0]);
   always @(*) begin
     shortPip_fclassResult = 32'h0;
-    shortPip_fclassResult[0] = (decode_shortPip_input_payload_rs1_sign && shortPip_decoded_isInfinity);
-    shortPip_fclassResult[1] = (decode_shortPip_input_payload_rs1_sign && shortPip_isNormal);
-    shortPip_fclassResult[2] = (decode_shortPip_input_payload_rs1_sign && shortPip_isSubnormal);
-    shortPip_fclassResult[3] = (decode_shortPip_input_payload_rs1_sign && shortPip_decoded_isZero);
-    shortPip_fclassResult[4] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_decoded_isZero);
-    shortPip_fclassResult[5] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_isSubnormal);
-    shortPip_fclassResult[6] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_isNormal);
-    shortPip_fclassResult[7] = ((! decode_shortPip_input_payload_rs1_sign) && shortPip_decoded_isInfinity);
+    shortPip_fclassResult[0] = (shortPip_input_payload_rs1_sign && shortPip_decoded_isInfinity);
+    shortPip_fclassResult[1] = (shortPip_input_payload_rs1_sign && shortPip_isNormal);
+    shortPip_fclassResult[2] = (shortPip_input_payload_rs1_sign && shortPip_isSubnormal);
+    shortPip_fclassResult[3] = (shortPip_input_payload_rs1_sign && shortPip_decoded_isZero);
+    shortPip_fclassResult[4] = ((! shortPip_input_payload_rs1_sign) && shortPip_decoded_isZero);
+    shortPip_fclassResult[5] = ((! shortPip_input_payload_rs1_sign) && shortPip_isSubnormal);
+    shortPip_fclassResult[6] = ((! shortPip_input_payload_rs1_sign) && shortPip_isNormal);
+    shortPip_fclassResult[7] = ((! shortPip_input_payload_rs1_sign) && shortPip_decoded_isInfinity);
     shortPip_fclassResult[8] = (shortPip_decoded_isNan && (! shortPip_decoded_isQuiet));
     shortPip_fclassResult[9] = (shortPip_decoded_isNan && shortPip_decoded_isQuiet);
   end
 
-  assign shortPip_decoded_isZero = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
-  assign shortPip_decoded_isNormal = (! decode_shortPip_input_payload_rs1_special);
-  assign shortPip_decoded_isInfinity = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
-  assign shortPip_decoded_isNan = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
-  assign shortPip_decoded_isQuiet = decode_shortPip_input_payload_rs1_mantissa[22];
-  assign shortPip_rfOutput_valid = ((decode_shortPip_input_valid && shortPip_toFpuRf) && (! shortPip_halt));
-  assign shortPip_rfOutput_payload_rd = decode_shortPip_input_payload_rd;
-  assign shortPip_rfOutput_payload_roundMode = decode_shortPip_input_payload_roundMode;
+  assign shortPip_decoded_isZero = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign shortPip_decoded_isNormal = (! shortPip_input_payload_rs1_special);
+  assign shortPip_decoded_isInfinity = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b01));
+  assign shortPip_decoded_isNan = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
+  assign shortPip_decoded_isQuiet = shortPip_input_payload_rs1_mantissa[22];
+  assign shortPip_rfOutput_valid = ((shortPip_input_valid && shortPip_toFpuRf) && (! shortPip_halt));
+  assign shortPip_rfOutput_payload_rd = shortPip_input_payload_rd;
+  assign shortPip_rfOutput_payload_roundMode = shortPip_input_payload_roundMode;
   assign shortPip_rfOutput_payload_scrap = 1'b0;
   always @(*) begin
-    shortPip_rfOutput_payload_value_sign = decode_shortPip_input_payload_rs1_sign;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_sign = shortPip_input_payload_rs1_sign;
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_sign = decode_shortPip_input_payload_rs2_sign;
+          shortPip_rfOutput_payload_value_sign = shortPip_input_payload_rs2_sign;
         end
       end
-      `FpuOpcode_binary_sequential_SGNJ : begin
+      FpuOpcode_SGNJ : begin
         if(when_FpuCore_l850) begin
           shortPip_rfOutput_payload_value_sign = shortPip_sgnjResult;
         end
@@ -12683,11 +12700,11 @@ module FpuCore (
   end
 
   always @(*) begin
-    shortPip_rfOutput_payload_value_exponent = decode_shortPip_input_payload_rs1_exponent;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_exponent = shortPip_input_payload_rs1_exponent;
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_exponent = decode_shortPip_input_payload_rs2_exponent;
+          shortPip_rfOutput_payload_value_exponent = shortPip_input_payload_rs2_exponent;
         end
         if(shortPip_minMaxSelectNanQuiet) begin
           shortPip_rfOutput_payload_value_exponent[1 : 0] = 2'b10;
@@ -12700,11 +12717,11 @@ module FpuCore (
   end
 
   always @(*) begin
-    shortPip_rfOutput_payload_value_mantissa = {decode_shortPip_input_payload_rs1_mantissa,1'b0};
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_mantissa = {shortPip_input_payload_rs1_mantissa,1'b0};
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_mantissa = {decode_shortPip_input_payload_rs2_mantissa,1'b0};
+          shortPip_rfOutput_payload_value_mantissa = {shortPip_input_payload_rs2_mantissa,1'b0};
         end
         if(shortPip_minMaxSelectNanQuiet) begin
           shortPip_rfOutput_payload_value_mantissa[23] = 1'b1;
@@ -12716,11 +12733,11 @@ module FpuCore (
   end
 
   always @(*) begin
-    shortPip_rfOutput_payload_value_special = decode_shortPip_input_payload_rs1_special;
-    case(decode_shortPip_input_payload_opcode)
-      `FpuOpcode_binary_sequential_MIN_MAX : begin
+    shortPip_rfOutput_payload_value_special = shortPip_input_payload_rs1_special;
+    case(shortPip_input_payload_opcode)
+      FpuOpcode_MIN_MAX : begin
         if(shortPip_minMaxSelectRs2) begin
-          shortPip_rfOutput_payload_value_special = decode_shortPip_input_payload_rs2_special;
+          shortPip_rfOutput_payload_value_special = shortPip_input_payload_rs2_special;
         end
         if(shortPip_minMaxSelectNanQuiet) begin
           shortPip_rfOutput_payload_value_special = 1'b1;
@@ -12731,26 +12748,26 @@ module FpuCore (
     endcase
   end
 
-  assign when_FpuCore_l850 = (! (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
-  assign shortPip_signalQuiet = ((decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_CMP) && (decode_shortPip_input_payload_arg != 2'b10));
-  assign shortPip_rs1Nan = (decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
-  assign shortPip_rs2Nan = (decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10));
-  assign shortPip_rs1NanNv = ((decode_shortPip_input_payload_rs1_special && (decode_shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && ((! decode_shortPip_input_payload_rs1_mantissa[22]) || shortPip_signalQuiet));
-  assign shortPip_rs2NanNv = ((decode_shortPip_input_payload_rs2_special && (decode_shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)) && ((! decode_shortPip_input_payload_rs2_mantissa[22]) || shortPip_signalQuiet));
-  assign shortPip_NV = ((({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_FCVT_X_X),{(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_CMP)}} != 3'b000) && shortPip_rs1NanNv) || (({(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_MIN_MAX),(decode_shortPip_input_payload_opcode == `FpuOpcode_binary_sequential_CMP)} != 2'b00) && shortPip_rs2NanNv));
-  assign decode_shortPip_input_ready = ((! shortPip_halt) && (shortPip_toFpuRf ? shortPip_rfOutput_ready : shortPip_rspStreams_0_ready));
-  assign shortPip_rspStreams_0_valid = (((decode_shortPip_input_valid && 1'b1) && (! shortPip_toFpuRf)) && (! shortPip_halt));
+  assign when_FpuCore_l850 = (! (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)));
+  assign shortPip_signalQuiet = ((shortPip_input_payload_opcode == FpuOpcode_CMP) && (shortPip_input_payload_arg != 2'b10));
+  assign shortPip_rs1Nan = (shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10));
+  assign shortPip_rs2Nan = (shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10));
+  assign shortPip_rs1NanNv = ((shortPip_input_payload_rs1_special && (shortPip_input_payload_rs1_exponent[1 : 0] == 2'b10)) && ((! shortPip_input_payload_rs1_mantissa[22]) || shortPip_signalQuiet));
+  assign shortPip_rs2NanNv = ((shortPip_input_payload_rs2_special && (shortPip_input_payload_rs2_exponent[1 : 0] == 2'b10)) && ((! shortPip_input_payload_rs2_mantissa[22]) || shortPip_signalQuiet));
+  assign shortPip_NV = ((({(shortPip_input_payload_opcode == FpuOpcode_FCVT_X_X),{(shortPip_input_payload_opcode == FpuOpcode_MIN_MAX),(shortPip_input_payload_opcode == FpuOpcode_CMP)}} != 3'b000) && shortPip_rs1NanNv) || (({(shortPip_input_payload_opcode == FpuOpcode_MIN_MAX),(shortPip_input_payload_opcode == FpuOpcode_CMP)} != 2'b00) && shortPip_rs2NanNv));
+  assign shortPip_input_ready = ((! shortPip_halt) && (shortPip_toFpuRf ? shortPip_rfOutput_ready : shortPip_rspStreams_0_ready));
+  assign shortPip_rspStreams_0_valid = (((shortPip_input_valid && 1'b1) && (! shortPip_toFpuRf)) && (! shortPip_halt));
   assign shortPip_rspStreams_0_payload_value = shortPip_result;
   assign shortPip_rspStreams_0_payload_NV = shortPip_rspNv;
   assign shortPip_rspStreams_0_payload_NX = shortPip_rspNx;
   always @(*) begin
     shortPip_rspStreams_0_ready = shortPip_rspStreams_0_m2sPipe_ready;
-    if(when_Stream_l342_5) begin
+    if(when_Stream_l368_5) begin
       shortPip_rspStreams_0_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_5 = (! shortPip_rspStreams_0_m2sPipe_valid);
+  assign when_Stream_l368_5 = (! shortPip_rspStreams_0_m2sPipe_valid);
   assign shortPip_rspStreams_0_m2sPipe_valid = shortPip_rspStreams_0_rValid;
   assign shortPip_rspStreams_0_m2sPipe_payload_value = shortPip_rspStreams_0_rData_value;
   assign shortPip_rspStreams_0_m2sPipe_payload_NV = shortPip_rspStreams_0_rData_NV;
@@ -12763,254 +12780,254 @@ module FpuCore (
   assign shortPip_rfOutput_payload_NV = shortPip_NV;
   assign shortPip_rfOutput_payload_DZ = 1'b0;
   always @(*) begin
-    decode_mul_ready = decode_mul_input_ready;
-    if(when_Stream_l342_6) begin
+    decode_mul_ready = mul_preMul_input_ready;
+    if(when_Stream_l368_6) begin
       decode_mul_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_6 = (! decode_mul_input_valid);
-  assign decode_mul_input_valid = decode_mul_rValid;
-  assign decode_mul_input_payload_rs1_mantissa = decode_mul_rData_rs1_mantissa;
-  assign decode_mul_input_payload_rs1_exponent = decode_mul_rData_rs1_exponent;
-  assign decode_mul_input_payload_rs1_sign = decode_mul_rData_rs1_sign;
-  assign decode_mul_input_payload_rs1_special = decode_mul_rData_rs1_special;
-  assign decode_mul_input_payload_rs2_mantissa = decode_mul_rData_rs2_mantissa;
-  assign decode_mul_input_payload_rs2_exponent = decode_mul_rData_rs2_exponent;
-  assign decode_mul_input_payload_rs2_sign = decode_mul_rData_rs2_sign;
-  assign decode_mul_input_payload_rs2_special = decode_mul_rData_rs2_special;
-  assign decode_mul_input_payload_rs3_mantissa = decode_mul_rData_rs3_mantissa;
-  assign decode_mul_input_payload_rs3_exponent = decode_mul_rData_rs3_exponent;
-  assign decode_mul_input_payload_rs3_sign = decode_mul_rData_rs3_sign;
-  assign decode_mul_input_payload_rs3_special = decode_mul_rData_rs3_special;
-  assign decode_mul_input_payload_rd = decode_mul_rData_rd;
-  assign decode_mul_input_payload_add = decode_mul_rData_add;
-  assign decode_mul_input_payload_divSqrt = decode_mul_rData_divSqrt;
-  assign decode_mul_input_payload_msb1 = decode_mul_rData_msb1;
-  assign decode_mul_input_payload_msb2 = decode_mul_rData_msb2;
-  assign decode_mul_input_payload_roundMode = decode_mul_rData_roundMode;
-  assign mul_preMul_output_valid = decode_mul_input_valid;
-  assign decode_mul_input_ready = mul_preMul_output_ready;
-  assign mul_preMul_output_payload_rs1_mantissa = decode_mul_input_payload_rs1_mantissa;
-  assign mul_preMul_output_payload_rs1_exponent = decode_mul_input_payload_rs1_exponent;
-  assign mul_preMul_output_payload_rs1_sign = decode_mul_input_payload_rs1_sign;
-  assign mul_preMul_output_payload_rs1_special = decode_mul_input_payload_rs1_special;
-  assign mul_preMul_output_payload_rs2_mantissa = decode_mul_input_payload_rs2_mantissa;
-  assign mul_preMul_output_payload_rs2_exponent = decode_mul_input_payload_rs2_exponent;
-  assign mul_preMul_output_payload_rs2_sign = decode_mul_input_payload_rs2_sign;
-  assign mul_preMul_output_payload_rs2_special = decode_mul_input_payload_rs2_special;
-  assign mul_preMul_output_payload_rs3_mantissa = decode_mul_input_payload_rs3_mantissa;
-  assign mul_preMul_output_payload_rs3_exponent = decode_mul_input_payload_rs3_exponent;
-  assign mul_preMul_output_payload_rs3_sign = decode_mul_input_payload_rs3_sign;
-  assign mul_preMul_output_payload_rs3_special = decode_mul_input_payload_rs3_special;
-  assign mul_preMul_output_payload_rd = decode_mul_input_payload_rd;
-  assign mul_preMul_output_payload_add = decode_mul_input_payload_add;
-  assign mul_preMul_output_payload_divSqrt = decode_mul_input_payload_divSqrt;
-  assign mul_preMul_output_payload_msb1 = decode_mul_input_payload_msb1;
-  assign mul_preMul_output_payload_msb2 = decode_mul_input_payload_msb2;
-  assign mul_preMul_output_payload_roundMode = decode_mul_input_payload_roundMode;
-  assign mul_preMul_output_payload_exp = ({1'b0,decode_mul_input_payload_rs1_exponent} + {1'b0,decode_mul_input_payload_rs2_exponent});
+  assign when_Stream_l368_6 = (! mul_preMul_input_valid);
+  assign mul_preMul_input_valid = decode_mul_rValid;
+  assign mul_preMul_input_payload_rs1_mantissa = decode_mul_rData_rs1_mantissa;
+  assign mul_preMul_input_payload_rs1_exponent = decode_mul_rData_rs1_exponent;
+  assign mul_preMul_input_payload_rs1_sign = decode_mul_rData_rs1_sign;
+  assign mul_preMul_input_payload_rs1_special = decode_mul_rData_rs1_special;
+  assign mul_preMul_input_payload_rs2_mantissa = decode_mul_rData_rs2_mantissa;
+  assign mul_preMul_input_payload_rs2_exponent = decode_mul_rData_rs2_exponent;
+  assign mul_preMul_input_payload_rs2_sign = decode_mul_rData_rs2_sign;
+  assign mul_preMul_input_payload_rs2_special = decode_mul_rData_rs2_special;
+  assign mul_preMul_input_payload_rs3_mantissa = decode_mul_rData_rs3_mantissa;
+  assign mul_preMul_input_payload_rs3_exponent = decode_mul_rData_rs3_exponent;
+  assign mul_preMul_input_payload_rs3_sign = decode_mul_rData_rs3_sign;
+  assign mul_preMul_input_payload_rs3_special = decode_mul_rData_rs3_special;
+  assign mul_preMul_input_payload_rd = decode_mul_rData_rd;
+  assign mul_preMul_input_payload_add = decode_mul_rData_add;
+  assign mul_preMul_input_payload_divSqrt = decode_mul_rData_divSqrt;
+  assign mul_preMul_input_payload_msb1 = decode_mul_rData_msb1;
+  assign mul_preMul_input_payload_msb2 = decode_mul_rData_msb2;
+  assign mul_preMul_input_payload_roundMode = decode_mul_rData_roundMode;
+  assign mul_preMul_output_valid = mul_preMul_input_valid;
+  assign mul_preMul_input_ready = mul_preMul_output_ready;
+  assign mul_preMul_output_payload_rs1_mantissa = mul_preMul_input_payload_rs1_mantissa;
+  assign mul_preMul_output_payload_rs1_exponent = mul_preMul_input_payload_rs1_exponent;
+  assign mul_preMul_output_payload_rs1_sign = mul_preMul_input_payload_rs1_sign;
+  assign mul_preMul_output_payload_rs1_special = mul_preMul_input_payload_rs1_special;
+  assign mul_preMul_output_payload_rs2_mantissa = mul_preMul_input_payload_rs2_mantissa;
+  assign mul_preMul_output_payload_rs2_exponent = mul_preMul_input_payload_rs2_exponent;
+  assign mul_preMul_output_payload_rs2_sign = mul_preMul_input_payload_rs2_sign;
+  assign mul_preMul_output_payload_rs2_special = mul_preMul_input_payload_rs2_special;
+  assign mul_preMul_output_payload_rs3_mantissa = mul_preMul_input_payload_rs3_mantissa;
+  assign mul_preMul_output_payload_rs3_exponent = mul_preMul_input_payload_rs3_exponent;
+  assign mul_preMul_output_payload_rs3_sign = mul_preMul_input_payload_rs3_sign;
+  assign mul_preMul_output_payload_rs3_special = mul_preMul_input_payload_rs3_special;
+  assign mul_preMul_output_payload_rd = mul_preMul_input_payload_rd;
+  assign mul_preMul_output_payload_add = mul_preMul_input_payload_add;
+  assign mul_preMul_output_payload_divSqrt = mul_preMul_input_payload_divSqrt;
+  assign mul_preMul_output_payload_msb1 = mul_preMul_input_payload_msb1;
+  assign mul_preMul_output_payload_msb2 = mul_preMul_input_payload_msb2;
+  assign mul_preMul_output_payload_roundMode = mul_preMul_input_payload_roundMode;
+  assign mul_preMul_output_payload_exp = ({1'b0,mul_preMul_input_payload_rs1_exponent} + {1'b0,mul_preMul_input_payload_rs2_exponent});
   always @(*) begin
-    mul_preMul_output_ready = mul_preMul_output_input_ready;
-    if(when_Stream_l342_7) begin
+    mul_preMul_output_ready = mul_mul_input_ready;
+    if(when_Stream_l368_7) begin
       mul_preMul_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_7 = (! mul_preMul_output_input_valid);
-  assign mul_preMul_output_input_valid = mul_preMul_output_rValid;
-  assign mul_preMul_output_input_payload_rs1_mantissa = mul_preMul_output_rData_rs1_mantissa;
-  assign mul_preMul_output_input_payload_rs1_exponent = mul_preMul_output_rData_rs1_exponent;
-  assign mul_preMul_output_input_payload_rs1_sign = mul_preMul_output_rData_rs1_sign;
-  assign mul_preMul_output_input_payload_rs1_special = mul_preMul_output_rData_rs1_special;
-  assign mul_preMul_output_input_payload_rs2_mantissa = mul_preMul_output_rData_rs2_mantissa;
-  assign mul_preMul_output_input_payload_rs2_exponent = mul_preMul_output_rData_rs2_exponent;
-  assign mul_preMul_output_input_payload_rs2_sign = mul_preMul_output_rData_rs2_sign;
-  assign mul_preMul_output_input_payload_rs2_special = mul_preMul_output_rData_rs2_special;
-  assign mul_preMul_output_input_payload_rs3_mantissa = mul_preMul_output_rData_rs3_mantissa;
-  assign mul_preMul_output_input_payload_rs3_exponent = mul_preMul_output_rData_rs3_exponent;
-  assign mul_preMul_output_input_payload_rs3_sign = mul_preMul_output_rData_rs3_sign;
-  assign mul_preMul_output_input_payload_rs3_special = mul_preMul_output_rData_rs3_special;
-  assign mul_preMul_output_input_payload_rd = mul_preMul_output_rData_rd;
-  assign mul_preMul_output_input_payload_add = mul_preMul_output_rData_add;
-  assign mul_preMul_output_input_payload_divSqrt = mul_preMul_output_rData_divSqrt;
-  assign mul_preMul_output_input_payload_msb1 = mul_preMul_output_rData_msb1;
-  assign mul_preMul_output_input_payload_msb2 = mul_preMul_output_rData_msb2;
-  assign mul_preMul_output_input_payload_roundMode = mul_preMul_output_rData_roundMode;
-  assign mul_preMul_output_input_payload_exp = mul_preMul_output_rData_exp;
-  assign mul_mul_output_valid = mul_preMul_output_input_valid;
-  assign mul_preMul_output_input_ready = mul_mul_output_ready;
-  assign mul_mul_mulA = {mul_preMul_output_input_payload_msb1,mul_preMul_output_input_payload_rs1_mantissa};
-  assign mul_mul_mulB = {mul_preMul_output_input_payload_msb2,mul_preMul_output_input_payload_rs2_mantissa};
-  assign mul_mul_output_payload_rs1_mantissa = mul_preMul_output_input_payload_rs1_mantissa;
-  assign mul_mul_output_payload_rs1_exponent = mul_preMul_output_input_payload_rs1_exponent;
-  assign mul_mul_output_payload_rs1_sign = mul_preMul_output_input_payload_rs1_sign;
-  assign mul_mul_output_payload_rs1_special = mul_preMul_output_input_payload_rs1_special;
-  assign mul_mul_output_payload_rs2_mantissa = mul_preMul_output_input_payload_rs2_mantissa;
-  assign mul_mul_output_payload_rs2_exponent = mul_preMul_output_input_payload_rs2_exponent;
-  assign mul_mul_output_payload_rs2_sign = mul_preMul_output_input_payload_rs2_sign;
-  assign mul_mul_output_payload_rs2_special = mul_preMul_output_input_payload_rs2_special;
-  assign mul_mul_output_payload_rs3_mantissa = mul_preMul_output_input_payload_rs3_mantissa;
-  assign mul_mul_output_payload_rs3_exponent = mul_preMul_output_input_payload_rs3_exponent;
-  assign mul_mul_output_payload_rs3_sign = mul_preMul_output_input_payload_rs3_sign;
-  assign mul_mul_output_payload_rs3_special = mul_preMul_output_input_payload_rs3_special;
-  assign mul_mul_output_payload_rd = mul_preMul_output_input_payload_rd;
-  assign mul_mul_output_payload_add = mul_preMul_output_input_payload_add;
-  assign mul_mul_output_payload_divSqrt = mul_preMul_output_input_payload_divSqrt;
-  assign mul_mul_output_payload_msb1 = mul_preMul_output_input_payload_msb1;
-  assign mul_mul_output_payload_msb2 = mul_preMul_output_input_payload_msb2;
-  assign mul_mul_output_payload_roundMode = mul_preMul_output_input_payload_roundMode;
-  assign mul_mul_output_payload_exp = mul_preMul_output_input_payload_exp;
+  assign when_Stream_l368_7 = (! mul_mul_input_valid);
+  assign mul_mul_input_valid = mul_preMul_output_rValid;
+  assign mul_mul_input_payload_rs1_mantissa = mul_preMul_output_rData_rs1_mantissa;
+  assign mul_mul_input_payload_rs1_exponent = mul_preMul_output_rData_rs1_exponent;
+  assign mul_mul_input_payload_rs1_sign = mul_preMul_output_rData_rs1_sign;
+  assign mul_mul_input_payload_rs1_special = mul_preMul_output_rData_rs1_special;
+  assign mul_mul_input_payload_rs2_mantissa = mul_preMul_output_rData_rs2_mantissa;
+  assign mul_mul_input_payload_rs2_exponent = mul_preMul_output_rData_rs2_exponent;
+  assign mul_mul_input_payload_rs2_sign = mul_preMul_output_rData_rs2_sign;
+  assign mul_mul_input_payload_rs2_special = mul_preMul_output_rData_rs2_special;
+  assign mul_mul_input_payload_rs3_mantissa = mul_preMul_output_rData_rs3_mantissa;
+  assign mul_mul_input_payload_rs3_exponent = mul_preMul_output_rData_rs3_exponent;
+  assign mul_mul_input_payload_rs3_sign = mul_preMul_output_rData_rs3_sign;
+  assign mul_mul_input_payload_rs3_special = mul_preMul_output_rData_rs3_special;
+  assign mul_mul_input_payload_rd = mul_preMul_output_rData_rd;
+  assign mul_mul_input_payload_add = mul_preMul_output_rData_add;
+  assign mul_mul_input_payload_divSqrt = mul_preMul_output_rData_divSqrt;
+  assign mul_mul_input_payload_msb1 = mul_preMul_output_rData_msb1;
+  assign mul_mul_input_payload_msb2 = mul_preMul_output_rData_msb2;
+  assign mul_mul_input_payload_roundMode = mul_preMul_output_rData_roundMode;
+  assign mul_mul_input_payload_exp = mul_preMul_output_rData_exp;
+  assign mul_mul_output_valid = mul_mul_input_valid;
+  assign mul_mul_input_ready = mul_mul_output_ready;
+  assign mul_mul_mulA = {mul_mul_input_payload_msb1,mul_mul_input_payload_rs1_mantissa};
+  assign mul_mul_mulB = {mul_mul_input_payload_msb2,mul_mul_input_payload_rs2_mantissa};
+  assign mul_mul_output_payload_rs1_mantissa = mul_mul_input_payload_rs1_mantissa;
+  assign mul_mul_output_payload_rs1_exponent = mul_mul_input_payload_rs1_exponent;
+  assign mul_mul_output_payload_rs1_sign = mul_mul_input_payload_rs1_sign;
+  assign mul_mul_output_payload_rs1_special = mul_mul_input_payload_rs1_special;
+  assign mul_mul_output_payload_rs2_mantissa = mul_mul_input_payload_rs2_mantissa;
+  assign mul_mul_output_payload_rs2_exponent = mul_mul_input_payload_rs2_exponent;
+  assign mul_mul_output_payload_rs2_sign = mul_mul_input_payload_rs2_sign;
+  assign mul_mul_output_payload_rs2_special = mul_mul_input_payload_rs2_special;
+  assign mul_mul_output_payload_rs3_mantissa = mul_mul_input_payload_rs3_mantissa;
+  assign mul_mul_output_payload_rs3_exponent = mul_mul_input_payload_rs3_exponent;
+  assign mul_mul_output_payload_rs3_sign = mul_mul_input_payload_rs3_sign;
+  assign mul_mul_output_payload_rs3_special = mul_mul_input_payload_rs3_special;
+  assign mul_mul_output_payload_rd = mul_mul_input_payload_rd;
+  assign mul_mul_output_payload_add = mul_mul_input_payload_add;
+  assign mul_mul_output_payload_divSqrt = mul_mul_input_payload_divSqrt;
+  assign mul_mul_output_payload_msb1 = mul_mul_input_payload_msb1;
+  assign mul_mul_output_payload_msb2 = mul_mul_input_payload_msb2;
+  assign mul_mul_output_payload_roundMode = mul_mul_input_payload_roundMode;
+  assign mul_mul_output_payload_exp = mul_mul_input_payload_exp;
   assign mul_mul_output_payload_muls_0 = (mul_mul_mulA[17 : 0] * mul_mul_mulB[17 : 0]);
   assign mul_mul_output_payload_muls_1 = (mul_mul_mulA[17 : 0] * mul_mul_mulB[23 : 18]);
   assign mul_mul_output_payload_muls_2 = (mul_mul_mulA[23 : 18] * mul_mul_mulB[17 : 0]);
   assign mul_mul_output_payload_muls_3 = (mul_mul_mulA[23 : 18] * mul_mul_mulB[23 : 18]);
   always @(*) begin
-    mul_mul_output_ready = mul_mul_output_input_ready;
-    if(when_Stream_l342_8) begin
+    mul_mul_output_ready = mul_sum1_input_ready;
+    if(when_Stream_l368_8) begin
       mul_mul_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_8 = (! mul_mul_output_input_valid);
-  assign mul_mul_output_input_valid = mul_mul_output_rValid;
-  assign mul_mul_output_input_payload_rs1_mantissa = mul_mul_output_rData_rs1_mantissa;
-  assign mul_mul_output_input_payload_rs1_exponent = mul_mul_output_rData_rs1_exponent;
-  assign mul_mul_output_input_payload_rs1_sign = mul_mul_output_rData_rs1_sign;
-  assign mul_mul_output_input_payload_rs1_special = mul_mul_output_rData_rs1_special;
-  assign mul_mul_output_input_payload_rs2_mantissa = mul_mul_output_rData_rs2_mantissa;
-  assign mul_mul_output_input_payload_rs2_exponent = mul_mul_output_rData_rs2_exponent;
-  assign mul_mul_output_input_payload_rs2_sign = mul_mul_output_rData_rs2_sign;
-  assign mul_mul_output_input_payload_rs2_special = mul_mul_output_rData_rs2_special;
-  assign mul_mul_output_input_payload_rs3_mantissa = mul_mul_output_rData_rs3_mantissa;
-  assign mul_mul_output_input_payload_rs3_exponent = mul_mul_output_rData_rs3_exponent;
-  assign mul_mul_output_input_payload_rs3_sign = mul_mul_output_rData_rs3_sign;
-  assign mul_mul_output_input_payload_rs3_special = mul_mul_output_rData_rs3_special;
-  assign mul_mul_output_input_payload_rd = mul_mul_output_rData_rd;
-  assign mul_mul_output_input_payload_add = mul_mul_output_rData_add;
-  assign mul_mul_output_input_payload_divSqrt = mul_mul_output_rData_divSqrt;
-  assign mul_mul_output_input_payload_msb1 = mul_mul_output_rData_msb1;
-  assign mul_mul_output_input_payload_msb2 = mul_mul_output_rData_msb2;
-  assign mul_mul_output_input_payload_roundMode = mul_mul_output_rData_roundMode;
-  assign mul_mul_output_input_payload_exp = mul_mul_output_rData_exp;
-  assign mul_mul_output_input_payload_muls_0 = mul_mul_output_rData_muls_0;
-  assign mul_mul_output_input_payload_muls_1 = mul_mul_output_rData_muls_1;
-  assign mul_mul_output_input_payload_muls_2 = mul_mul_output_rData_muls_2;
-  assign mul_mul_output_input_payload_muls_3 = mul_mul_output_rData_muls_3;
+  assign when_Stream_l368_8 = (! mul_sum1_input_valid);
+  assign mul_sum1_input_valid = mul_mul_output_rValid;
+  assign mul_sum1_input_payload_rs1_mantissa = mul_mul_output_rData_rs1_mantissa;
+  assign mul_sum1_input_payload_rs1_exponent = mul_mul_output_rData_rs1_exponent;
+  assign mul_sum1_input_payload_rs1_sign = mul_mul_output_rData_rs1_sign;
+  assign mul_sum1_input_payload_rs1_special = mul_mul_output_rData_rs1_special;
+  assign mul_sum1_input_payload_rs2_mantissa = mul_mul_output_rData_rs2_mantissa;
+  assign mul_sum1_input_payload_rs2_exponent = mul_mul_output_rData_rs2_exponent;
+  assign mul_sum1_input_payload_rs2_sign = mul_mul_output_rData_rs2_sign;
+  assign mul_sum1_input_payload_rs2_special = mul_mul_output_rData_rs2_special;
+  assign mul_sum1_input_payload_rs3_mantissa = mul_mul_output_rData_rs3_mantissa;
+  assign mul_sum1_input_payload_rs3_exponent = mul_mul_output_rData_rs3_exponent;
+  assign mul_sum1_input_payload_rs3_sign = mul_mul_output_rData_rs3_sign;
+  assign mul_sum1_input_payload_rs3_special = mul_mul_output_rData_rs3_special;
+  assign mul_sum1_input_payload_rd = mul_mul_output_rData_rd;
+  assign mul_sum1_input_payload_add = mul_mul_output_rData_add;
+  assign mul_sum1_input_payload_divSqrt = mul_mul_output_rData_divSqrt;
+  assign mul_sum1_input_payload_msb1 = mul_mul_output_rData_msb1;
+  assign mul_sum1_input_payload_msb2 = mul_mul_output_rData_msb2;
+  assign mul_sum1_input_payload_roundMode = mul_mul_output_rData_roundMode;
+  assign mul_sum1_input_payload_exp = mul_mul_output_rData_exp;
+  assign mul_sum1_input_payload_muls_0 = mul_mul_output_rData_muls_0;
+  assign mul_sum1_input_payload_muls_1 = mul_mul_output_rData_muls_1;
+  assign mul_sum1_input_payload_muls_2 = mul_mul_output_rData_muls_2;
+  assign mul_sum1_input_payload_muls_3 = mul_mul_output_rData_muls_3;
   assign mul_sum1_sum = (_zz_mul_sum1_sum + _zz_mul_sum1_sum_1);
-  assign mul_sum1_output_valid = mul_mul_output_input_valid;
-  assign mul_mul_output_input_ready = mul_sum1_output_ready;
-  assign mul_sum1_output_payload_rs1_mantissa = mul_mul_output_input_payload_rs1_mantissa;
-  assign mul_sum1_output_payload_rs1_exponent = mul_mul_output_input_payload_rs1_exponent;
-  assign mul_sum1_output_payload_rs1_sign = mul_mul_output_input_payload_rs1_sign;
-  assign mul_sum1_output_payload_rs1_special = mul_mul_output_input_payload_rs1_special;
-  assign mul_sum1_output_payload_rs2_mantissa = mul_mul_output_input_payload_rs2_mantissa;
-  assign mul_sum1_output_payload_rs2_exponent = mul_mul_output_input_payload_rs2_exponent;
-  assign mul_sum1_output_payload_rs2_sign = mul_mul_output_input_payload_rs2_sign;
-  assign mul_sum1_output_payload_rs2_special = mul_mul_output_input_payload_rs2_special;
-  assign mul_sum1_output_payload_rs3_mantissa = mul_mul_output_input_payload_rs3_mantissa;
-  assign mul_sum1_output_payload_rs3_exponent = mul_mul_output_input_payload_rs3_exponent;
-  assign mul_sum1_output_payload_rs3_sign = mul_mul_output_input_payload_rs3_sign;
-  assign mul_sum1_output_payload_rs3_special = mul_mul_output_input_payload_rs3_special;
-  assign mul_sum1_output_payload_rd = mul_mul_output_input_payload_rd;
-  assign mul_sum1_output_payload_add = mul_mul_output_input_payload_add;
-  assign mul_sum1_output_payload_divSqrt = mul_mul_output_input_payload_divSqrt;
-  assign mul_sum1_output_payload_msb1 = mul_mul_output_input_payload_msb1;
-  assign mul_sum1_output_payload_msb2 = mul_mul_output_input_payload_msb2;
-  assign mul_sum1_output_payload_roundMode = mul_mul_output_input_payload_roundMode;
-  assign mul_sum1_output_payload_exp = mul_mul_output_input_payload_exp;
+  assign mul_sum1_output_valid = mul_sum1_input_valid;
+  assign mul_sum1_input_ready = mul_sum1_output_ready;
+  assign mul_sum1_output_payload_rs1_mantissa = mul_sum1_input_payload_rs1_mantissa;
+  assign mul_sum1_output_payload_rs1_exponent = mul_sum1_input_payload_rs1_exponent;
+  assign mul_sum1_output_payload_rs1_sign = mul_sum1_input_payload_rs1_sign;
+  assign mul_sum1_output_payload_rs1_special = mul_sum1_input_payload_rs1_special;
+  assign mul_sum1_output_payload_rs2_mantissa = mul_sum1_input_payload_rs2_mantissa;
+  assign mul_sum1_output_payload_rs2_exponent = mul_sum1_input_payload_rs2_exponent;
+  assign mul_sum1_output_payload_rs2_sign = mul_sum1_input_payload_rs2_sign;
+  assign mul_sum1_output_payload_rs2_special = mul_sum1_input_payload_rs2_special;
+  assign mul_sum1_output_payload_rs3_mantissa = mul_sum1_input_payload_rs3_mantissa;
+  assign mul_sum1_output_payload_rs3_exponent = mul_sum1_input_payload_rs3_exponent;
+  assign mul_sum1_output_payload_rs3_sign = mul_sum1_input_payload_rs3_sign;
+  assign mul_sum1_output_payload_rs3_special = mul_sum1_input_payload_rs3_special;
+  assign mul_sum1_output_payload_rd = mul_sum1_input_payload_rd;
+  assign mul_sum1_output_payload_add = mul_sum1_input_payload_add;
+  assign mul_sum1_output_payload_divSqrt = mul_sum1_input_payload_divSqrt;
+  assign mul_sum1_output_payload_msb1 = mul_sum1_input_payload_msb1;
+  assign mul_sum1_output_payload_msb2 = mul_sum1_input_payload_msb2;
+  assign mul_sum1_output_payload_roundMode = mul_sum1_input_payload_roundMode;
+  assign mul_sum1_output_payload_exp = mul_sum1_input_payload_exp;
   assign mul_sum1_output_payload_mulC2 = mul_sum1_sum;
-  assign mul_sum1_output_payload_muls2_0 = mul_mul_output_input_payload_muls_2;
-  assign mul_sum1_output_payload_muls2_1 = mul_mul_output_input_payload_muls_3;
+  assign mul_sum1_output_payload_muls2_0 = mul_sum1_input_payload_muls_2;
+  assign mul_sum1_output_payload_muls2_1 = mul_sum1_input_payload_muls_3;
   always @(*) begin
-    mul_sum1_output_ready = mul_sum1_output_input_ready;
-    if(when_Stream_l342_9) begin
+    mul_sum1_output_ready = mul_sum2_input_ready;
+    if(when_Stream_l368_9) begin
       mul_sum1_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_9 = (! mul_sum1_output_input_valid);
-  assign mul_sum1_output_input_valid = mul_sum1_output_rValid;
-  assign mul_sum1_output_input_payload_rs1_mantissa = mul_sum1_output_rData_rs1_mantissa;
-  assign mul_sum1_output_input_payload_rs1_exponent = mul_sum1_output_rData_rs1_exponent;
-  assign mul_sum1_output_input_payload_rs1_sign = mul_sum1_output_rData_rs1_sign;
-  assign mul_sum1_output_input_payload_rs1_special = mul_sum1_output_rData_rs1_special;
-  assign mul_sum1_output_input_payload_rs2_mantissa = mul_sum1_output_rData_rs2_mantissa;
-  assign mul_sum1_output_input_payload_rs2_exponent = mul_sum1_output_rData_rs2_exponent;
-  assign mul_sum1_output_input_payload_rs2_sign = mul_sum1_output_rData_rs2_sign;
-  assign mul_sum1_output_input_payload_rs2_special = mul_sum1_output_rData_rs2_special;
-  assign mul_sum1_output_input_payload_rs3_mantissa = mul_sum1_output_rData_rs3_mantissa;
-  assign mul_sum1_output_input_payload_rs3_exponent = mul_sum1_output_rData_rs3_exponent;
-  assign mul_sum1_output_input_payload_rs3_sign = mul_sum1_output_rData_rs3_sign;
-  assign mul_sum1_output_input_payload_rs3_special = mul_sum1_output_rData_rs3_special;
-  assign mul_sum1_output_input_payload_rd = mul_sum1_output_rData_rd;
-  assign mul_sum1_output_input_payload_add = mul_sum1_output_rData_add;
-  assign mul_sum1_output_input_payload_divSqrt = mul_sum1_output_rData_divSqrt;
-  assign mul_sum1_output_input_payload_msb1 = mul_sum1_output_rData_msb1;
-  assign mul_sum1_output_input_payload_msb2 = mul_sum1_output_rData_msb2;
-  assign mul_sum1_output_input_payload_roundMode = mul_sum1_output_rData_roundMode;
-  assign mul_sum1_output_input_payload_exp = mul_sum1_output_rData_exp;
-  assign mul_sum1_output_input_payload_muls2_0 = mul_sum1_output_rData_muls2_0;
-  assign mul_sum1_output_input_payload_muls2_1 = mul_sum1_output_rData_muls2_1;
-  assign mul_sum1_output_input_payload_mulC2 = mul_sum1_output_rData_mulC2;
-  assign mul_sum2_sum = (mul_sum1_output_input_payload_mulC2 + _zz_mul_sum2_sum);
-  assign mul_sum1_output_input_fire = (mul_sum1_output_input_valid && mul_sum1_output_input_ready);
-  assign when_FpuCore_l221_1 = (mul_sum1_output_input_fire && 1'b1);
+  assign when_Stream_l368_9 = (! mul_sum2_input_valid);
+  assign mul_sum2_input_valid = mul_sum1_output_rValid;
+  assign mul_sum2_input_payload_rs1_mantissa = mul_sum1_output_rData_rs1_mantissa;
+  assign mul_sum2_input_payload_rs1_exponent = mul_sum1_output_rData_rs1_exponent;
+  assign mul_sum2_input_payload_rs1_sign = mul_sum1_output_rData_rs1_sign;
+  assign mul_sum2_input_payload_rs1_special = mul_sum1_output_rData_rs1_special;
+  assign mul_sum2_input_payload_rs2_mantissa = mul_sum1_output_rData_rs2_mantissa;
+  assign mul_sum2_input_payload_rs2_exponent = mul_sum1_output_rData_rs2_exponent;
+  assign mul_sum2_input_payload_rs2_sign = mul_sum1_output_rData_rs2_sign;
+  assign mul_sum2_input_payload_rs2_special = mul_sum1_output_rData_rs2_special;
+  assign mul_sum2_input_payload_rs3_mantissa = mul_sum1_output_rData_rs3_mantissa;
+  assign mul_sum2_input_payload_rs3_exponent = mul_sum1_output_rData_rs3_exponent;
+  assign mul_sum2_input_payload_rs3_sign = mul_sum1_output_rData_rs3_sign;
+  assign mul_sum2_input_payload_rs3_special = mul_sum1_output_rData_rs3_special;
+  assign mul_sum2_input_payload_rd = mul_sum1_output_rData_rd;
+  assign mul_sum2_input_payload_add = mul_sum1_output_rData_add;
+  assign mul_sum2_input_payload_divSqrt = mul_sum1_output_rData_divSqrt;
+  assign mul_sum2_input_payload_msb1 = mul_sum1_output_rData_msb1;
+  assign mul_sum2_input_payload_msb2 = mul_sum1_output_rData_msb2;
+  assign mul_sum2_input_payload_roundMode = mul_sum1_output_rData_roundMode;
+  assign mul_sum2_input_payload_exp = mul_sum1_output_rData_exp;
+  assign mul_sum2_input_payload_muls2_0 = mul_sum1_output_rData_muls2_0;
+  assign mul_sum2_input_payload_muls2_1 = mul_sum1_output_rData_muls2_1;
+  assign mul_sum2_input_payload_mulC2 = mul_sum1_output_rData_mulC2;
+  assign mul_sum2_sum = (mul_sum2_input_payload_mulC2 + _zz_mul_sum2_sum);
+  assign mul_sum2_input_fire = (mul_sum2_input_valid && mul_sum2_input_ready);
+  assign when_FpuCore_l221_1 = (mul_sum2_input_fire && 1'b1);
   assign mul_sum2_isCommited = commitLogic_0_mul_notEmpty;
-  assign _zz_mul_sum1_output_input_ready = (! (! mul_sum2_isCommited));
-  assign mul_sum1_output_input_ready = (mul_sum2_output_ready && _zz_mul_sum1_output_input_ready);
-  assign mul_sum2_output_valid = (mul_sum1_output_input_valid && _zz_mul_sum1_output_input_ready);
-  assign mul_sum2_output_payload_rs1_mantissa = mul_sum1_output_input_payload_rs1_mantissa;
-  assign mul_sum2_output_payload_rs1_exponent = mul_sum1_output_input_payload_rs1_exponent;
-  assign mul_sum2_output_payload_rs1_sign = mul_sum1_output_input_payload_rs1_sign;
-  assign mul_sum2_output_payload_rs1_special = mul_sum1_output_input_payload_rs1_special;
-  assign mul_sum2_output_payload_rs2_mantissa = mul_sum1_output_input_payload_rs2_mantissa;
-  assign mul_sum2_output_payload_rs2_exponent = mul_sum1_output_input_payload_rs2_exponent;
-  assign mul_sum2_output_payload_rs2_sign = mul_sum1_output_input_payload_rs2_sign;
-  assign mul_sum2_output_payload_rs2_special = mul_sum1_output_input_payload_rs2_special;
-  assign mul_sum2_output_payload_rs3_mantissa = mul_sum1_output_input_payload_rs3_mantissa;
-  assign mul_sum2_output_payload_rs3_exponent = mul_sum1_output_input_payload_rs3_exponent;
-  assign mul_sum2_output_payload_rs3_sign = mul_sum1_output_input_payload_rs3_sign;
-  assign mul_sum2_output_payload_rs3_special = mul_sum1_output_input_payload_rs3_special;
-  assign mul_sum2_output_payload_rd = mul_sum1_output_input_payload_rd;
-  assign mul_sum2_output_payload_add = mul_sum1_output_input_payload_add;
-  assign mul_sum2_output_payload_divSqrt = mul_sum1_output_input_payload_divSqrt;
-  assign mul_sum2_output_payload_msb1 = mul_sum1_output_input_payload_msb1;
-  assign mul_sum2_output_payload_msb2 = mul_sum1_output_input_payload_msb2;
-  assign mul_sum2_output_payload_roundMode = mul_sum1_output_input_payload_roundMode;
-  assign mul_sum2_output_payload_exp = mul_sum1_output_input_payload_exp;
+  assign _zz_mul_sum2_input_ready = (! (! mul_sum2_isCommited));
+  assign mul_sum2_input_ready = (mul_sum2_output_ready && _zz_mul_sum2_input_ready);
+  assign mul_sum2_output_valid = (mul_sum2_input_valid && _zz_mul_sum2_input_ready);
+  assign mul_sum2_output_payload_rs1_mantissa = mul_sum2_input_payload_rs1_mantissa;
+  assign mul_sum2_output_payload_rs1_exponent = mul_sum2_input_payload_rs1_exponent;
+  assign mul_sum2_output_payload_rs1_sign = mul_sum2_input_payload_rs1_sign;
+  assign mul_sum2_output_payload_rs1_special = mul_sum2_input_payload_rs1_special;
+  assign mul_sum2_output_payload_rs2_mantissa = mul_sum2_input_payload_rs2_mantissa;
+  assign mul_sum2_output_payload_rs2_exponent = mul_sum2_input_payload_rs2_exponent;
+  assign mul_sum2_output_payload_rs2_sign = mul_sum2_input_payload_rs2_sign;
+  assign mul_sum2_output_payload_rs2_special = mul_sum2_input_payload_rs2_special;
+  assign mul_sum2_output_payload_rs3_mantissa = mul_sum2_input_payload_rs3_mantissa;
+  assign mul_sum2_output_payload_rs3_exponent = mul_sum2_input_payload_rs3_exponent;
+  assign mul_sum2_output_payload_rs3_sign = mul_sum2_input_payload_rs3_sign;
+  assign mul_sum2_output_payload_rs3_special = mul_sum2_input_payload_rs3_special;
+  assign mul_sum2_output_payload_rd = mul_sum2_input_payload_rd;
+  assign mul_sum2_output_payload_add = mul_sum2_input_payload_add;
+  assign mul_sum2_output_payload_divSqrt = mul_sum2_input_payload_divSqrt;
+  assign mul_sum2_output_payload_msb1 = mul_sum2_input_payload_msb1;
+  assign mul_sum2_output_payload_msb2 = mul_sum2_input_payload_msb2;
+  assign mul_sum2_output_payload_roundMode = mul_sum2_input_payload_roundMode;
+  assign mul_sum2_output_payload_exp = mul_sum2_input_payload_exp;
   assign mul_sum2_output_payload_mulC = mul_sum2_sum;
   always @(*) begin
-    mul_sum2_output_ready = mul_sum2_output_input_ready;
-    if(when_Stream_l342_10) begin
+    mul_sum2_output_ready = mul_norm_input_ready;
+    if(when_Stream_l368_10) begin
       mul_sum2_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_10 = (! mul_sum2_output_input_valid);
-  assign mul_sum2_output_input_valid = mul_sum2_output_rValid;
-  assign mul_sum2_output_input_payload_rs1_mantissa = mul_sum2_output_rData_rs1_mantissa;
-  assign mul_sum2_output_input_payload_rs1_exponent = mul_sum2_output_rData_rs1_exponent;
-  assign mul_sum2_output_input_payload_rs1_sign = mul_sum2_output_rData_rs1_sign;
-  assign mul_sum2_output_input_payload_rs1_special = mul_sum2_output_rData_rs1_special;
-  assign mul_sum2_output_input_payload_rs2_mantissa = mul_sum2_output_rData_rs2_mantissa;
-  assign mul_sum2_output_input_payload_rs2_exponent = mul_sum2_output_rData_rs2_exponent;
-  assign mul_sum2_output_input_payload_rs2_sign = mul_sum2_output_rData_rs2_sign;
-  assign mul_sum2_output_input_payload_rs2_special = mul_sum2_output_rData_rs2_special;
-  assign mul_sum2_output_input_payload_rs3_mantissa = mul_sum2_output_rData_rs3_mantissa;
-  assign mul_sum2_output_input_payload_rs3_exponent = mul_sum2_output_rData_rs3_exponent;
-  assign mul_sum2_output_input_payload_rs3_sign = mul_sum2_output_rData_rs3_sign;
-  assign mul_sum2_output_input_payload_rs3_special = mul_sum2_output_rData_rs3_special;
-  assign mul_sum2_output_input_payload_rd = mul_sum2_output_rData_rd;
-  assign mul_sum2_output_input_payload_add = mul_sum2_output_rData_add;
-  assign mul_sum2_output_input_payload_divSqrt = mul_sum2_output_rData_divSqrt;
-  assign mul_sum2_output_input_payload_msb1 = mul_sum2_output_rData_msb1;
-  assign mul_sum2_output_input_payload_msb2 = mul_sum2_output_rData_msb2;
-  assign mul_sum2_output_input_payload_roundMode = mul_sum2_output_rData_roundMode;
-  assign mul_sum2_output_input_payload_exp = mul_sum2_output_rData_exp;
-  assign mul_sum2_output_input_payload_mulC = mul_sum2_output_rData_mulC;
-  assign mul_norm_mulHigh = mul_sum2_output_input_payload_mulC[47 : 22];
-  assign mul_norm_mulLow = mul_sum2_output_input_payload_mulC[21 : 0];
+  assign when_Stream_l368_10 = (! mul_norm_input_valid);
+  assign mul_norm_input_valid = mul_sum2_output_rValid;
+  assign mul_norm_input_payload_rs1_mantissa = mul_sum2_output_rData_rs1_mantissa;
+  assign mul_norm_input_payload_rs1_exponent = mul_sum2_output_rData_rs1_exponent;
+  assign mul_norm_input_payload_rs1_sign = mul_sum2_output_rData_rs1_sign;
+  assign mul_norm_input_payload_rs1_special = mul_sum2_output_rData_rs1_special;
+  assign mul_norm_input_payload_rs2_mantissa = mul_sum2_output_rData_rs2_mantissa;
+  assign mul_norm_input_payload_rs2_exponent = mul_sum2_output_rData_rs2_exponent;
+  assign mul_norm_input_payload_rs2_sign = mul_sum2_output_rData_rs2_sign;
+  assign mul_norm_input_payload_rs2_special = mul_sum2_output_rData_rs2_special;
+  assign mul_norm_input_payload_rs3_mantissa = mul_sum2_output_rData_rs3_mantissa;
+  assign mul_norm_input_payload_rs3_exponent = mul_sum2_output_rData_rs3_exponent;
+  assign mul_norm_input_payload_rs3_sign = mul_sum2_output_rData_rs3_sign;
+  assign mul_norm_input_payload_rs3_special = mul_sum2_output_rData_rs3_special;
+  assign mul_norm_input_payload_rd = mul_sum2_output_rData_rd;
+  assign mul_norm_input_payload_add = mul_sum2_output_rData_add;
+  assign mul_norm_input_payload_divSqrt = mul_sum2_output_rData_divSqrt;
+  assign mul_norm_input_payload_msb1 = mul_sum2_output_rData_msb1;
+  assign mul_norm_input_payload_msb2 = mul_sum2_output_rData_msb2;
+  assign mul_norm_input_payload_roundMode = mul_sum2_output_rData_roundMode;
+  assign mul_norm_input_payload_exp = mul_sum2_output_rData_exp;
+  assign mul_norm_input_payload_mulC = mul_sum2_output_rData_mulC;
+  assign mul_norm_mulHigh = mul_norm_input_payload_mulC[47 : 22];
+  assign mul_norm_mulLow = mul_norm_input_payload_mulC[21 : 0];
   always @(*) begin
     mul_norm_scrap = (mul_norm_mulLow != 22'h0);
     if(when_FpuCore_l967) begin
@@ -13019,17 +13036,17 @@ module FpuCore (
   end
 
   assign mul_norm_needShift = mul_norm_mulHigh[25];
-  assign mul_norm_exp = (mul_sum2_output_input_payload_exp + _zz_mul_norm_exp);
+  assign mul_norm_exp = (mul_norm_input_payload_exp + _zz_mul_norm_exp);
   assign mul_norm_man = (mul_norm_needShift ? mul_norm_mulHigh[24 : 1] : mul_norm_mulHigh[23 : 0]);
   assign when_FpuCore_l967 = (mul_norm_needShift && mul_norm_mulHigh[0]);
-  assign mul_norm_forceZero = ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign mul_norm_forceZero = ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b00)));
   assign mul_norm_underflowThreshold = 9'h167;
   assign mul_norm_underflowExp = 7'h67;
   assign mul_norm_forceUnderflow = (mul_norm_exp < _zz_mul_norm_forceUnderflow);
-  assign mul_norm_forceOverflow = ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b01)));
-  assign mul_norm_infinitynan = (((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b01))) && ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b00))));
-  assign mul_norm_forceNan = (((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b10))) || mul_norm_infinitynan);
-  assign mul_norm_output_sign = (mul_sum2_output_input_payload_rs1_sign ^ mul_sum2_output_input_payload_rs2_sign);
+  assign mul_norm_forceOverflow = ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign mul_norm_infinitynan = (((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b01))) && ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b00))));
+  assign mul_norm_forceNan = (((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b10))) || mul_norm_infinitynan);
+  assign mul_norm_output_sign = (mul_norm_input_payload_rs1_sign ^ mul_norm_input_payload_rs2_sign);
   always @(*) begin
     mul_norm_output_exponent = _zz_mul_norm_output_exponent[8:0];
     if(when_FpuCore_l983) begin
@@ -13085,12 +13102,12 @@ module FpuCore (
   end
 
   assign when_FpuCore_l983 = (3'b101 <= mul_norm_exp[9 : 7]);
-  assign when_FpuCore_l987 = ((mul_norm_infinitynan || ((mul_sum2_output_input_payload_rs1_special && (mul_sum2_output_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! mul_sum2_output_input_payload_rs1_mantissa[22]))) || ((mul_sum2_output_input_payload_rs2_special && (mul_sum2_output_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! mul_sum2_output_input_payload_rs2_mantissa[22])));
-  assign mul_result_notMul_output_valid = (mul_sum2_output_input_valid && mul_sum2_output_input_payload_divSqrt);
-  assign mul_result_notMul_output_payload = mul_sum2_output_input_payload_mulC[46 : 23];
-  assign mul_result_output_valid = ((mul_sum2_output_input_valid && (! mul_sum2_output_input_payload_add)) && (! mul_sum2_output_input_payload_divSqrt));
-  assign mul_result_output_payload_rd = mul_sum2_output_input_payload_rd;
-  assign mul_result_output_payload_roundMode = mul_sum2_output_input_payload_roundMode;
+  assign when_FpuCore_l987 = ((mul_norm_infinitynan || ((mul_norm_input_payload_rs1_special && (mul_norm_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! mul_norm_input_payload_rs1_mantissa[22]))) || ((mul_norm_input_payload_rs2_special && (mul_norm_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! mul_norm_input_payload_rs2_mantissa[22])));
+  assign mul_result_notMul_output_valid = (mul_norm_input_valid && mul_norm_input_payload_divSqrt);
+  assign mul_result_notMul_output_payload = mul_norm_input_payload_mulC[46 : 23];
+  assign mul_result_output_valid = ((mul_norm_input_valid && (! mul_norm_input_payload_add)) && (! mul_norm_input_payload_divSqrt));
+  assign mul_result_output_payload_rd = mul_norm_input_payload_rd;
+  assign mul_result_output_payload_roundMode = mul_norm_input_payload_roundMode;
   assign mul_result_output_payload_scrap = mul_norm_scrap;
   assign mul_result_output_payload_value_mantissa = mul_norm_output_mantissa;
   assign mul_result_output_payload_value_exponent = mul_norm_output_exponent;
@@ -13100,12 +13117,12 @@ module FpuCore (
   assign mul_result_output_payload_DZ = 1'b0;
   always @(*) begin
     mul_result_mulToAdd_ready = mul_result_mulToAdd_m2sPipe_ready;
-    if(when_Stream_l342_11) begin
+    if(when_Stream_l368_11) begin
       mul_result_mulToAdd_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_11 = (! mul_result_mulToAdd_m2sPipe_valid);
+  assign when_Stream_l368_11 = (! mul_result_mulToAdd_m2sPipe_valid);
   assign mul_result_mulToAdd_m2sPipe_valid = mul_result_mulToAdd_rValid;
   assign mul_result_mulToAdd_m2sPipe_payload_rs1_mantissa = mul_result_mulToAdd_rData_rs1_mantissa;
   assign mul_result_mulToAdd_m2sPipe_payload_rs1_exponent = mul_result_mulToAdd_rData_rs1_exponent;
@@ -13131,7 +13148,7 @@ module FpuCore (
   assign decode_mulToAdd_payload_rd = mul_result_mulToAdd_m2sPipe_payload_rd;
   assign decode_mulToAdd_payload_roundMode = mul_result_mulToAdd_m2sPipe_payload_roundMode;
   assign decode_mulToAdd_payload_needCommit = mul_result_mulToAdd_m2sPipe_payload_needCommit;
-  assign mul_result_mulToAdd_valid = (mul_sum2_output_input_valid && mul_sum2_output_input_payload_add);
+  assign mul_result_mulToAdd_valid = (mul_norm_input_valid && mul_norm_input_payload_add);
   always @(*) begin
     mul_result_mulToAdd_payload_rs1_mantissa = {mul_norm_output_mantissa,mul_norm_scrap};
     if(mul_norm_NV) begin
@@ -13142,27 +13159,27 @@ module FpuCore (
   assign mul_result_mulToAdd_payload_rs1_exponent = mul_norm_output_exponent;
   assign mul_result_mulToAdd_payload_rs1_sign = mul_norm_output_sign;
   assign mul_result_mulToAdd_payload_rs1_special = mul_norm_output_special;
-  assign mul_result_mulToAdd_payload_rs2_exponent = mul_sum2_output_input_payload_rs3_exponent;
-  assign mul_result_mulToAdd_payload_rs2_sign = mul_sum2_output_input_payload_rs3_sign;
-  assign mul_result_mulToAdd_payload_rs2_special = mul_sum2_output_input_payload_rs3_special;
-  assign mul_result_mulToAdd_payload_rs2_mantissa = ({2'd0,mul_sum2_output_input_payload_rs3_mantissa} <<< 2);
-  assign mul_result_mulToAdd_payload_rd = mul_sum2_output_input_payload_rd;
-  assign mul_result_mulToAdd_payload_roundMode = mul_sum2_output_input_payload_roundMode;
+  assign mul_result_mulToAdd_payload_rs2_exponent = mul_norm_input_payload_rs3_exponent;
+  assign mul_result_mulToAdd_payload_rs2_sign = mul_norm_input_payload_rs3_sign;
+  assign mul_result_mulToAdd_payload_rs2_special = mul_norm_input_payload_rs3_special;
+  assign mul_result_mulToAdd_payload_rs2_mantissa = ({2'd0,mul_norm_input_payload_rs3_mantissa} <<< 2);
+  assign mul_result_mulToAdd_payload_rd = mul_norm_input_payload_rd;
+  assign mul_result_mulToAdd_payload_roundMode = mul_norm_input_payload_roundMode;
   assign mul_result_mulToAdd_payload_needCommit = 1'b0;
-  assign mul_sum2_output_input_ready = ((mul_sum2_output_input_payload_add ? mul_result_mulToAdd_ready : mul_result_output_ready) || mul_sum2_output_input_payload_divSqrt);
-  assign decode_div_input_fire = (decode_div_input_valid && decode_div_input_ready);
+  assign mul_norm_input_ready = ((mul_norm_input_payload_add ? mul_result_mulToAdd_ready : mul_result_output_ready) || mul_norm_input_payload_divSqrt);
+  assign div_input_fire = (div_input_valid && div_input_ready);
   assign decode_div_ready = (! decode_div_rValid);
-  assign decode_div_input_valid = decode_div_rValid;
-  assign decode_div_input_payload_rs1_mantissa = decode_div_rData_rs1_mantissa;
-  assign decode_div_input_payload_rs1_exponent = decode_div_rData_rs1_exponent;
-  assign decode_div_input_payload_rs1_sign = decode_div_rData_rs1_sign;
-  assign decode_div_input_payload_rs1_special = decode_div_rData_rs1_special;
-  assign decode_div_input_payload_rs2_mantissa = decode_div_rData_rs2_mantissa;
-  assign decode_div_input_payload_rs2_exponent = decode_div_rData_rs2_exponent;
-  assign decode_div_input_payload_rs2_sign = decode_div_rData_rs2_sign;
-  assign decode_div_input_payload_rs2_special = decode_div_rData_rs2_special;
-  assign decode_div_input_payload_rd = decode_div_rData_rd;
-  assign decode_div_input_payload_roundMode = decode_div_rData_roundMode;
+  assign div_input_valid = decode_div_rValid;
+  assign div_input_payload_rs1_mantissa = decode_div_rData_rs1_mantissa;
+  assign div_input_payload_rs1_exponent = decode_div_rData_rs1_exponent;
+  assign div_input_payload_rs1_sign = decode_div_rData_rs1_sign;
+  assign div_input_payload_rs1_special = decode_div_rData_rs1_special;
+  assign div_input_payload_rs2_mantissa = decode_div_rData_rs2_mantissa;
+  assign div_input_payload_rs2_exponent = decode_div_rData_rs2_exponent;
+  assign div_input_payload_rs2_sign = decode_div_rData_rs2_sign;
+  assign div_input_payload_rs2_special = decode_div_rData_rs2_special;
+  assign div_input_payload_rd = decode_div_rData_rd;
+  assign div_input_payload_roundMode = decode_div_rData_roundMode;
   always @(*) begin
     div_haltIt = 1'b1;
     if(div_divider_io_output_valid) begin
@@ -13170,20 +13187,20 @@ module FpuCore (
     end
   end
 
-  assign decode_div_input_fire_1 = (decode_div_input_valid && decode_div_input_ready);
-  assign when_FpuCore_l221_2 = (decode_div_input_fire_1 && 1'b1);
-  assign _zz_decode_div_input_ready = (! (div_haltIt || (! div_isCommited)));
-  assign decode_div_input_ready = (div_output_ready && _zz_decode_div_input_ready);
-  assign div_output_valid = (decode_div_input_valid && _zz_decode_div_input_ready);
-  assign div_divider_io_input_payload_a = ({1'd0,decode_div_input_payload_rs1_mantissa} <<< 1);
-  assign div_divider_io_input_payload_b = ({1'd0,decode_div_input_payload_rs2_mantissa} <<< 1);
+  assign div_input_fire_1 = (div_input_valid && div_input_ready);
+  assign when_FpuCore_l221_2 = (div_input_fire_1 && 1'b1);
+  assign _zz_div_input_ready = (! (div_haltIt || (! div_isCommited)));
+  assign div_input_ready = (div_output_ready && _zz_div_input_ready);
+  assign div_output_valid = (div_input_valid && _zz_div_input_ready);
+  assign div_divider_io_input_payload_a = ({1'd0,div_input_payload_rs1_mantissa} <<< 1);
+  assign div_divider_io_input_payload_b = ({1'd0,div_input_payload_rs2_mantissa} <<< 1);
   assign div_dividerResult = (div_divider_io_output_payload_result >>> 1);
   assign div_dividerScrap = ((div_divider_io_output_payload_remain != 25'h0) || (div_divider_io_output_payload_result[0 : 0] != 1'b0));
   assign div_divider_io_input_fire = (div_divider_io_input_valid && div_divider_io_input_ready);
   assign when_FpuCore_l1056 = (! div_haltIt);
-  assign div_divider_io_input_valid = (decode_div_input_valid && (! div_cmdSent));
-  assign div_output_payload_rd = decode_div_input_payload_rd;
-  assign div_output_payload_roundMode = decode_div_input_payload_roundMode;
+  assign div_divider_io_input_valid = (div_input_valid && (! div_cmdSent));
+  assign div_output_payload_rd = div_input_payload_rd;
+  assign div_output_payload_roundMode = div_input_payload_roundMode;
   assign div_needShift = (! div_dividerResult[25]);
   assign div_mantissa = (div_needShift ? div_dividerResult[23 : 0] : div_dividerResult[24 : 1]);
   assign div_scrap = (div_dividerScrap || ((! div_needShift) && div_dividerResult[0]));
@@ -13203,7 +13220,7 @@ module FpuCore (
     end
   end
 
-  assign div_output_payload_value_sign = (decode_div_input_payload_rs1_sign ^ decode_div_input_payload_rs2_sign);
+  assign div_output_payload_value_sign = (div_input_payload_rs1_sign ^ div_input_payload_rs2_sign);
   always @(*) begin
     div_output_payload_value_exponent = div_exponent[8:0];
     if(when_FpuCore_l1072) begin
@@ -13242,10 +13259,10 @@ module FpuCore (
   assign div_underflowThreshold = 11'h468;
   assign div_underflowExp = 11'h467;
   assign div_forceUnderflow = (div_exponent < div_underflowThreshold);
-  assign div_forceOverflow = ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
-  assign div_infinitynan = (((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b00))) || ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b01))));
-  assign div_forceNan = (((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b10))) || div_infinitynan);
-  assign div_forceZero = ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign div_forceOverflow = ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign div_infinitynan = (((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b00))) || ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b01))));
+  assign div_forceNan = (((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b10))) || div_infinitynan);
+  assign div_forceZero = ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b00)) || (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b01)));
   always @(*) begin
     div_output_payload_NV = 1'b0;
     if(div_forceNan) begin
@@ -13255,18 +13272,18 @@ module FpuCore (
     end
   end
 
-  assign div_output_payload_DZ = (((! div_forceNan) && (! (decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b01)))) && (decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign div_output_payload_DZ = (((! div_forceNan) && (! (div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b01)))) && (div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b00)));
   assign when_FpuCore_l1089 = (div_exponent[10 : 8] == 3'b111);
-  assign when_FpuCore_l1093 = ((div_infinitynan || ((decode_div_input_payload_rs1_special && (decode_div_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! decode_div_input_payload_rs1_mantissa[22]))) || ((decode_div_input_payload_rs2_special && (decode_div_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! decode_div_input_payload_rs2_mantissa[22])));
-  assign decode_sqrt_input_fire = (decode_sqrt_input_valid && decode_sqrt_input_ready);
+  assign when_FpuCore_l1093 = ((div_infinitynan || ((div_input_payload_rs1_special && (div_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! div_input_payload_rs1_mantissa[22]))) || ((div_input_payload_rs2_special && (div_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! div_input_payload_rs2_mantissa[22])));
+  assign sqrt_input_fire = (sqrt_input_valid && sqrt_input_ready);
   assign decode_sqrt_ready = (! decode_sqrt_rValid);
-  assign decode_sqrt_input_valid = decode_sqrt_rValid;
-  assign decode_sqrt_input_payload_rs1_mantissa = decode_sqrt_rData_rs1_mantissa;
-  assign decode_sqrt_input_payload_rs1_exponent = decode_sqrt_rData_rs1_exponent;
-  assign decode_sqrt_input_payload_rs1_sign = decode_sqrt_rData_rs1_sign;
-  assign decode_sqrt_input_payload_rs1_special = decode_sqrt_rData_rs1_special;
-  assign decode_sqrt_input_payload_rd = decode_sqrt_rData_rd;
-  assign decode_sqrt_input_payload_roundMode = decode_sqrt_rData_roundMode;
+  assign sqrt_input_valid = decode_sqrt_rValid;
+  assign sqrt_input_payload_rs1_mantissa = decode_sqrt_rData_rs1_mantissa;
+  assign sqrt_input_payload_rs1_exponent = decode_sqrt_rData_rs1_exponent;
+  assign sqrt_input_payload_rs1_sign = decode_sqrt_rData_rs1_sign;
+  assign sqrt_input_payload_rs1_special = decode_sqrt_rData_rs1_special;
+  assign sqrt_input_payload_rd = decode_sqrt_rData_rd;
+  assign sqrt_input_payload_roundMode = decode_sqrt_rData_roundMode;
   always @(*) begin
     sqrt_haltIt = 1'b1;
     if(sqrt_sqrt_io_output_valid) begin
@@ -13274,18 +13291,18 @@ module FpuCore (
     end
   end
 
-  assign decode_sqrt_input_fire_1 = (decode_sqrt_input_valid && decode_sqrt_input_ready);
-  assign when_FpuCore_l221_3 = (decode_sqrt_input_fire_1 && 1'b1);
-  assign _zz_decode_sqrt_input_ready = (! (sqrt_haltIt || (! sqrt_isCommited)));
-  assign decode_sqrt_input_ready = (sqrt_output_ready && _zz_decode_sqrt_input_ready);
-  assign sqrt_output_valid = (decode_sqrt_input_valid && _zz_decode_sqrt_input_ready);
-  assign sqrt_needShift = (! decode_sqrt_input_payload_rs1_exponent[0]);
-  assign sqrt_sqrt_io_input_payload_a = (sqrt_needShift ? {{1'b1,decode_sqrt_input_payload_rs1_mantissa},1'b0} : {2'b01,decode_sqrt_input_payload_rs1_mantissa});
+  assign sqrt_input_fire_1 = (sqrt_input_valid && sqrt_input_ready);
+  assign when_FpuCore_l221_3 = (sqrt_input_fire_1 && 1'b1);
+  assign _zz_sqrt_input_ready = (! (sqrt_haltIt || (! sqrt_isCommited)));
+  assign sqrt_input_ready = (sqrt_output_ready && _zz_sqrt_input_ready);
+  assign sqrt_output_valid = (sqrt_input_valid && _zz_sqrt_input_ready);
+  assign sqrt_needShift = (! sqrt_input_payload_rs1_exponent[0]);
+  assign sqrt_sqrt_io_input_payload_a = (sqrt_needShift ? {{1'b1,sqrt_input_payload_rs1_mantissa},1'b0} : {2'b01,sqrt_input_payload_rs1_mantissa});
   assign sqrt_sqrt_io_input_fire = (sqrt_sqrt_io_input_valid && sqrt_sqrt_io_input_ready);
   assign when_FpuCore_l1118 = (! sqrt_haltIt);
-  assign sqrt_sqrt_io_input_valid = (decode_sqrt_input_valid && (! sqrt_cmdSent));
-  assign sqrt_output_payload_rd = decode_sqrt_input_payload_rd;
-  assign sqrt_output_payload_roundMode = decode_sqrt_input_payload_roundMode;
+  assign sqrt_sqrt_io_input_valid = (sqrt_input_valid && (! sqrt_cmdSent));
+  assign sqrt_output_payload_rd = sqrt_input_payload_rd;
+  assign sqrt_output_payload_roundMode = sqrt_input_payload_roundMode;
   assign sqrt_scrap = (sqrt_sqrt_io_output_payload_remain != 28'h0);
   always @(*) begin
     sqrt_output_payload_value_special = 1'b0;
@@ -13303,7 +13320,7 @@ module FpuCore (
     end
   end
 
-  assign sqrt_output_payload_value_sign = decode_sqrt_input_payload_rs1_sign;
+  assign sqrt_output_payload_value_sign = sqrt_input_payload_rs1_sign;
   always @(*) begin
     sqrt_output_payload_value_exponent = sqrt_exponent;
     if(when_FpuCore_l1137) begin
@@ -13339,15 +13356,15 @@ module FpuCore (
       sqrt_output_payload_NV = 1'b1;
     end
     if(when_FpuCore_l1144) begin
-      sqrt_output_payload_NV = (! decode_sqrt_input_payload_rs1_mantissa[22]);
+      sqrt_output_payload_NV = (! sqrt_input_payload_rs1_mantissa[22]);
     end
   end
 
   assign sqrt_output_payload_DZ = 1'b0;
-  assign sqrt_negative = (((! (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10))) && (! (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00)))) && decode_sqrt_input_payload_rs1_sign);
-  assign when_FpuCore_l1137 = (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b01));
-  assign when_FpuCore_l1144 = (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10));
-  assign when_FpuCore_l1148 = (decode_sqrt_input_payload_rs1_special && (decode_sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00));
+  assign sqrt_negative = (((! (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10))) && (! (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00)))) && sqrt_input_payload_rs1_sign);
+  assign when_FpuCore_l1137 = (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b01));
+  assign when_FpuCore_l1144 = (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b10));
+  assign when_FpuCore_l1148 = (sqrt_input_payload_rs1_special && (sqrt_input_payload_rs1_exponent[1 : 0] == 2'b00));
   assign add_preShifter_input_valid = decode_add_valid;
   assign decode_add_ready = add_preShifter_input_ready;
   assign add_preShifter_input_payload_rs1_mantissa = decode_add_payload_rs1_mantissa;
@@ -13382,50 +13399,50 @@ module FpuCore (
   assign add_preShifter_output_payload_absRs1Bigger = add_preShifter_absRs1Bigger;
   assign add_preShifter_output_payload_rs1ExponentBigger = add_preShifter_rs1ExponentBigger;
   always @(*) begin
-    add_preShifter_output_ready = add_preShifter_output_input_ready;
-    if(when_Stream_l342_12) begin
+    add_preShifter_output_ready = add_shifter_input_ready;
+    if(when_Stream_l368_12) begin
       add_preShifter_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_12 = (! add_preShifter_output_input_valid);
-  assign add_preShifter_output_input_valid = add_preShifter_output_rValid;
-  assign add_preShifter_output_input_payload_rs1_mantissa = add_preShifter_output_rData_rs1_mantissa;
-  assign add_preShifter_output_input_payload_rs1_exponent = add_preShifter_output_rData_rs1_exponent;
-  assign add_preShifter_output_input_payload_rs1_sign = add_preShifter_output_rData_rs1_sign;
-  assign add_preShifter_output_input_payload_rs1_special = add_preShifter_output_rData_rs1_special;
-  assign add_preShifter_output_input_payload_rs2_mantissa = add_preShifter_output_rData_rs2_mantissa;
-  assign add_preShifter_output_input_payload_rs2_exponent = add_preShifter_output_rData_rs2_exponent;
-  assign add_preShifter_output_input_payload_rs2_sign = add_preShifter_output_rData_rs2_sign;
-  assign add_preShifter_output_input_payload_rs2_special = add_preShifter_output_rData_rs2_special;
-  assign add_preShifter_output_input_payload_rd = add_preShifter_output_rData_rd;
-  assign add_preShifter_output_input_payload_roundMode = add_preShifter_output_rData_roundMode;
-  assign add_preShifter_output_input_payload_needCommit = add_preShifter_output_rData_needCommit;
-  assign add_preShifter_output_input_payload_absRs1Bigger = add_preShifter_output_rData_absRs1Bigger;
-  assign add_preShifter_output_input_payload_rs1ExponentBigger = add_preShifter_output_rData_rs1ExponentBigger;
-  assign add_shifter_output_valid = add_preShifter_output_input_valid;
-  assign add_preShifter_output_input_ready = add_shifter_output_ready;
-  assign add_shifter_output_payload_rs1_mantissa = add_preShifter_output_input_payload_rs1_mantissa;
-  assign add_shifter_output_payload_rs1_exponent = add_preShifter_output_input_payload_rs1_exponent;
-  assign add_shifter_output_payload_rs1_sign = add_preShifter_output_input_payload_rs1_sign;
-  assign add_shifter_output_payload_rs1_special = add_preShifter_output_input_payload_rs1_special;
-  assign add_shifter_output_payload_rs2_mantissa = add_preShifter_output_input_payload_rs2_mantissa;
-  assign add_shifter_output_payload_rs2_exponent = add_preShifter_output_input_payload_rs2_exponent;
-  assign add_shifter_output_payload_rs2_sign = add_preShifter_output_input_payload_rs2_sign;
-  assign add_shifter_output_payload_rs2_special = add_preShifter_output_input_payload_rs2_special;
-  assign add_shifter_output_payload_rd = add_preShifter_output_input_payload_rd;
-  assign add_shifter_output_payload_roundMode = add_preShifter_output_input_payload_roundMode;
-  assign add_shifter_output_payload_needCommit = add_preShifter_output_input_payload_needCommit;
-  assign add_shifter_exp21 = ({1'b0,add_preShifter_output_input_payload_rs2_exponent} - {1'b0,add_preShifter_output_input_payload_rs1_exponent});
+  assign when_Stream_l368_12 = (! add_shifter_input_valid);
+  assign add_shifter_input_valid = add_preShifter_output_rValid;
+  assign add_shifter_input_payload_rs1_mantissa = add_preShifter_output_rData_rs1_mantissa;
+  assign add_shifter_input_payload_rs1_exponent = add_preShifter_output_rData_rs1_exponent;
+  assign add_shifter_input_payload_rs1_sign = add_preShifter_output_rData_rs1_sign;
+  assign add_shifter_input_payload_rs1_special = add_preShifter_output_rData_rs1_special;
+  assign add_shifter_input_payload_rs2_mantissa = add_preShifter_output_rData_rs2_mantissa;
+  assign add_shifter_input_payload_rs2_exponent = add_preShifter_output_rData_rs2_exponent;
+  assign add_shifter_input_payload_rs2_sign = add_preShifter_output_rData_rs2_sign;
+  assign add_shifter_input_payload_rs2_special = add_preShifter_output_rData_rs2_special;
+  assign add_shifter_input_payload_rd = add_preShifter_output_rData_rd;
+  assign add_shifter_input_payload_roundMode = add_preShifter_output_rData_roundMode;
+  assign add_shifter_input_payload_needCommit = add_preShifter_output_rData_needCommit;
+  assign add_shifter_input_payload_absRs1Bigger = add_preShifter_output_rData_absRs1Bigger;
+  assign add_shifter_input_payload_rs1ExponentBigger = add_preShifter_output_rData_rs1ExponentBigger;
+  assign add_shifter_output_valid = add_shifter_input_valid;
+  assign add_shifter_input_ready = add_shifter_output_ready;
+  assign add_shifter_output_payload_rs1_mantissa = add_shifter_input_payload_rs1_mantissa;
+  assign add_shifter_output_payload_rs1_exponent = add_shifter_input_payload_rs1_exponent;
+  assign add_shifter_output_payload_rs1_sign = add_shifter_input_payload_rs1_sign;
+  assign add_shifter_output_payload_rs1_special = add_shifter_input_payload_rs1_special;
+  assign add_shifter_output_payload_rs2_mantissa = add_shifter_input_payload_rs2_mantissa;
+  assign add_shifter_output_payload_rs2_exponent = add_shifter_input_payload_rs2_exponent;
+  assign add_shifter_output_payload_rs2_sign = add_shifter_input_payload_rs2_sign;
+  assign add_shifter_output_payload_rs2_special = add_shifter_input_payload_rs2_special;
+  assign add_shifter_output_payload_rd = add_shifter_input_payload_rd;
+  assign add_shifter_output_payload_roundMode = add_shifter_input_payload_roundMode;
+  assign add_shifter_output_payload_needCommit = add_shifter_input_payload_needCommit;
+  assign add_shifter_exp21 = ({1'b0,add_shifter_input_payload_rs2_exponent} - {1'b0,add_shifter_input_payload_rs1_exponent});
   assign _zz_add_shifter_shiftBy = add_shifter_exp21;
   assign add_shifter_shiftBy = (_zz_add_shifter_shiftBy_1 + _zz_add_shifter_shiftBy_3);
   assign add_shifter_shiftOverflow = (10'h01a <= add_shifter_shiftBy);
-  assign add_shifter_passThrough = ((add_shifter_shiftOverflow || (add_preShifter_output_input_payload_rs1_special && (add_preShifter_output_input_payload_rs1_exponent[1 : 0] == 2'b00))) || (add_preShifter_output_input_payload_rs2_special && (add_preShifter_output_input_payload_rs2_exponent[1 : 0] == 2'b00)));
-  assign add_shifter_xySign = (add_preShifter_output_input_payload_absRs1Bigger ? add_preShifter_output_input_payload_rs1_sign : add_preShifter_output_input_payload_rs2_sign);
-  assign add_shifter_output_payload_xSign = (add_shifter_xySign ^ (add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs1_sign : add_preShifter_output_input_payload_rs2_sign));
-  assign add_shifter_output_payload_ySign = (add_shifter_xySign ^ (add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs2_sign : add_preShifter_output_input_payload_rs1_sign));
-  assign add_shifter_xMantissa = {1'b1,(add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs1_mantissa : add_preShifter_output_input_payload_rs2_mantissa)};
-  assign add_shifter_yMantissaUnshifted = {1'b1,(add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs2_mantissa : add_preShifter_output_input_payload_rs1_mantissa)};
+  assign add_shifter_passThrough = ((add_shifter_shiftOverflow || (add_shifter_input_payload_rs1_special && (add_shifter_input_payload_rs1_exponent[1 : 0] == 2'b00))) || (add_shifter_input_payload_rs2_special && (add_shifter_input_payload_rs2_exponent[1 : 0] == 2'b00)));
+  assign add_shifter_xySign = (add_shifter_input_payload_absRs1Bigger ? add_shifter_input_payload_rs1_sign : add_shifter_input_payload_rs2_sign);
+  assign add_shifter_output_payload_xSign = (add_shifter_xySign ^ (add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs1_sign : add_shifter_input_payload_rs2_sign));
+  assign add_shifter_output_payload_ySign = (add_shifter_xySign ^ (add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs2_sign : add_shifter_input_payload_rs1_sign));
+  assign add_shifter_xMantissa = {1'b1,(add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs1_mantissa : add_shifter_input_payload_rs2_mantissa)};
+  assign add_shifter_yMantissaUnshifted = {1'b1,(add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs2_mantissa : add_shifter_input_payload_rs1_mantissa)};
   assign add_shifter_yMantissa = add_shifter_yMantissaUnshifted;
   always @(*) begin
     add_shifter_roundingScrap = 1'b0;
@@ -13457,115 +13474,115 @@ module FpuCore (
   assign when_FpuCore_l1419_2 = (add_shifter_shiftBy[2] && (add_shifter_yMantissa_2[3 : 0] != 4'b0000));
   assign when_FpuCore_l1419_3 = (add_shifter_shiftBy[1] && (add_shifter_yMantissa_3[1 : 0] != 2'b00));
   assign when_FpuCore_l1419_4 = (add_shifter_shiftBy[0] && (add_shifter_yMantissa_4[0 : 0] != 1'b0));
-  assign when_FpuCore_l1424 = (add_preShifter_output_input_payload_rs1_special || add_preShifter_output_input_payload_rs2_special);
-  assign add_shifter_output_payload_xyExponent = (add_preShifter_output_input_payload_rs1ExponentBigger ? add_preShifter_output_input_payload_rs1_exponent : add_preShifter_output_input_payload_rs2_exponent);
+  assign when_FpuCore_l1424 = (add_shifter_input_payload_rs1_special || add_shifter_input_payload_rs2_special);
+  assign add_shifter_output_payload_xyExponent = (add_shifter_input_payload_rs1ExponentBigger ? add_shifter_input_payload_rs1_exponent : add_shifter_input_payload_rs2_exponent);
   assign add_shifter_output_payload_xMantissa = add_shifter_xMantissa;
   assign add_shifter_output_payload_yMantissa = add_shifter_yMantissa_5;
   assign add_shifter_output_payload_xySign = add_shifter_xySign;
   assign add_shifter_output_payload_roundingScrap = add_shifter_roundingScrap;
   always @(*) begin
-    add_shifter_output_ready = add_shifter_output_input_ready;
-    if(when_Stream_l342_13) begin
+    add_shifter_output_ready = add_math_input_ready;
+    if(when_Stream_l368_13) begin
       add_shifter_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_13 = (! add_shifter_output_input_valid);
-  assign add_shifter_output_input_valid = add_shifter_output_rValid;
-  assign add_shifter_output_input_payload_rs1_mantissa = add_shifter_output_rData_rs1_mantissa;
-  assign add_shifter_output_input_payload_rs1_exponent = add_shifter_output_rData_rs1_exponent;
-  assign add_shifter_output_input_payload_rs1_sign = add_shifter_output_rData_rs1_sign;
-  assign add_shifter_output_input_payload_rs1_special = add_shifter_output_rData_rs1_special;
-  assign add_shifter_output_input_payload_rs2_mantissa = add_shifter_output_rData_rs2_mantissa;
-  assign add_shifter_output_input_payload_rs2_exponent = add_shifter_output_rData_rs2_exponent;
-  assign add_shifter_output_input_payload_rs2_sign = add_shifter_output_rData_rs2_sign;
-  assign add_shifter_output_input_payload_rs2_special = add_shifter_output_rData_rs2_special;
-  assign add_shifter_output_input_payload_rd = add_shifter_output_rData_rd;
-  assign add_shifter_output_input_payload_roundMode = add_shifter_output_rData_roundMode;
-  assign add_shifter_output_input_payload_needCommit = add_shifter_output_rData_needCommit;
-  assign add_shifter_output_input_payload_xSign = add_shifter_output_rData_xSign;
-  assign add_shifter_output_input_payload_ySign = add_shifter_output_rData_ySign;
-  assign add_shifter_output_input_payload_xMantissa = add_shifter_output_rData_xMantissa;
-  assign add_shifter_output_input_payload_yMantissa = add_shifter_output_rData_yMantissa;
-  assign add_shifter_output_input_payload_xyExponent = add_shifter_output_rData_xyExponent;
-  assign add_shifter_output_input_payload_xySign = add_shifter_output_rData_xySign;
-  assign add_shifter_output_input_payload_roundingScrap = add_shifter_output_rData_roundingScrap;
-  assign add_math_output_valid = add_shifter_output_input_valid;
-  assign add_shifter_output_input_ready = add_math_output_ready;
-  assign add_math_output_payload_rs1_mantissa = add_shifter_output_input_payload_rs1_mantissa;
-  assign add_math_output_payload_rs1_exponent = add_shifter_output_input_payload_rs1_exponent;
-  assign add_math_output_payload_rs1_sign = add_shifter_output_input_payload_rs1_sign;
-  assign add_math_output_payload_rs1_special = add_shifter_output_input_payload_rs1_special;
-  assign add_math_output_payload_rs2_mantissa = add_shifter_output_input_payload_rs2_mantissa;
-  assign add_math_output_payload_rs2_exponent = add_shifter_output_input_payload_rs2_exponent;
-  assign add_math_output_payload_rs2_sign = add_shifter_output_input_payload_rs2_sign;
-  assign add_math_output_payload_rs2_special = add_shifter_output_input_payload_rs2_special;
-  assign add_math_output_payload_rd = add_shifter_output_input_payload_rd;
-  assign add_math_output_payload_roundMode = add_shifter_output_input_payload_roundMode;
-  assign add_math_output_payload_needCommit = add_shifter_output_input_payload_needCommit;
-  assign add_math_output_payload_xSign = add_shifter_output_input_payload_xSign;
-  assign add_math_output_payload_ySign = add_shifter_output_input_payload_ySign;
-  assign add_math_output_payload_xMantissa = add_shifter_output_input_payload_xMantissa;
-  assign add_math_output_payload_yMantissa = add_shifter_output_input_payload_yMantissa;
-  assign add_math_output_payload_xyExponent = add_shifter_output_input_payload_xyExponent;
-  assign add_math_output_payload_xySign = add_shifter_output_input_payload_xySign;
-  assign add_math_output_payload_roundingScrap = add_shifter_output_input_payload_roundingScrap;
+  assign when_Stream_l368_13 = (! add_math_input_valid);
+  assign add_math_input_valid = add_shifter_output_rValid;
+  assign add_math_input_payload_rs1_mantissa = add_shifter_output_rData_rs1_mantissa;
+  assign add_math_input_payload_rs1_exponent = add_shifter_output_rData_rs1_exponent;
+  assign add_math_input_payload_rs1_sign = add_shifter_output_rData_rs1_sign;
+  assign add_math_input_payload_rs1_special = add_shifter_output_rData_rs1_special;
+  assign add_math_input_payload_rs2_mantissa = add_shifter_output_rData_rs2_mantissa;
+  assign add_math_input_payload_rs2_exponent = add_shifter_output_rData_rs2_exponent;
+  assign add_math_input_payload_rs2_sign = add_shifter_output_rData_rs2_sign;
+  assign add_math_input_payload_rs2_special = add_shifter_output_rData_rs2_special;
+  assign add_math_input_payload_rd = add_shifter_output_rData_rd;
+  assign add_math_input_payload_roundMode = add_shifter_output_rData_roundMode;
+  assign add_math_input_payload_needCommit = add_shifter_output_rData_needCommit;
+  assign add_math_input_payload_xSign = add_shifter_output_rData_xSign;
+  assign add_math_input_payload_ySign = add_shifter_output_rData_ySign;
+  assign add_math_input_payload_xMantissa = add_shifter_output_rData_xMantissa;
+  assign add_math_input_payload_yMantissa = add_shifter_output_rData_yMantissa;
+  assign add_math_input_payload_xyExponent = add_shifter_output_rData_xyExponent;
+  assign add_math_input_payload_xySign = add_shifter_output_rData_xySign;
+  assign add_math_input_payload_roundingScrap = add_shifter_output_rData_roundingScrap;
+  assign add_math_output_valid = add_math_input_valid;
+  assign add_math_input_ready = add_math_output_ready;
+  assign add_math_output_payload_rs1_mantissa = add_math_input_payload_rs1_mantissa;
+  assign add_math_output_payload_rs1_exponent = add_math_input_payload_rs1_exponent;
+  assign add_math_output_payload_rs1_sign = add_math_input_payload_rs1_sign;
+  assign add_math_output_payload_rs1_special = add_math_input_payload_rs1_special;
+  assign add_math_output_payload_rs2_mantissa = add_math_input_payload_rs2_mantissa;
+  assign add_math_output_payload_rs2_exponent = add_math_input_payload_rs2_exponent;
+  assign add_math_output_payload_rs2_sign = add_math_input_payload_rs2_sign;
+  assign add_math_output_payload_rs2_special = add_math_input_payload_rs2_special;
+  assign add_math_output_payload_rd = add_math_input_payload_rd;
+  assign add_math_output_payload_roundMode = add_math_input_payload_roundMode;
+  assign add_math_output_payload_needCommit = add_math_input_payload_needCommit;
+  assign add_math_output_payload_xSign = add_math_input_payload_xSign;
+  assign add_math_output_payload_ySign = add_math_input_payload_ySign;
+  assign add_math_output_payload_xMantissa = add_math_input_payload_xMantissa;
+  assign add_math_output_payload_yMantissa = add_math_input_payload_yMantissa;
+  assign add_math_output_payload_xyExponent = add_math_input_payload_xyExponent;
+  assign add_math_output_payload_xySign = add_math_input_payload_xySign;
+  assign add_math_output_payload_roundingScrap = add_math_input_payload_roundingScrap;
   assign add_math_xSigned = _zz_add_math_xSigned;
   assign add_math_ySigned = _zz_add_math_ySigned;
   assign add_math_output_payload_xyMantissa = _zz_add_math_output_payload_xyMantissa[26 : 0];
   always @(*) begin
-    add_math_output_ready = add_math_output_input_ready;
-    if(when_Stream_l342_14) begin
+    add_math_output_ready = add_oh_input_ready;
+    if(when_Stream_l368_14) begin
       add_math_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_14 = (! add_math_output_input_valid);
-  assign add_math_output_input_valid = add_math_output_rValid;
-  assign add_math_output_input_payload_rs1_mantissa = add_math_output_rData_rs1_mantissa;
-  assign add_math_output_input_payload_rs1_exponent = add_math_output_rData_rs1_exponent;
-  assign add_math_output_input_payload_rs1_sign = add_math_output_rData_rs1_sign;
-  assign add_math_output_input_payload_rs1_special = add_math_output_rData_rs1_special;
-  assign add_math_output_input_payload_rs2_mantissa = add_math_output_rData_rs2_mantissa;
-  assign add_math_output_input_payload_rs2_exponent = add_math_output_rData_rs2_exponent;
-  assign add_math_output_input_payload_rs2_sign = add_math_output_rData_rs2_sign;
-  assign add_math_output_input_payload_rs2_special = add_math_output_rData_rs2_special;
-  assign add_math_output_input_payload_rd = add_math_output_rData_rd;
-  assign add_math_output_input_payload_roundMode = add_math_output_rData_roundMode;
-  assign add_math_output_input_payload_needCommit = add_math_output_rData_needCommit;
-  assign add_math_output_input_payload_xSign = add_math_output_rData_xSign;
-  assign add_math_output_input_payload_ySign = add_math_output_rData_ySign;
-  assign add_math_output_input_payload_xMantissa = add_math_output_rData_xMantissa;
-  assign add_math_output_input_payload_yMantissa = add_math_output_rData_yMantissa;
-  assign add_math_output_input_payload_xyExponent = add_math_output_rData_xyExponent;
-  assign add_math_output_input_payload_xySign = add_math_output_rData_xySign;
-  assign add_math_output_input_payload_roundingScrap = add_math_output_rData_roundingScrap;
-  assign add_math_output_input_payload_xyMantissa = add_math_output_rData_xyMantissa;
-  assign add_math_output_input_fire = (add_math_output_input_valid && add_math_output_input_ready);
-  assign when_FpuCore_l221_4 = ((add_math_output_input_fire && add_math_output_input_payload_needCommit) && 1'b1);
+  assign when_Stream_l368_14 = (! add_oh_input_valid);
+  assign add_oh_input_valid = add_math_output_rValid;
+  assign add_oh_input_payload_rs1_mantissa = add_math_output_rData_rs1_mantissa;
+  assign add_oh_input_payload_rs1_exponent = add_math_output_rData_rs1_exponent;
+  assign add_oh_input_payload_rs1_sign = add_math_output_rData_rs1_sign;
+  assign add_oh_input_payload_rs1_special = add_math_output_rData_rs1_special;
+  assign add_oh_input_payload_rs2_mantissa = add_math_output_rData_rs2_mantissa;
+  assign add_oh_input_payload_rs2_exponent = add_math_output_rData_rs2_exponent;
+  assign add_oh_input_payload_rs2_sign = add_math_output_rData_rs2_sign;
+  assign add_oh_input_payload_rs2_special = add_math_output_rData_rs2_special;
+  assign add_oh_input_payload_rd = add_math_output_rData_rd;
+  assign add_oh_input_payload_roundMode = add_math_output_rData_roundMode;
+  assign add_oh_input_payload_needCommit = add_math_output_rData_needCommit;
+  assign add_oh_input_payload_xSign = add_math_output_rData_xSign;
+  assign add_oh_input_payload_ySign = add_math_output_rData_ySign;
+  assign add_oh_input_payload_xMantissa = add_math_output_rData_xMantissa;
+  assign add_oh_input_payload_yMantissa = add_math_output_rData_yMantissa;
+  assign add_oh_input_payload_xyExponent = add_math_output_rData_xyExponent;
+  assign add_oh_input_payload_xySign = add_math_output_rData_xySign;
+  assign add_oh_input_payload_roundingScrap = add_math_output_rData_roundingScrap;
+  assign add_oh_input_payload_xyMantissa = add_math_output_rData_xyMantissa;
+  assign add_oh_input_fire = (add_oh_input_valid && add_oh_input_ready);
+  assign when_FpuCore_l221_4 = ((add_oh_input_fire && add_oh_input_payload_needCommit) && 1'b1);
   assign add_oh_isCommited = commitLogic_0_add_notEmpty;
-  assign _zz_add_math_output_input_ready = (! (add_math_output_input_payload_needCommit && (! add_oh_isCommited)));
-  assign add_math_output_input_ready = (add_oh_output_ready && _zz_add_math_output_input_ready);
-  assign add_oh_output_valid = (add_math_output_input_valid && _zz_add_math_output_input_ready);
-  assign add_oh_output_payload_rs1_mantissa = add_math_output_input_payload_rs1_mantissa;
-  assign add_oh_output_payload_rs1_exponent = add_math_output_input_payload_rs1_exponent;
-  assign add_oh_output_payload_rs1_sign = add_math_output_input_payload_rs1_sign;
-  assign add_oh_output_payload_rs1_special = add_math_output_input_payload_rs1_special;
-  assign add_oh_output_payload_rs2_mantissa = add_math_output_input_payload_rs2_mantissa;
-  assign add_oh_output_payload_rs2_exponent = add_math_output_input_payload_rs2_exponent;
-  assign add_oh_output_payload_rs2_sign = add_math_output_input_payload_rs2_sign;
-  assign add_oh_output_payload_rs2_special = add_math_output_input_payload_rs2_special;
-  assign add_oh_output_payload_rd = add_math_output_input_payload_rd;
-  assign add_oh_output_payload_roundMode = add_math_output_input_payload_roundMode;
-  assign add_oh_output_payload_needCommit = add_math_output_input_payload_needCommit;
-  assign add_oh_output_payload_xSign = add_math_output_input_payload_xSign;
-  assign add_oh_output_payload_ySign = add_math_output_input_payload_ySign;
-  assign add_oh_output_payload_xMantissa = add_math_output_input_payload_xMantissa;
-  assign add_oh_output_payload_yMantissa = add_math_output_input_payload_yMantissa;
-  assign add_oh_output_payload_xyExponent = add_math_output_input_payload_xyExponent;
-  assign add_oh_output_payload_xySign = add_math_output_input_payload_xySign;
-  assign add_oh_output_payload_roundingScrap = add_math_output_input_payload_roundingScrap;
-  assign add_oh_output_payload_xyMantissa = add_math_output_input_payload_xyMantissa;
+  assign _zz_add_oh_input_ready = (! (add_oh_input_payload_needCommit && (! add_oh_isCommited)));
+  assign add_oh_input_ready = (add_oh_output_ready && _zz_add_oh_input_ready);
+  assign add_oh_output_valid = (add_oh_input_valid && _zz_add_oh_input_ready);
+  assign add_oh_output_payload_rs1_mantissa = add_oh_input_payload_rs1_mantissa;
+  assign add_oh_output_payload_rs1_exponent = add_oh_input_payload_rs1_exponent;
+  assign add_oh_output_payload_rs1_sign = add_oh_input_payload_rs1_sign;
+  assign add_oh_output_payload_rs1_special = add_oh_input_payload_rs1_special;
+  assign add_oh_output_payload_rs2_mantissa = add_oh_input_payload_rs2_mantissa;
+  assign add_oh_output_payload_rs2_exponent = add_oh_input_payload_rs2_exponent;
+  assign add_oh_output_payload_rs2_sign = add_oh_input_payload_rs2_sign;
+  assign add_oh_output_payload_rs2_special = add_oh_input_payload_rs2_special;
+  assign add_oh_output_payload_rd = add_oh_input_payload_rd;
+  assign add_oh_output_payload_roundMode = add_oh_input_payload_roundMode;
+  assign add_oh_output_payload_needCommit = add_oh_input_payload_needCommit;
+  assign add_oh_output_payload_xSign = add_oh_input_payload_xSign;
+  assign add_oh_output_payload_ySign = add_oh_input_payload_ySign;
+  assign add_oh_output_payload_xMantissa = add_oh_input_payload_xMantissa;
+  assign add_oh_output_payload_yMantissa = add_oh_input_payload_yMantissa;
+  assign add_oh_output_payload_xyExponent = add_oh_input_payload_xyExponent;
+  assign add_oh_output_payload_xySign = add_oh_input_payload_xySign;
+  assign add_oh_output_payload_roundingScrap = add_oh_input_payload_roundingScrap;
+  assign add_oh_output_payload_xyMantissa = add_oh_input_payload_xyMantissa;
   assign _zz_add_oh_shift = {add_oh_output_payload_xyMantissa[0],{add_oh_output_payload_xyMantissa[1],{add_oh_output_payload_xyMantissa[2],{add_oh_output_payload_xyMantissa[3],{add_oh_output_payload_xyMantissa[4],{add_oh_output_payload_xyMantissa[5],{add_oh_output_payload_xyMantissa[6],{add_oh_output_payload_xyMantissa[7],{add_oh_output_payload_xyMantissa[8],{_zz__zz_add_oh_shift,{_zz__zz_add_oh_shift_1,_zz__zz_add_oh_shift_2}}}}}}}}}}};
   assign _zz_add_oh_shift_1 = (_zz_add_oh_shift & (~ _zz__zz_add_oh_shift_1_1));
   assign _zz_add_oh_shift_2 = _zz_add_oh_shift_1[3];
@@ -13597,56 +13614,56 @@ module FpuCore (
   assign add_oh_shift = {_zz_add_oh_shift_27,{_zz_add_oh_shift_26,{_zz_add_oh_shift_25,{_zz_add_oh_shift_24,_zz_add_oh_shift_23}}}};
   assign add_oh_output_payload_shift = add_oh_shift;
   always @(*) begin
-    add_oh_output_ready = add_oh_output_input_ready;
-    if(when_Stream_l342_15) begin
+    add_oh_output_ready = add_norm_input_ready;
+    if(when_Stream_l368_15) begin
       add_oh_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_15 = (! add_oh_output_input_valid);
-  assign add_oh_output_input_valid = add_oh_output_rValid;
-  assign add_oh_output_input_payload_rs1_mantissa = add_oh_output_rData_rs1_mantissa;
-  assign add_oh_output_input_payload_rs1_exponent = add_oh_output_rData_rs1_exponent;
-  assign add_oh_output_input_payload_rs1_sign = add_oh_output_rData_rs1_sign;
-  assign add_oh_output_input_payload_rs1_special = add_oh_output_rData_rs1_special;
-  assign add_oh_output_input_payload_rs2_mantissa = add_oh_output_rData_rs2_mantissa;
-  assign add_oh_output_input_payload_rs2_exponent = add_oh_output_rData_rs2_exponent;
-  assign add_oh_output_input_payload_rs2_sign = add_oh_output_rData_rs2_sign;
-  assign add_oh_output_input_payload_rs2_special = add_oh_output_rData_rs2_special;
-  assign add_oh_output_input_payload_rd = add_oh_output_rData_rd;
-  assign add_oh_output_input_payload_roundMode = add_oh_output_rData_roundMode;
-  assign add_oh_output_input_payload_needCommit = add_oh_output_rData_needCommit;
-  assign add_oh_output_input_payload_xSign = add_oh_output_rData_xSign;
-  assign add_oh_output_input_payload_ySign = add_oh_output_rData_ySign;
-  assign add_oh_output_input_payload_xMantissa = add_oh_output_rData_xMantissa;
-  assign add_oh_output_input_payload_yMantissa = add_oh_output_rData_yMantissa;
-  assign add_oh_output_input_payload_xyExponent = add_oh_output_rData_xyExponent;
-  assign add_oh_output_input_payload_xySign = add_oh_output_rData_xySign;
-  assign add_oh_output_input_payload_roundingScrap = add_oh_output_rData_roundingScrap;
-  assign add_oh_output_input_payload_xyMantissa = add_oh_output_rData_xyMantissa;
-  assign add_oh_output_input_payload_shift = add_oh_output_rData_shift;
-  assign add_norm_output_valid = add_oh_output_input_valid;
-  assign add_oh_output_input_ready = add_norm_output_ready;
-  assign add_norm_output_payload_rs1_mantissa = add_oh_output_input_payload_rs1_mantissa;
-  assign add_norm_output_payload_rs1_exponent = add_oh_output_input_payload_rs1_exponent;
-  assign add_norm_output_payload_rs1_sign = add_oh_output_input_payload_rs1_sign;
-  assign add_norm_output_payload_rs1_special = add_oh_output_input_payload_rs1_special;
-  assign add_norm_output_payload_rs2_mantissa = add_oh_output_input_payload_rs2_mantissa;
-  assign add_norm_output_payload_rs2_exponent = add_oh_output_input_payload_rs2_exponent;
-  assign add_norm_output_payload_rs2_sign = add_oh_output_input_payload_rs2_sign;
-  assign add_norm_output_payload_rs2_special = add_oh_output_input_payload_rs2_special;
-  assign add_norm_output_payload_rd = add_oh_output_input_payload_rd;
-  assign add_norm_output_payload_roundMode = add_oh_output_input_payload_roundMode;
-  assign add_norm_output_payload_needCommit = add_oh_output_input_payload_needCommit;
-  assign add_norm_output_payload_xySign = add_oh_output_input_payload_xySign;
-  assign add_norm_output_payload_roundingScrap = add_oh_output_input_payload_roundingScrap;
-  assign add_norm_output_payload_mantissa = (add_oh_output_input_payload_xyMantissa <<< add_oh_output_input_payload_shift);
+  assign when_Stream_l368_15 = (! add_norm_input_valid);
+  assign add_norm_input_valid = add_oh_output_rValid;
+  assign add_norm_input_payload_rs1_mantissa = add_oh_output_rData_rs1_mantissa;
+  assign add_norm_input_payload_rs1_exponent = add_oh_output_rData_rs1_exponent;
+  assign add_norm_input_payload_rs1_sign = add_oh_output_rData_rs1_sign;
+  assign add_norm_input_payload_rs1_special = add_oh_output_rData_rs1_special;
+  assign add_norm_input_payload_rs2_mantissa = add_oh_output_rData_rs2_mantissa;
+  assign add_norm_input_payload_rs2_exponent = add_oh_output_rData_rs2_exponent;
+  assign add_norm_input_payload_rs2_sign = add_oh_output_rData_rs2_sign;
+  assign add_norm_input_payload_rs2_special = add_oh_output_rData_rs2_special;
+  assign add_norm_input_payload_rd = add_oh_output_rData_rd;
+  assign add_norm_input_payload_roundMode = add_oh_output_rData_roundMode;
+  assign add_norm_input_payload_needCommit = add_oh_output_rData_needCommit;
+  assign add_norm_input_payload_xSign = add_oh_output_rData_xSign;
+  assign add_norm_input_payload_ySign = add_oh_output_rData_ySign;
+  assign add_norm_input_payload_xMantissa = add_oh_output_rData_xMantissa;
+  assign add_norm_input_payload_yMantissa = add_oh_output_rData_yMantissa;
+  assign add_norm_input_payload_xyExponent = add_oh_output_rData_xyExponent;
+  assign add_norm_input_payload_xySign = add_oh_output_rData_xySign;
+  assign add_norm_input_payload_roundingScrap = add_oh_output_rData_roundingScrap;
+  assign add_norm_input_payload_xyMantissa = add_oh_output_rData_xyMantissa;
+  assign add_norm_input_payload_shift = add_oh_output_rData_shift;
+  assign add_norm_output_valid = add_norm_input_valid;
+  assign add_norm_input_ready = add_norm_output_ready;
+  assign add_norm_output_payload_rs1_mantissa = add_norm_input_payload_rs1_mantissa;
+  assign add_norm_output_payload_rs1_exponent = add_norm_input_payload_rs1_exponent;
+  assign add_norm_output_payload_rs1_sign = add_norm_input_payload_rs1_sign;
+  assign add_norm_output_payload_rs1_special = add_norm_input_payload_rs1_special;
+  assign add_norm_output_payload_rs2_mantissa = add_norm_input_payload_rs2_mantissa;
+  assign add_norm_output_payload_rs2_exponent = add_norm_input_payload_rs2_exponent;
+  assign add_norm_output_payload_rs2_sign = add_norm_input_payload_rs2_sign;
+  assign add_norm_output_payload_rs2_special = add_norm_input_payload_rs2_special;
+  assign add_norm_output_payload_rd = add_norm_input_payload_rd;
+  assign add_norm_output_payload_roundMode = add_norm_input_payload_roundMode;
+  assign add_norm_output_payload_needCommit = add_norm_input_payload_needCommit;
+  assign add_norm_output_payload_xySign = add_norm_input_payload_xySign;
+  assign add_norm_output_payload_roundingScrap = add_norm_input_payload_roundingScrap;
+  assign add_norm_output_payload_mantissa = (add_norm_input_payload_xyMantissa <<< add_norm_input_payload_shift);
   assign add_norm_output_payload_exponent = (_zz_add_norm_output_payload_exponent + 10'h001);
-  assign add_norm_output_payload_forceInfinity = ((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b01)));
-  assign add_norm_output_payload_forceZero = ((add_oh_output_input_payload_xyMantissa == 27'h0) || ((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b00))));
-  assign add_norm_output_payload_infinityNan = (((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b01))) && (add_oh_output_input_payload_rs1_sign ^ add_oh_output_input_payload_rs2_sign));
-  assign add_norm_output_payload_forceNan = (((add_oh_output_input_payload_rs1_special && (add_oh_output_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (add_oh_output_input_payload_rs2_special && (add_oh_output_input_payload_rs2_exponent[1 : 0] == 2'b10))) || add_norm_output_payload_infinityNan);
-  assign add_norm_output_payload_xyMantissaZero = (add_oh_output_input_payload_xyMantissa == 27'h0);
+  assign add_norm_output_payload_forceInfinity = ((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) || (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b01)));
+  assign add_norm_output_payload_forceZero = ((add_norm_input_payload_xyMantissa == 27'h0) || ((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b00))));
+  assign add_norm_output_payload_infinityNan = (((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b01)) && (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b01))) && (add_norm_input_payload_rs1_sign ^ add_norm_input_payload_rs2_sign));
+  assign add_norm_output_payload_forceNan = (((add_norm_input_payload_rs1_special && (add_norm_input_payload_rs1_exponent[1 : 0] == 2'b10)) || (add_norm_input_payload_rs2_special && (add_norm_input_payload_rs2_exponent[1 : 0] == 2'b10))) || add_norm_output_payload_infinityNan);
+  assign add_norm_output_payload_xyMantissaZero = (add_norm_input_payload_xyMantissa == 27'h0);
   assign add_result_input_valid = add_norm_output_valid;
   assign add_norm_output_ready = add_result_input_ready;
   assign add_result_input_payload_rs1_mantissa = add_norm_output_payload_rs1_mantissa;
@@ -13731,15 +13748,15 @@ module FpuCore (
   assign add_result_output_payload_NV = ((add_result_input_payload_infinityNan || ((add_result_input_payload_rs1_special && (add_result_input_payload_rs1_exponent[1 : 0] == 2'b10)) && (! add_result_input_payload_rs1_mantissa[24]))) || ((add_result_input_payload_rs2_special && (add_result_input_payload_rs2_exponent[1 : 0] == 2'b10)) && (! add_result_input_payload_rs2_mantissa[24])));
   assign add_result_output_payload_DZ = 1'b0;
   assign when_FpuCore_l1513 = (add_result_input_payload_xyMantissaZero || ((add_result_input_payload_rs1_special && (add_result_input_payload_rs1_exponent[1 : 0] == 2'b00)) && (add_result_input_payload_rs2_special && (add_result_input_payload_rs2_exponent[1 : 0] == 2'b00))));
-  assign when_FpuCore_l1516 = ((add_result_input_payload_rs1_sign || add_result_input_payload_rs2_sign) && (add_result_input_payload_roundMode == `FpuRoundMode_opt_RDN));
+  assign when_FpuCore_l1516 = ((add_result_input_payload_rs1_sign || add_result_input_payload_rs2_sign) && (add_result_input_payload_roundMode == FpuRoundMode_RDN));
   always @(*) begin
     load_s1_output_ready = load_s1_output_m2sPipe_ready;
-    if(when_Stream_l342_16) begin
+    if(when_Stream_l368_16) begin
       load_s1_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_16 = (! load_s1_output_m2sPipe_valid);
+  assign when_Stream_l368_16 = (! load_s1_output_m2sPipe_valid);
   assign load_s1_output_m2sPipe_valid = load_s1_output_rValid;
   assign load_s1_output_m2sPipe_payload_rd = load_s1_output_rData_rd;
   assign load_s1_output_m2sPipe_payload_value_mantissa = load_s1_output_rData_value_mantissa;
@@ -13752,12 +13769,12 @@ module FpuCore (
   assign load_s1_output_m2sPipe_payload_DZ = load_s1_output_rData_DZ;
   always @(*) begin
     shortPip_output_ready = shortPip_output_m2sPipe_ready;
-    if(when_Stream_l342_17) begin
+    if(when_Stream_l368_17) begin
       shortPip_output_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342_17 = (! shortPip_output_m2sPipe_valid);
+  assign when_Stream_l368_17 = (! shortPip_output_m2sPipe_valid);
   assign shortPip_output_m2sPipe_valid = shortPip_output_rValid;
   assign shortPip_output_m2sPipe_payload_rd = shortPip_output_rData_rd;
   assign shortPip_output_m2sPipe_payload_value_mantissa = shortPip_output_rData_value_mantissa;
@@ -13803,16 +13820,16 @@ module FpuCore (
   assign roundFront_roundAdjusted = {_zz_roundFront_roundAdjusted[roundFront_discardCount],((roundFront_manAggregate & roundFront_exactMask) != 25'h0)};
   always @(*) begin
     case(roundFront_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         _zz_roundFront_mantissaIncrement = (roundFront_roundAdjusted[1] && (roundFront_roundAdjusted[0] || _zz__zz_roundFront_mantissaIncrement[roundFront_discardCount]));
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         _zz_roundFront_mantissaIncrement = 1'b0;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         _zz_roundFront_mantissaIncrement = ((roundFront_roundAdjusted != 2'b00) && roundFront_input_payload_value_sign);
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         _zz_roundFront_mantissaIncrement = ((roundFront_roundAdjusted != 2'b00) && (! roundFront_input_payload_value_sign));
       end
       default : begin
@@ -13917,16 +13934,16 @@ module FpuCore (
   assign roundBack_ofThreshold = 9'h17e;
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         roundBack_threshold = 3'b110;
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         roundBack_threshold = 3'b110;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         roundBack_threshold = (roundBack_input_payload_value_sign ? 3'b101 : 3'b111);
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         roundBack_threshold = (roundBack_input_payload_value_sign ? 3'b111 : 3'b101);
       end
       default : begin
@@ -13941,16 +13958,16 @@ module FpuCore (
   assign when_FpuCore_l1611 = ((! roundBack_math_special) && (roundBack_ofThreshold < roundBack_math_exponent));
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         when_FpuCore_l1621 = 1'b0;
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         when_FpuCore_l1621 = 1'b1;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         when_FpuCore_l1621 = (! roundBack_math_sign);
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         when_FpuCore_l1621 = roundBack_math_sign;
       end
       default : begin
@@ -13962,16 +13979,16 @@ module FpuCore (
   assign when_FpuCore_l1630 = ((! roundBack_math_special) && (roundBack_math_exponent < _zz_when_FpuCore_l1630));
   always @(*) begin
     case(roundBack_input_payload_roundMode)
-      `FpuRoundMode_opt_RNE : begin
+      FpuRoundMode_RNE : begin
         when_FpuCore_l1640 = 1'b0;
       end
-      `FpuRoundMode_opt_RTZ : begin
+      FpuRoundMode_RTZ : begin
         when_FpuCore_l1640 = 1'b0;
       end
-      `FpuRoundMode_opt_RDN : begin
+      FpuRoundMode_RDN : begin
         when_FpuCore_l1640 = roundBack_math_sign;
       end
-      `FpuRoundMode_opt_RUP : begin
+      FpuRoundMode_RUP : begin
         when_FpuCore_l1640 = (! roundBack_math_sign);
       end
       default : begin
@@ -14064,7 +14081,7 @@ module FpuCore (
       if(io_port_0_cmd_valid) begin
         io_port_0_cmd_rValid <= 1'b1;
       end
-      if(io_port_0_cmd_input_ready) begin
+      if(scheduler_0_input_ready) begin
         io_port_0_cmd_rValid <= 1'b0;
       end
       if(read_s0_ready) begin
@@ -14112,7 +14129,7 @@ module FpuCore (
       if(decode_div_valid) begin
         decode_div_rValid <= 1'b1;
       end
-      if(decode_div_input_fire) begin
+      if(div_input_fire) begin
         decode_div_rValid <= 1'b0;
       end
       if(div_divider_io_input_fire) begin
@@ -14124,7 +14141,7 @@ module FpuCore (
       if(decode_sqrt_valid) begin
         decode_sqrt_rValid <= 1'b1;
       end
-      if(decode_sqrt_input_fire) begin
+      if(sqrt_input_fire) begin
         decode_sqrt_rValid <= 1'b0;
       end
       if(sqrt_sqrt_io_input_fire) begin
@@ -14157,20 +14174,20 @@ module FpuCore (
       if(writeback_port_valid) begin
         `ifndef SYNTHESIS
           `ifdef FORMAL
-            assert((! ((writeback_port_payload_data_value_exponent == 9'h0) && (! writeback_port_payload_data_value_special))));
+            assert((! ((writeback_port_payload_data_value_exponent == 9'h0) && (! writeback_port_payload_data_value_special)))); // FpuCore.scala:L1705
           `else
             if(!(! ((writeback_port_payload_data_value_exponent == 9'h0) && (! writeback_port_payload_data_value_special)))) begin
-              $display("FAILURE Special violation");
+              $display("FAILURE Special violation"); // FpuCore.scala:L1705
               $finish;
             end
           `endif
         `endif
         `ifndef SYNTHESIS
           `ifdef FORMAL
-            assert((! ((writeback_port_payload_data_value_exponent == 9'h1ff) && (! writeback_port_payload_data_value_special))));
+            assert((! ((writeback_port_payload_data_value_exponent == 9'h1ff) && (! writeback_port_payload_data_value_special)))); // FpuCore.scala:L1706
           `else
             if(!(! ((writeback_port_payload_data_value_exponent == 9'h1ff) && (! writeback_port_payload_data_value_special)))) begin
-              $display("FAILURE Special violation");
+              $display("FAILURE Special violation"); // FpuCore.scala:L1706
               $finish;
             end
           `endif
@@ -14241,7 +14258,7 @@ module FpuCore (
         end else begin
           load_s1_fsm_shift_by <= {_zz_load_s1_fsm_shift_by_32,{_zz_load_s1_fsm_shift_by_31,{_zz_load_s1_fsm_shift_by_30,{_zz_load_s1_fsm_shift_by_29,_zz_load_s1_fsm_shift_by_28}}}};
           load_s1_fsm_boot <= 1'b0;
-          load_s1_fsm_i2fZero <= (load_s0_output_input_payload_value[31 : 0] == 32'h0);
+          load_s1_fsm_i2fZero <= (load_s1_input_payload_value[31 : 0] == 32'h0);
         end
       end else begin
         load_s1_fsm_done <= 1'b1;
@@ -14620,6 +14637,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -14643,6 +14661,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -14659,6 +14679,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -14700,40 +14721,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -14743,33 +14764,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -14777,18 +14798,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -14800,17 +14821,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -14864,14 +14885,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -14885,42 +14906,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -14930,7 +14951,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -14940,7 +14961,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -14950,7 +14971,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -14975,14 +14996,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -14992,7 +15013,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -15002,7 +15023,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -15012,7 +15033,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -15025,15 +15046,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -15041,7 +15062,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -15063,42 +15084,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -15106,7 +15127,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -15116,27 +15137,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -15147,8 +15168,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -15156,26 +15177,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -15196,22 +15217,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -15220,8 +15241,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -15234,8 +15255,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -15250,8 +15271,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -15261,12 +15282,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -15275,11 +15296,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -15295,12 +15316,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -15308,26 +15329,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -15338,27 +15359,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -15379,28 +15400,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -15411,7 +15438,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -15419,7 +15446,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -15470,6 +15497,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -15487,7 +15515,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -15533,8 +15561,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -15604,10 +15632,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -15635,7 +15663,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
@@ -15734,7 +15762,7 @@ module StreamArbiter_1 (
   input               io_inputs_0_payload_value_sign,
   input               io_inputs_0_payload_value_special,
   input               io_inputs_0_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_0_payload_roundMode,
+  input      [2:0]    io_inputs_0_payload_roundMode,
   input               io_inputs_0_payload_NV,
   input               io_inputs_0_payload_DZ,
   input               io_inputs_1_valid,
@@ -15745,7 +15773,7 @@ module StreamArbiter_1 (
   input               io_inputs_1_payload_value_sign,
   input               io_inputs_1_payload_value_special,
   input               io_inputs_1_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_1_payload_roundMode,
+  input      [2:0]    io_inputs_1_payload_roundMode,
   input               io_inputs_1_payload_NV,
   input               io_inputs_1_payload_DZ,
   input               io_inputs_2_valid,
@@ -15756,7 +15784,7 @@ module StreamArbiter_1 (
   input               io_inputs_2_payload_value_sign,
   input               io_inputs_2_payload_value_special,
   input               io_inputs_2_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_2_payload_roundMode,
+  input      [2:0]    io_inputs_2_payload_roundMode,
   input               io_inputs_2_payload_NV,
   input               io_inputs_2_payload_DZ,
   input               io_inputs_3_valid,
@@ -15767,7 +15795,7 @@ module StreamArbiter_1 (
   input               io_inputs_3_payload_value_sign,
   input               io_inputs_3_payload_value_special,
   input               io_inputs_3_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_3_payload_roundMode,
+  input      [2:0]    io_inputs_3_payload_roundMode,
   input               io_inputs_3_payload_NV,
   input               io_inputs_3_payload_DZ,
   input               io_inputs_4_valid,
@@ -15778,7 +15806,7 @@ module StreamArbiter_1 (
   input               io_inputs_4_payload_value_sign,
   input               io_inputs_4_payload_value_special,
   input               io_inputs_4_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_4_payload_roundMode,
+  input      [2:0]    io_inputs_4_payload_roundMode,
   input               io_inputs_4_payload_NV,
   input               io_inputs_4_payload_DZ,
   input               io_inputs_5_valid,
@@ -15789,7 +15817,7 @@ module StreamArbiter_1 (
   input               io_inputs_5_payload_value_sign,
   input               io_inputs_5_payload_value_special,
   input               io_inputs_5_payload_scrap,
-  input      `FpuRoundMode_opt_type io_inputs_5_payload_roundMode,
+  input      [2:0]    io_inputs_5_payload_roundMode,
   input               io_inputs_5_payload_NV,
   input               io_inputs_5_payload_DZ,
   output              io_output_valid,
@@ -15800,7 +15828,7 @@ module StreamArbiter_1 (
   output              io_output_payload_value_sign,
   output              io_output_payload_value_special,
   output              io_output_payload_scrap,
-  output     `FpuRoundMode_opt_type io_output_payload_roundMode,
+  output     [2:0]    io_output_payload_roundMode,
   output              io_output_payload_NV,
   output              io_output_payload_DZ,
   output     [2:0]    io_chosen,
@@ -15808,8 +15836,14 @@ module StreamArbiter_1 (
   input               clk,
   input               reset
 );
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire       [5:0]    _zz__zz_maskProposal_1_1;
-  reg        `FpuRoundMode_opt_type _zz__zz_io_output_payload_roundMode;
+  reg        [2:0]    _zz__zz_io_output_payload_roundMode;
   reg        [4:0]    _zz_io_output_payload_rd_4;
   reg        [23:0]   _zz_io_output_payload_value_mantissa;
   reg        [8:0]    _zz_io_output_payload_value_exponent;
@@ -15843,7 +15877,7 @@ module StreamArbiter_1 (
   wire                _zz_io_output_payload_rd_1;
   wire                _zz_io_output_payload_rd_2;
   wire       [2:0]    _zz_io_output_payload_rd_3;
-  wire       `FpuRoundMode_opt_type _zz_io_output_payload_roundMode;
+  wire       [2:0]    _zz_io_output_payload_roundMode;
   wire                _zz_io_chosen;
   wire                _zz_io_chosen_1;
   wire                _zz_io_chosen_2;
@@ -15936,81 +15970,81 @@ module StreamArbiter_1 (
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_inputs_0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_0_payload_roundMode_string = "RMM";
       default : io_inputs_0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_1_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_1_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_1_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_1_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_1_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_1_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_1_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_1_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_1_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_1_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_1_payload_roundMode_string = "RMM";
       default : io_inputs_1_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_2_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_2_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_2_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_2_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_2_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_2_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_2_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_2_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_2_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_2_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_2_payload_roundMode_string = "RMM";
       default : io_inputs_2_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_3_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_3_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_3_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_3_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_3_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_3_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_3_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_3_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_3_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_3_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_3_payload_roundMode_string = "RMM";
       default : io_inputs_3_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_4_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_4_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_4_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_4_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_4_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_4_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_4_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_4_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_4_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_4_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_4_payload_roundMode_string = "RMM";
       default : io_inputs_4_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_inputs_5_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_5_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_5_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_5_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_5_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_5_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_5_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_5_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_5_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_5_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_5_payload_roundMode_string = "RMM";
       default : io_inputs_5_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_output_payload_roundMode_string = "RMM";
       default : io_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_io_output_payload_roundMode_string = "RMM";
       default : _zz_io_output_payload_roundMode_string = "???";
     endcase
   end
@@ -16084,6 +16118,7 @@ module FpuSqrt (
   input               clk,
   input               reset
 );
+
   wire       [27:0]   _zz_t;
   wire       [25:0]   _zz_t_1;
   wire       [24:0]   _zz_q;
@@ -16179,6 +16214,7 @@ module FpuDiv (
   input               clk,
   input               reset
 );
+
   wire       [24:0]   _zz_shifter_1;
   wire       [24:0]   _zz_div1;
   wire       [26:0]   _zz_div3;
@@ -16288,28 +16324,52 @@ endmodule
 module StreamArbiter (
   input               io_inputs_0_valid,
   output              io_inputs_0_ready,
-  input      `FpuOpcode_binary_sequential_type io_inputs_0_payload_opcode,
+  input      [3:0]    io_inputs_0_payload_opcode,
   input      [1:0]    io_inputs_0_payload_arg,
   input      [4:0]    io_inputs_0_payload_rs1,
   input      [4:0]    io_inputs_0_payload_rs2,
   input      [4:0]    io_inputs_0_payload_rs3,
   input      [4:0]    io_inputs_0_payload_rd,
-  input      `FpuFormat_binary_sequential_type io_inputs_0_payload_format,
-  input      `FpuRoundMode_opt_type io_inputs_0_payload_roundMode,
+  input      [0:0]    io_inputs_0_payload_format,
+  input      [2:0]    io_inputs_0_payload_roundMode,
   output              io_output_valid,
   input               io_output_ready,
-  output     `FpuOpcode_binary_sequential_type io_output_payload_opcode,
+  output     [3:0]    io_output_payload_opcode,
   output     [1:0]    io_output_payload_arg,
   output     [4:0]    io_output_payload_rs1,
   output     [4:0]    io_output_payload_rs2,
   output     [4:0]    io_output_payload_rs3,
   output     [4:0]    io_output_payload_rd,
-  output     `FpuFormat_binary_sequential_type io_output_payload_format,
-  output     `FpuRoundMode_opt_type io_output_payload_roundMode,
+  output     [0:0]    io_output_payload_format,
+  output     [2:0]    io_output_payload_roundMode,
   output     [0:0]    io_chosenOH,
   input               clk,
   input               reset
 );
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+  localparam FpuFormat_FLOAT = 1'd0;
+  localparam FpuFormat_DOUBLE = 1'd1;
+  localparam FpuRoundMode_RNE = 3'd0;
+  localparam FpuRoundMode_RTZ = 3'd1;
+  localparam FpuRoundMode_RDN = 3'd2;
+  localparam FpuRoundMode_RUP = 3'd3;
+  localparam FpuRoundMode_RMM = 3'd4;
+
   wire       [1:0]    _zz__zz_maskProposal_0_2;
   wire       [1:0]    _zz__zz_maskProposal_0_2_1;
   wire       [0:0]    _zz__zz_maskProposal_0_2_2;
@@ -16321,9 +16381,9 @@ module StreamArbiter (
   wire       [0:0]    _zz_maskProposal_0;
   wire       [1:0]    _zz_maskProposal_0_1;
   wire       [1:0]    _zz_maskProposal_0_2;
-  wire       `FpuOpcode_binary_sequential_type _zz_io_output_payload_opcode;
-  wire       `FpuFormat_binary_sequential_type _zz_io_output_payload_format;
-  wire       `FpuRoundMode_opt_type _zz_io_output_payload_roundMode;
+  wire       [3:0]    _zz_io_output_payload_opcode;
+  wire       [0:0]    _zz_io_output_payload_format;
+  wire       [2:0]    _zz_io_output_payload_roundMode;
   `ifndef SYNTHESIS
   reg [63:0] io_inputs_0_payload_opcode_string;
   reg [47:0] io_inputs_0_payload_format_string;
@@ -16344,115 +16404,115 @@ module StreamArbiter (
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_inputs_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_inputs_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_inputs_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_inputs_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_inputs_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_inputs_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_inputs_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_inputs_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_inputs_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_inputs_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_inputs_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_inputs_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_inputs_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_inputs_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_inputs_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_inputs_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_inputs_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_inputs_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_inputs_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_inputs_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_inputs_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_inputs_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_inputs_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_inputs_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_inputs_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_inputs_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_inputs_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_inputs_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_inputs_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_inputs_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_inputs_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_inputs_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_inputs_0_payload_opcode_string = "FCVT_X_X";
       default : io_inputs_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_inputs_0_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_inputs_0_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_inputs_0_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_inputs_0_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_inputs_0_payload_format_string = "DOUBLE";
       default : io_inputs_0_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_inputs_0_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_inputs_0_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_inputs_0_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_inputs_0_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_inputs_0_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_inputs_0_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_inputs_0_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_inputs_0_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_inputs_0_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_inputs_0_payload_roundMode_string = "RMM";
       default : io_inputs_0_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(io_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_output_payload_opcode_string = "FCVT_X_X";
       default : io_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_output_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : io_output_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : io_output_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : io_output_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : io_output_payload_format_string = "DOUBLE";
       default : io_output_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : io_output_payload_roundMode_string = "RMM";
       default : io_output_payload_roundMode_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : _zz_io_output_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : _zz_io_output_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : _zz_io_output_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : _zz_io_output_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : _zz_io_output_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : _zz_io_output_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : _zz_io_output_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : _zz_io_output_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : _zz_io_output_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : _zz_io_output_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : _zz_io_output_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : _zz_io_output_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : _zz_io_output_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : _zz_io_output_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : _zz_io_output_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : _zz_io_output_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : _zz_io_output_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : _zz_io_output_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : _zz_io_output_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : _zz_io_output_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : _zz_io_output_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : _zz_io_output_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : _zz_io_output_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : _zz_io_output_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : _zz_io_output_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : _zz_io_output_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : _zz_io_output_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : _zz_io_output_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : _zz_io_output_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : _zz_io_output_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : _zz_io_output_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : _zz_io_output_payload_opcode_string = "FCVT_X_X";
       default : _zz_io_output_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_format)
-      `FpuFormat_binary_sequential_FLOAT : _zz_io_output_payload_format_string = "FLOAT ";
-      `FpuFormat_binary_sequential_DOUBLE : _zz_io_output_payload_format_string = "DOUBLE";
+      FpuFormat_FLOAT : _zz_io_output_payload_format_string = "FLOAT ";
+      FpuFormat_DOUBLE : _zz_io_output_payload_format_string = "DOUBLE";
       default : _zz_io_output_payload_format_string = "??????";
     endcase
   end
   always @(*) begin
     case(_zz_io_output_payload_roundMode)
-      `FpuRoundMode_opt_RNE : _zz_io_output_payload_roundMode_string = "RNE";
-      `FpuRoundMode_opt_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
-      `FpuRoundMode_opt_RDN : _zz_io_output_payload_roundMode_string = "RDN";
-      `FpuRoundMode_opt_RUP : _zz_io_output_payload_roundMode_string = "RUP";
-      `FpuRoundMode_opt_RMM : _zz_io_output_payload_roundMode_string = "RMM";
+      FpuRoundMode_RNE : _zz_io_output_payload_roundMode_string = "RNE";
+      FpuRoundMode_RTZ : _zz_io_output_payload_roundMode_string = "RTZ";
+      FpuRoundMode_RDN : _zz_io_output_payload_roundMode_string = "RDN";
+      FpuRoundMode_RUP : _zz_io_output_payload_roundMode_string = "RUP";
+      FpuRoundMode_RMM : _zz_io_output_payload_roundMode_string = "RMM";
       default : _zz_io_output_payload_roundMode_string = "???";
     endcase
   end
@@ -16494,23 +16554,40 @@ endmodule
 module StreamFork (
   input               io_input_valid,
   output              io_input_ready,
-  input      `FpuOpcode_binary_sequential_type io_input_payload_opcode,
+  input      [3:0]    io_input_payload_opcode,
   input      [4:0]    io_input_payload_rd,
   input               io_input_payload_write,
   input      [31:0]   io_input_payload_value,
   output              io_outputs_0_valid,
   input               io_outputs_0_ready,
-  output     `FpuOpcode_binary_sequential_type io_outputs_0_payload_opcode,
+  output     [3:0]    io_outputs_0_payload_opcode,
   output     [4:0]    io_outputs_0_payload_rd,
   output              io_outputs_0_payload_write,
   output     [31:0]   io_outputs_0_payload_value,
   output              io_outputs_1_valid,
   input               io_outputs_1_ready,
-  output     `FpuOpcode_binary_sequential_type io_outputs_1_payload_opcode,
+  output     [3:0]    io_outputs_1_payload_opcode,
   output     [4:0]    io_outputs_1_payload_rd,
   output              io_outputs_1_payload_write,
   output     [31:0]   io_outputs_1_payload_value
 );
+  localparam FpuOpcode_LOAD = 4'd0;
+  localparam FpuOpcode_STORE = 4'd1;
+  localparam FpuOpcode_MUL = 4'd2;
+  localparam FpuOpcode_ADD = 4'd3;
+  localparam FpuOpcode_FMA = 4'd4;
+  localparam FpuOpcode_I2F = 4'd5;
+  localparam FpuOpcode_F2I = 4'd6;
+  localparam FpuOpcode_CMP = 4'd7;
+  localparam FpuOpcode_DIV = 4'd8;
+  localparam FpuOpcode_SQRT = 4'd9;
+  localparam FpuOpcode_MIN_MAX = 4'd10;
+  localparam FpuOpcode_SGNJ = 4'd11;
+  localparam FpuOpcode_FMV_X_W = 4'd12;
+  localparam FpuOpcode_FMV_W_X = 4'd13;
+  localparam FpuOpcode_FCLASS = 4'd14;
+  localparam FpuOpcode_FCVT_X_X = 4'd15;
+
   `ifndef SYNTHESIS
   reg [63:0] io_input_payload_opcode_string;
   reg [63:0] io_outputs_0_payload_opcode_string;
@@ -16521,64 +16598,64 @@ module StreamFork (
   `ifndef SYNTHESIS
   always @(*) begin
     case(io_input_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_input_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_input_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_input_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_input_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_input_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_input_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_input_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_input_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_input_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_input_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_input_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_input_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_input_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_input_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_input_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_input_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_input_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_input_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_input_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_input_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_input_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_input_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_input_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_input_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_input_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_input_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_input_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_input_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_input_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_input_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_input_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_input_payload_opcode_string = "FCVT_X_X";
       default : io_input_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_outputs_0_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_outputs_0_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_outputs_0_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_outputs_0_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_outputs_0_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_outputs_0_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_outputs_0_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_outputs_0_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_outputs_0_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_outputs_0_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_outputs_0_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_outputs_0_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_outputs_0_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_outputs_0_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_outputs_0_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_outputs_0_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_outputs_0_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_outputs_0_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_outputs_0_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_outputs_0_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_outputs_0_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_outputs_0_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_outputs_0_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_outputs_0_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_outputs_0_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_outputs_0_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_outputs_0_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_outputs_0_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_outputs_0_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_outputs_0_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_outputs_0_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_outputs_0_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_outputs_0_payload_opcode_string = "FCVT_X_X";
       default : io_outputs_0_payload_opcode_string = "????????";
     endcase
   end
   always @(*) begin
     case(io_outputs_1_payload_opcode)
-      `FpuOpcode_binary_sequential_LOAD : io_outputs_1_payload_opcode_string = "LOAD    ";
-      `FpuOpcode_binary_sequential_STORE : io_outputs_1_payload_opcode_string = "STORE   ";
-      `FpuOpcode_binary_sequential_MUL : io_outputs_1_payload_opcode_string = "MUL     ";
-      `FpuOpcode_binary_sequential_ADD : io_outputs_1_payload_opcode_string = "ADD     ";
-      `FpuOpcode_binary_sequential_FMA : io_outputs_1_payload_opcode_string = "FMA     ";
-      `FpuOpcode_binary_sequential_I2F : io_outputs_1_payload_opcode_string = "I2F     ";
-      `FpuOpcode_binary_sequential_F2I : io_outputs_1_payload_opcode_string = "F2I     ";
-      `FpuOpcode_binary_sequential_CMP : io_outputs_1_payload_opcode_string = "CMP     ";
-      `FpuOpcode_binary_sequential_DIV : io_outputs_1_payload_opcode_string = "DIV     ";
-      `FpuOpcode_binary_sequential_SQRT : io_outputs_1_payload_opcode_string = "SQRT    ";
-      `FpuOpcode_binary_sequential_MIN_MAX : io_outputs_1_payload_opcode_string = "MIN_MAX ";
-      `FpuOpcode_binary_sequential_SGNJ : io_outputs_1_payload_opcode_string = "SGNJ    ";
-      `FpuOpcode_binary_sequential_FMV_X_W : io_outputs_1_payload_opcode_string = "FMV_X_W ";
-      `FpuOpcode_binary_sequential_FMV_W_X : io_outputs_1_payload_opcode_string = "FMV_W_X ";
-      `FpuOpcode_binary_sequential_FCLASS : io_outputs_1_payload_opcode_string = "FCLASS  ";
-      `FpuOpcode_binary_sequential_FCVT_X_X : io_outputs_1_payload_opcode_string = "FCVT_X_X";
+      FpuOpcode_LOAD : io_outputs_1_payload_opcode_string = "LOAD    ";
+      FpuOpcode_STORE : io_outputs_1_payload_opcode_string = "STORE   ";
+      FpuOpcode_MUL : io_outputs_1_payload_opcode_string = "MUL     ";
+      FpuOpcode_ADD : io_outputs_1_payload_opcode_string = "ADD     ";
+      FpuOpcode_FMA : io_outputs_1_payload_opcode_string = "FMA     ";
+      FpuOpcode_I2F : io_outputs_1_payload_opcode_string = "I2F     ";
+      FpuOpcode_F2I : io_outputs_1_payload_opcode_string = "F2I     ";
+      FpuOpcode_CMP : io_outputs_1_payload_opcode_string = "CMP     ";
+      FpuOpcode_DIV : io_outputs_1_payload_opcode_string = "DIV     ";
+      FpuOpcode_SQRT : io_outputs_1_payload_opcode_string = "SQRT    ";
+      FpuOpcode_MIN_MAX : io_outputs_1_payload_opcode_string = "MIN_MAX ";
+      FpuOpcode_SGNJ : io_outputs_1_payload_opcode_string = "SGNJ    ";
+      FpuOpcode_FMV_X_W : io_outputs_1_payload_opcode_string = "FMV_X_W ";
+      FpuOpcode_FMV_W_X : io_outputs_1_payload_opcode_string = "FMV_W_X ";
+      FpuOpcode_FCLASS : io_outputs_1_payload_opcode_string = "FCLASS  ";
+      FpuOpcode_FCVT_X_X : io_outputs_1_payload_opcode_string = "FCVT_X_X";
       default : io_outputs_1_payload_opcode_string = "????????";
     endcase
   end

--- a/soc/vexriscv/VexRiscv_HpsCfu.v
+++ b/soc/vexriscv/VexRiscv_HpsCfu.v
@@ -1,51 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 665470729d63ff293f82037047a4ab71bed16398
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b10
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -85,6 +42,34 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_ECALL = 2'd2;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -113,6 +98,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -195,173 +182,156 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [6:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
+  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -431,10 +401,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -442,46 +412,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -491,9 +463,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -507,20 +481,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -534,42 +507,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -578,6 +551,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -590,8 +564,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -603,7 +577,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -647,6 +621,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -715,6 +690,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -757,14 +733,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -806,18 +782,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -836,7 +812,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -883,45 +858,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -975,7 +950,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -995,7 +970,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1013,11 +988,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1034,56 +1009,56 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1131,22 +1106,25 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1168,7 +1146,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1178,9 +1156,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1200,80 +1178,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1281,31 +1265,32 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
@@ -1316,8 +1301,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1406,7 +1391,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1420,7 +1405,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1435,7 +1420,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1447,6 +1432,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1520,166 +1507,147 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h10003050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h10003050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h10000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (|{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00403040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = (decode_INSTRUCTION & 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}};
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86) == 32'h00001010);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00001030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00002020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h00000070;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00004010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = (decode_INSTRUCTION & 32'h00000024);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 32'h00006014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = 32'h00002000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & 32'h00005054) == 32'h00001004);
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1702,880 +1670,863 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2619,6 +2570,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2653,6 +2606,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2673,14 +2628,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2756,10 +2710,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2770,7 +2724,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2807,10 +2761,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2832,6 +2786,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -2889,7 +2844,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2902,7 +2857,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2930,22 +2885,25 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2979,7 +2937,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -2997,7 +2955,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3028,10 +2986,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3042,45 +3000,47 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3121,9 +3081,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3146,7 +3106,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3208,24 +3168,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3250,7 +3216,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3296,7 +3262,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3344,7 +3310,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3425,12 +3391,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3448,7 +3414,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3467,9 +3433,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3479,12 +3447,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3497,7 +3465,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3507,7 +3475,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3526,7 +3494,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3539,8 +3507,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3553,7 +3521,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3605,7 +3573,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3618,7 +3586,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3638,11 +3606,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3657,8 +3626,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3690,10 +3659,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3704,10 +3673,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3718,13 +3687,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3783,13 +3752,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3842,7 +3811,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -3959,9 +3928,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -3979,13 +3948,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4058,10 +4027,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4073,7 +4042,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4108,11 +4077,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4163,14 +4132,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4181,9 +4150,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4227,29 +4196,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4257,7 +4226,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4295,12 +4264,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4356,18 +4325,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4375,14 +4344,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4395,19 +4364,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4416,9 +4385,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4429,8 +4398,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4523,12 +4492,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4562,7 +4534,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4573,16 +4545,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4619,64 +4591,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4703,18 +4678,18 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4723,12 +4698,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -4801,8 +4777,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | ((_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11) | _zz_CsrPlugin_csrMapping_readDataInit_12));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4858,11 +4834,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -4872,6 +4846,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4903,16 +4879,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -4930,13 +4906,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4945,7 +4921,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4954,7 +4930,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4963,7 +4939,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4986,50 +4962,54 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5038,7 +5018,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5049,8 +5029,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5060,7 +5040,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5071,16 +5051,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5103,9 +5083,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5169,10 +5155,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5185,21 +5167,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5317,150 +5299,159 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5509,6 +5500,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -5532,6 +5524,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5548,6 +5542,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -5589,40 +5584,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5632,33 +5627,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5666,18 +5661,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5689,17 +5684,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -5753,14 +5748,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -5774,42 +5769,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5819,7 +5814,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -5829,7 +5824,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -5839,7 +5834,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5864,14 +5859,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -5881,7 +5876,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -5891,7 +5886,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -5901,7 +5896,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -5914,15 +5909,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -5930,7 +5925,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -5952,42 +5947,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -5995,7 +5990,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6005,27 +6000,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6036,8 +6031,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6045,26 +6040,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6085,22 +6080,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6109,8 +6104,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6123,8 +6118,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6139,8 +6134,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6150,12 +6145,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6164,11 +6159,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6184,12 +6179,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6197,26 +6192,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6227,27 +6222,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6268,28 +6263,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6300,7 +6301,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6308,7 +6309,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6359,6 +6360,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [21:0]   _zz_ways_0_tags_port1;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -6376,7 +6378,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6422,8 +6424,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -6493,10 +6495,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6524,7 +6526,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_HpsdeltaCfu.v
+++ b/soc/vexriscv/VexRiscv_HpsdeltaCfu.v
@@ -1,51 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 7de06b1f9dd600f033d09829432d24e646eeef37
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b10
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -85,6 +42,34 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_ECALL = 2'd2;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -113,6 +98,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -195,173 +182,156 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [6:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
+  wire       [4:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -431,10 +401,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -442,46 +412,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -491,9 +463,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -507,20 +481,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -534,42 +507,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -578,6 +551,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -590,8 +564,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -603,7 +577,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -647,6 +621,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -715,6 +690,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -757,14 +733,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -806,18 +782,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -836,7 +812,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -883,45 +858,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -975,7 +950,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -995,7 +970,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1013,11 +988,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1034,56 +1009,56 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1131,22 +1106,25 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1168,7 +1146,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1178,9 +1156,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1200,80 +1178,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1281,31 +1265,32 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
@@ -1316,8 +1301,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1406,7 +1391,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1420,7 +1405,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1435,7 +1420,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1447,6 +1432,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1520,166 +1507,147 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h10003050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h10003050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h10000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (|{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00403040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = (decode_INSTRUCTION & 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}};
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86) == 32'h00001010);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00001030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00002020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h00000070;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00004010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = (decode_INSTRUCTION & 32'h00000024);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h0;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 32'h00006014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = 32'h00002000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & 32'h00005054) == 32'h00001004);
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1702,880 +1670,863 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2619,6 +2570,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2653,6 +2606,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2673,14 +2628,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2756,10 +2710,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2770,7 +2724,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2807,10 +2761,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2832,6 +2786,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -2889,7 +2844,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2902,7 +2857,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2930,22 +2885,25 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2979,7 +2937,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -2997,7 +2955,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3028,10 +2986,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3042,45 +3000,47 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3121,9 +3081,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3146,7 +3106,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3208,24 +3168,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3250,7 +3216,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3296,7 +3262,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3344,7 +3310,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3425,12 +3391,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3448,7 +3414,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3467,9 +3433,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3479,12 +3447,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3497,7 +3465,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3507,7 +3475,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3526,7 +3494,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3539,8 +3507,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3553,7 +3521,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3605,7 +3573,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3618,7 +3586,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3638,11 +3606,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3657,8 +3626,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3690,10 +3659,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3704,10 +3673,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3718,13 +3687,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3783,13 +3752,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3842,7 +3811,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -3959,9 +3928,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -3979,13 +3948,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4058,10 +4027,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4073,7 +4042,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4108,11 +4077,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4163,14 +4132,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4181,9 +4150,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4227,29 +4196,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4257,7 +4226,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4295,12 +4264,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4356,18 +4325,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4375,14 +4344,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4395,19 +4364,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4416,9 +4385,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4429,8 +4398,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4523,12 +4492,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4562,7 +4534,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4573,16 +4545,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4619,64 +4591,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4703,18 +4678,18 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4723,12 +4698,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_3[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_3[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_3[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -4801,8 +4777,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | ((_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11) | _zz_CsrPlugin_csrMapping_readDataInit_12));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -4858,11 +4834,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -4872,6 +4846,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -4903,16 +4879,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -4930,13 +4906,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4945,7 +4921,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4954,7 +4930,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4963,7 +4939,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -4986,50 +4962,54 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5038,7 +5018,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5049,8 +5029,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5060,7 +5040,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5071,16 +5051,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5103,9 +5083,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5169,10 +5155,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5185,21 +5167,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5317,150 +5299,159 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5509,6 +5500,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -5532,6 +5524,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5548,6 +5542,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -5589,40 +5584,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5632,33 +5627,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5666,18 +5661,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -5689,17 +5684,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -5753,14 +5748,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -5774,42 +5769,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5819,7 +5814,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -5829,7 +5824,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -5839,7 +5834,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -5864,14 +5859,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -5881,7 +5876,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -5891,7 +5886,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -5901,7 +5896,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -5914,15 +5909,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -5930,7 +5925,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -5952,42 +5947,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -5995,7 +5990,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6005,27 +6000,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6036,8 +6031,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6045,26 +6040,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6085,22 +6080,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6109,8 +6104,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6123,8 +6118,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6139,8 +6134,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6150,12 +6145,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6164,11 +6159,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6184,12 +6179,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6197,26 +6192,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6227,27 +6222,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6268,28 +6263,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6300,7 +6301,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6308,7 +6309,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6359,6 +6360,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [21:0]   _zz_ways_0_tags_port1;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -6376,7 +6378,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6422,8 +6424,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -6493,10 +6495,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6524,7 +6526,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_MinCfu.v
+++ b/soc/vexriscv/VexRiscv_MinCfu.v
@@ -1,51 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : b5eedd874caa5068bc7401416d904a4c37f8e8c2
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b10
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -85,6 +42,34 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_ECALL = 2'd2;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -127,114 +112,97 @@ module VexRiscv (
   wire       [2:0]    _zz_DBusSimplePlugin_memoryExceptionPort_payload_code;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
-  wire       [20:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
+  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [17:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [14:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [11:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [8:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [6:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [6:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -270,50 +238,52 @@ module VexRiscv (
   wire                decode_SRC2_FORCE_ZERO;
   wire       [31:0]   decode_RS2;
   wire       [31:0]   decode_RS1;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
   wire                decode_MEMORY_ENABLE;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
@@ -323,24 +293,26 @@ module VexRiscv (
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   reg        [31:0]   _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -350,41 +322,40 @@ module VexRiscv (
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   _zz_execute_to_memory_REGFILE_WRITE_DATA;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
-  wire                writeBack_MEMORY_STORE;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_lastStageRegFileWrite_payload_data;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
@@ -409,7 +380,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -453,6 +424,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusSimplePlugin_fetcherHalt;
+  wire                IBusSimplePlugin_forceNoDecodeCond;
   reg                 IBusSimplePlugin_incomingInstruction;
   wire                IBusSimplePlugin_pcValids_0;
   wire                IBusSimplePlugin_pcValids_1;
@@ -475,6 +447,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -513,12 +486,12 @@ module VexRiscv (
   reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusSimplePlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
   reg                 IBusSimplePlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
@@ -558,17 +531,17 @@ module VexRiscv (
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l323;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
   wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
@@ -578,20 +551,24 @@ module VexRiscv (
   reg        [2:0]    IBusSimplePlugin_pending_value;
   wire       [2:0]    IBusSimplePlugin_pending_next;
   wire                IBusSimplePlugin_cmdFork_canEmit;
-  wire                when_IBusSimplePlugin_l304;
+  wire                when_IBusSimplePlugin_l305;
   wire                IBusSimplePlugin_cmd_fire;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
   reg        [2:0]    IBusSimplePlugin_rspJoin_rspBuffer_discardCounter;
+  wire                iBus_rsp_toStream_valid;
+  wire                iBus_rsp_toStream_ready;
+  wire                iBus_rsp_toStream_payload_error;
+  wire       [31:0]   iBus_rsp_toStream_payload_inst;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_flush;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_pc;
   reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
   wire                IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
-  wire                when_IBusSimplePlugin_l375;
+  wire                when_IBusSimplePlugin_l376;
   wire                IBusSimplePlugin_rspJoin_join_valid;
   wire                IBusSimplePlugin_rspJoin_join_ready;
   wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_pc;
@@ -614,14 +591,14 @@ module VexRiscv (
   wire                _zz_dBus_cmd_valid;
   reg                 execute_DBusSimplePlugin_skipCmd;
   reg        [31:0]   _zz_dBus_cmd_payload_data;
-  wire                when_DBusSimplePlugin_l426;
+  wire                when_DBusSimplePlugin_l428;
   reg        [3:0]    _zz_execute_DBusSimplePlugin_formalMask;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
-  wire                when_DBusSimplePlugin_l479;
-  wire                when_DBusSimplePlugin_l486;
-  wire                when_DBusSimplePlugin_l512;
+  wire                when_DBusSimplePlugin_l482;
+  wire                when_DBusSimplePlugin_l489;
+  wire                when_DBusSimplePlugin_l515;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusSimplePlugin_rspFormated_1;
   wire                _zz_writeBack_DBusSimplePlugin_rspFormated_2;
@@ -634,14 +611,15 @@ module VexRiscv (
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -697,7 +675,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_DO;
   reg                 _zz_execute_BRANCH_DO_1;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
@@ -710,7 +688,7 @@ module VexRiscv (
   reg        [31:0]   _zz_execute_BranchPlugin_branch_src2_6;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l216;
+  wire                when_BranchPlugin_l222;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -728,11 +706,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -747,76 +725,79 @@ module VexRiscv (
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   wire                CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -836,7 +817,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_8;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
   wire                when_Pipeline_l124_9;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_10;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_11;
@@ -846,9 +827,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_13;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_14;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_15;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_16;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_17;
@@ -866,52 +847,56 @@ module VexRiscv (
   wire                when_Pipeline_l124_23;
   reg                 execute_to_memory_MEMORY_STORE;
   wire                when_Pipeline_l124_24;
-  reg                 memory_to_writeBack_MEMORY_STORE;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_25;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_26;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_28;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_29;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_30;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_31;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_32;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_33;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_36;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_37;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_38;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_41;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_42;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg                 execute_to_memory_ALIGNEMENT_FAULT;
   wire                when_Pipeline_l124_43;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
   wire                when_Pipeline_l124_44;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
   wire                when_Pipeline_l124_45;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_46;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_47;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_48;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_49;
   reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -919,28 +904,29 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_4032;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
@@ -951,14 +937,14 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
   reg                 iBus_cmd_rValid;
   reg        [31:0]   iBus_cmd_rData_pc;
-  wire                when_Stream_l342;
+  wire                when_Stream_l368;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
   wire                dBus_cmd_halfPipe_payload_wr;
@@ -1045,7 +1031,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1058,7 +1044,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
   assign _zz_IBusSimplePlugin_jump_pcLoad_payload_1 = (_zz_IBusSimplePlugin_jump_pcLoad_payload & (~ _zz_IBusSimplePlugin_jump_pcLoad_payload_2));
@@ -1087,7 +1073,7 @@ module VexRiscv (
   assign _zz_execute_SrcPlugin_addSub_5 = 32'h00000001;
   assign _zz_execute_SrcPlugin_addSub_6 = 32'h0;
   assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (_zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 >>> 1);
-  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz__zz_execute_to_memory_REGFILE_WRITE_DATA_1_1 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
   assign _zz__zz_execute_BranchPlugin_branch_src2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
@@ -1113,116 +1099,99 @@ module VexRiscv (
   assign _zz_decode_LEGAL_INSTRUCTION_15 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
   assign _zz_decode_LEGAL_INSTRUCTION_16 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
   assign _zz_decode_LEGAL_INSTRUCTION_17 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = (decode_INSTRUCTION & 32'h10003050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15) == 32'h00005010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = 32'h00007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00003054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 3'b000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = ((decode_INSTRUCTION & 32'h00001010) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ((decode_INSTRUCTION & 32'h00000070) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = 32'h00006010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = 32'h00004010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = 32'h10003050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = 32'h10000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) == 32'h00000004)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8) == 32'h00000040));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h0000001c;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00005010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14) == 32'h40001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h40003054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = 32'h00007054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = (decode_INSTRUCTION & 32'h00003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00001000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = (|{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = 32'h00002000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = 32'h00001000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = (|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = (decode_INSTRUCTION & 32'h00403040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (|{_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & 32'h00001010) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = ((decode_INSTRUCTION & 32'h00000070) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h00006010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00004010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
       _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
@@ -1242,700 +1211,700 @@ module VexRiscv (
   end
 
   StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c (
-    .io_push_valid            (iBus_rsp_valid                                             ), //i
-    .io_push_ready            (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready         ), //o
-    .io_push_payload_error    (iBus_rsp_payload_error                                     ), //i
-    .io_push_payload_inst     (iBus_rsp_payload_inst                                      ), //i
-    .io_pop_valid             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid          ), //o
-    .io_pop_ready             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready          ), //i
-    .io_pop_payload_error     (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error  ), //o
-    .io_pop_payload_inst      (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst   ), //o
-    .io_flush                 (1'b0                                                       ), //i
-    .io_occupancy             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy          ), //o
-    .clk                      (clk                                                        ), //i
-    .reset                    (reset                                                      )  //i
+    .io_push_valid         (iBus_rsp_toStream_valid                                       ), //i
+    .io_push_ready         (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready            ), //o
+    .io_push_payload_error (iBus_rsp_toStream_payload_error                               ), //i
+    .io_push_payload_inst  (iBus_rsp_toStream_payload_inst[31:0]                          ), //i
+    .io_pop_valid          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid             ), //o
+    .io_pop_ready          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready             ), //i
+    .io_pop_payload_error  (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error     ), //o
+    .io_pop_payload_inst   (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]), //o
+    .io_flush              (1'b0                                                          ), //i
+    .io_occupancy          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy             ), //o
+    .clk                   (clk                                                           ), //i
+    .reset                 (reset                                                         )  //i
   );
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -1968,6 +1937,8 @@ module VexRiscv (
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign decode_MEMORY_STORE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[12];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[11];
@@ -2001,13 +1972,15 @@ module VexRiscv (
   always @(*) begin
     _zz_memory_to_writeBack_REGFILE_WRITE_DATA = memory_REGFILE_WRITE_DATA;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_memory_to_writeBack_REGFILE_WRITE_DATA = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_memory_to_writeBack_REGFILE_WRITE_DATA = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
@@ -2032,7 +2005,7 @@ module VexRiscv (
     if(when_ShiftPlugins_l169) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = _zz_execute_to_memory_REGFILE_WRITE_DATA_1;
     end
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_execute_to_memory_REGFILE_WRITE_DATA = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2069,8 +2042,7 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 21'h0);
-  assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_lastStageRegFileWrite_payload_data = writeBack_REGFILE_WRITE_DATA;
     if(when_DBusSimplePlugin_l558) begin
@@ -2111,7 +2083,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2136,7 +2108,7 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l426) begin
+    if(when_DBusSimplePlugin_l428) begin
       execute_arbitration_haltItself = 1'b1;
     end
     if(when_ShiftPlugins_l169) begin
@@ -2144,12 +2116,15 @@ module VexRiscv (
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
@@ -2178,11 +2153,11 @@ module VexRiscv (
 
   always @(*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(when_DBusSimplePlugin_l479) begin
+    if(when_DBusSimplePlugin_l482) begin
       memory_arbitration_haltItself = 1'b1;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -2219,10 +2194,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @(*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2233,17 +2208,18 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusSimplePlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusSimplePlugin_incomingInstruction = 1'b0;
     if(IBusSimplePlugin_iBusRsp_stages_1_input_valid) begin
@@ -2254,27 +2230,28 @@ module VexRiscv (
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   assign CsrPlugin_inWfi = 1'b0;
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2308,9 +2285,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
   assign IBusSimplePlugin_fetchPc_output_fire_1 = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
   always @(*) begin
     IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
     if(IBusSimplePlugin_jump_pcLoad_valid) begin
@@ -2327,7 +2304,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
   assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
@@ -2336,7 +2313,7 @@ module VexRiscv (
   assign IBusSimplePlugin_iBusRsp_stages_0_input_payload = IBusSimplePlugin_fetchPc_output_payload;
   always @(*) begin
     IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(when_IBusSimplePlugin_l304) begin
+    if(when_IBusSimplePlugin_l305) begin
       IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
@@ -2361,7 +2338,7 @@ module VexRiscv (
     if(IBusSimplePlugin_injector_decodeInput_valid) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
   end
@@ -2372,28 +2349,38 @@ module VexRiscv (
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  assign when_Fetcher_l320 = (! IBusSimplePlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l323 = (! IBusSimplePlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusSimplePlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusSimplePlugin_injector_decodeInput_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
   assign IBusSimplePlugin_pcValids_3 = IBusSimplePlugin_injector_nextPcCalc_valids_4;
   assign IBusSimplePlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
+    if(IBusSimplePlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign iBus_cmd_valid = IBusSimplePlugin_cmd_valid;
   assign IBusSimplePlugin_cmd_ready = iBus_cmd_ready;
   assign iBus_cmd_payload_pc = IBusSimplePlugin_cmd_payload_pc;
   assign IBusSimplePlugin_pending_next = (_zz_IBusSimplePlugin_pending_next - _zz_IBusSimplePlugin_pending_next_3);
   assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != 3'b111));
-  assign when_IBusSimplePlugin_l304 = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready)));
+  assign when_IBusSimplePlugin_l305 = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready)));
   assign IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
   assign IBusSimplePlugin_cmd_fire = (IBusSimplePlugin_cmd_valid && IBusSimplePlugin_cmd_ready);
   assign IBusSimplePlugin_pending_inc = IBusSimplePlugin_cmd_fire;
   assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_iBusRsp_stages_0_input_payload[31 : 2],2'b00};
+  assign iBus_rsp_toStream_valid = iBus_rsp_valid;
+  assign iBus_rsp_toStream_payload_error = iBus_rsp_payload_error;
+  assign iBus_rsp_toStream_payload_inst = iBus_rsp_payload_inst;
+  assign iBus_rsp_toStream_ready = IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
   assign IBusSimplePlugin_rspJoin_rspBuffer_flush = ((IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000) || IBusSimplePlugin_iBusRsp_flush);
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == 3'b000));
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
@@ -2404,13 +2391,13 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   always @(*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
-    if(when_IBusSimplePlugin_l375) begin
+    if(when_IBusSimplePlugin_l376) begin
       IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = 1'b0;
     end
   end
 
   assign IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
-  assign when_IBusSimplePlugin_l375 = (! IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
+  assign when_IBusSimplePlugin_l376 = (! IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
   assign IBusSimplePlugin_rspJoin_join_valid = (IBusSimplePlugin_iBusRsp_stages_1_output_valid && IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_join_payload_pc = IBusSimplePlugin_rspJoin_fetchRsp_pc;
@@ -2454,7 +2441,7 @@ module VexRiscv (
   end
 
   assign dBus_cmd_payload_data = _zz_dBus_cmd_payload_data;
-  assign when_DBusSimplePlugin_l426 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
+  assign when_DBusSimplePlugin_l428 = ((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_dBus_cmd_valid));
   always @(*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
@@ -2471,23 +2458,23 @@ module VexRiscv (
 
   assign execute_DBusSimplePlugin_formalMask = (_zz_execute_DBusSimplePlugin_formalMask <<< dBus_cmd_payload_address[1 : 0]);
   assign dBus_cmd_payload_address = execute_SRC_ADD;
-  assign when_DBusSimplePlugin_l479 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
+  assign when_DBusSimplePlugin_l482 = (((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0));
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(when_DBusSimplePlugin_l486) begin
+    if(when_DBusSimplePlugin_l489) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(when_DBusSimplePlugin_l512) begin
+    if(when_DBusSimplePlugin_l515) begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @(*) begin
     DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
-    if(when_DBusSimplePlugin_l486) begin
+    if(when_DBusSimplePlugin_l489) begin
       DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT) begin
@@ -2496,8 +2483,8 @@ module VexRiscv (
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  assign when_DBusSimplePlugin_l486 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign when_DBusSimplePlugin_l512 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
+  assign when_DBusSimplePlugin_l489 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign when_DBusSimplePlugin_l515 = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
   always @(*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2515,7 +2502,7 @@ module VexRiscv (
     endcase
   end
 
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusSimplePlugin_rspFormated = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusSimplePlugin_rspFormated_1[31] = _zz_writeBack_DBusSimplePlugin_rspFormated;
@@ -2567,7 +2554,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusSimplePlugin_rspFormated = _zz_writeBack_DBusSimplePlugin_rspFormated_1;
       end
@@ -2582,11 +2569,12 @@ module VexRiscv (
 
   assign when_DBusSimplePlugin_l558 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1) != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2) == 32'h00000050)),{(|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2)),{(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[1 : 0];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[6 : 5];
@@ -2601,8 +2589,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[25 : 24];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 27];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 27];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -2634,10 +2622,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -2648,10 +2636,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -2662,13 +2650,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -2727,13 +2715,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -2750,14 +2738,14 @@ module VexRiscv (
   end
 
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
-  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_binary_sequential_DISABLE_1);
+  assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != ShiftCtrlEnum_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
   assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   assign when_ShiftPlugins_l169 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+      ShiftCtrlEnum_SLL_1 : begin
         _zz_execute_to_memory_REGFILE_WRITE_DATA_1 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
@@ -2855,9 +2843,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_DO = execute_BranchPlugin_eq;
       end
@@ -2875,13 +2863,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_DO_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_DO_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_DO_1 = 1'b1;
       end
       default : begin
@@ -2890,7 +2878,7 @@ module VexRiscv (
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JALR) ? execute_RS1 : execute_PC);
+  assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JALR) ? execute_RS1 : execute_PC);
   assign _zz_execute_BranchPlugin_branch_src2 = _zz__zz_execute_BranchPlugin_branch_src2[19];
   always @(*) begin
     _zz_execute_BranchPlugin_branch_src2_1[10] = _zz_execute_BranchPlugin_branch_src2;
@@ -2955,10 +2943,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_branch_src2_6 = {{_zz_execute_BranchPlugin_branch_src2_1,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_branch_src2_6 = {_zz_execute_BranchPlugin_branch_src2_3,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
@@ -2973,14 +2961,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && BranchPlugin_jumpInterface_payload[1]);
-    if(when_BranchPlugin_l216) begin
+    if(when_BranchPlugin_l222) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = BranchPlugin_jumpInterface_payload;
-  assign when_BranchPlugin_l216 = 1'b0;
+  assign when_BranchPlugin_l222 = 1'b0;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire) begin
@@ -2990,9 +2978,9 @@ module VexRiscv (
 
   assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid};
@@ -3034,29 +3022,29 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_lastStageWasWfi = 1'b0;
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -3064,7 +3052,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -3102,12 +3090,12 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768) begin
@@ -3158,18 +3146,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -3177,14 +3165,14 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -3197,19 +3185,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3218,9 +3206,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -3231,16 +3219,19 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -3274,7 +3265,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -3285,16 +3276,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -3328,49 +3319,51 @@ module VexRiscv (
   assign when_Pipeline_l124_21 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_22 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_23 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_24 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_25 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_24 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_25 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_26 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_31 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_32 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! writeBack_arbitration_isStuck);
   assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_37 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_38 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_42 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
+  assign when_Pipeline_l124_40 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_42 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_45 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_45 = ((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers));
   assign when_Pipeline_l124_46 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_47 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_47 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_48 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_49 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -3397,23 +3390,24 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_2[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_2[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -3486,16 +3480,16 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = ((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_6 | _zz_CsrPlugin_csrMapping_readDataInit_7) | (_zz_CsrPlugin_csrMapping_readDataInit_8 | _zz_CsrPlugin_csrMapping_readDataInit_9))) | (_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   always @(*) begin
     iBus_cmd_ready = iBus_cmd_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       iBus_cmd_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! iBus_cmd_m2sPipe_valid);
+  assign when_Stream_l368 = (! iBus_cmd_m2sPipe_valid);
   assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
   assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
   assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
@@ -3574,6 +3568,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -3602,16 +3598,16 @@ module VexRiscv (
         IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusSimplePlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusSimplePlugin_fetchPc_output_fire_1) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
       if(IBusSimplePlugin_iBusRsp_flush) begin
@@ -3629,13 +3625,13 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3644,7 +3640,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3653,7 +3649,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3662,7 +3658,7 @@ module VexRiscv (
       if(IBusSimplePlugin_fetchPc_flushed) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= IBusSimplePlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusSimplePlugin_fetchPc_flushed) begin
@@ -3673,26 +3669,6 @@ module VexRiscv (
       if(IBusSimplePlugin_iBusRsp_flush) begin
         IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
       end
-      `ifndef SYNTHESIS
-        `ifdef FORMAL
-          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
-        `else
-          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
-            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
-            $finish;
-          end
-        `endif
-      `endif
-      `ifndef SYNTHESIS
-        `ifdef FORMAL
-          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
-        `else
-          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
-            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
-            $finish;
-          end
-        `endif
-      `endif
       _zz_2 <= 1'b0;
       if(when_ShiftPlugins_l169) begin
         if(when_ShiftPlugins_l175) begin
@@ -3706,50 +3682,54 @@ module VexRiscv (
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -3758,7 +3738,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3769,8 +3749,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -3780,7 +3760,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
       end
@@ -3790,16 +3770,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_45) begin
+      if(when_Pipeline_l124_47) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -3822,9 +3802,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -3871,10 +3857,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(decodeExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
@@ -3887,21 +3869,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusSimplePlugin_memoryExceptionPort_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -3992,105 +3974,111 @@ module VexRiscv (
       execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
     end
     if(when_Pipeline_l124_24) begin
-      memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_25) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_30) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_31) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_32) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_37) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_38) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_41) begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_42) begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
     end
     if(when_Pipeline_l124_43) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
     if(when_Pipeline_l124_44) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if(when_Pipeline_l124_45) begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_execute_to_memory_REGFILE_WRITE_DATA;
     end
     if(when_Pipeline_l124_46) begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_memory_to_writeBack_REGFILE_WRITE_DATA;
+    end
+    if(when_Pipeline_l124_48) begin
       memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
     end
-    if(when_Pipeline_l124_47) begin
+    if(when_Pipeline_l124_49) begin
       memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -4137,7 +4125,8 @@ module StreamFifoLowLatency (
   input               clk,
   input               reset
 );
-  reg                 when_Phase_l623;
+
+  reg                 when_Phase_l649;
   reg                 pushPtr_willIncrement;
   reg                 pushPtr_willClear;
   wire                pushPtr_willOverflowIfInc;
@@ -4152,15 +4141,18 @@ module StreamFifoLowLatency (
   wire                full;
   wire                pushing;
   wire                popping;
-  wire                when_Stream_l995;
-  wire       [32:0]   _zz_io_pop_payload_error;
-  wire                when_Stream_l1008;
-  reg        [32:0]   _zz_io_pop_payload_error_1;
+  wire                readed_error;
+  wire       [31:0]   readed_inst;
+  wire       [32:0]   _zz_readed_error;
+  wire                when_Stream_l1178;
+  wire                when_Stream_l1191;
+  wire       [32:0]   _zz_readed_error_1;
+  reg        [32:0]   _zz_readed_error_2;
 
   always @(*) begin
-    when_Phase_l623 = 1'b0;
+    when_Phase_l649 = 1'b0;
     if(pushing) begin
-      when_Phase_l623 = 1'b1;
+      when_Phase_l649 = 1'b1;
     end
   end
 
@@ -4202,39 +4194,42 @@ module StreamFifoLowLatency (
   assign pushing = (io_push_valid && io_push_ready);
   assign popping = (io_pop_valid && io_pop_ready);
   assign io_push_ready = (! full);
-  assign when_Stream_l995 = (! empty);
+  assign _zz_readed_error = _zz_readed_error_1;
+  assign readed_error = _zz_readed_error[0];
+  assign readed_inst = _zz_readed_error[32 : 1];
+  assign when_Stream_l1178 = (! empty);
   always @(*) begin
-    if(when_Stream_l995) begin
+    if(when_Stream_l1178) begin
       io_pop_valid = 1'b1;
     end else begin
       io_pop_valid = io_push_valid;
     end
   end
 
-  assign _zz_io_pop_payload_error = _zz_io_pop_payload_error_1;
   always @(*) begin
-    if(when_Stream_l995) begin
-      io_pop_payload_error = _zz_io_pop_payload_error[0];
+    if(when_Stream_l1178) begin
+      io_pop_payload_error = readed_error;
     end else begin
       io_pop_payload_error = io_push_payload_error;
     end
   end
 
   always @(*) begin
-    if(when_Stream_l995) begin
-      io_pop_payload_inst = _zz_io_pop_payload_error[32 : 1];
+    if(when_Stream_l1178) begin
+      io_pop_payload_inst = readed_inst;
     end else begin
       io_pop_payload_inst = io_push_payload_inst;
     end
   end
 
-  assign when_Stream_l1008 = (pushing != popping);
+  assign when_Stream_l1191 = (pushing != popping);
   assign io_occupancy = (risingOccupancy && ptrMatch);
+  assign _zz_readed_error_1 = _zz_readed_error_2;
   always @(posedge clk) begin
     if(reset) begin
       risingOccupancy <= 1'b0;
     end else begin
-      if(when_Stream_l1008) begin
+      if(when_Stream_l1191) begin
         risingOccupancy <= pushing;
       end
       if(io_flush) begin
@@ -4244,8 +4239,8 @@ module StreamFifoLowLatency (
   end
 
   always @(posedge clk) begin
-    if(when_Phase_l623) begin
-      _zz_io_pop_payload_error_1 <= {io_push_payload_inst,io_push_payload_error};
+    if(when_Phase_l649) begin
+      _zz_readed_error_2 <= {io_push_payload_inst,io_push_payload_error};
     end
   end
 

--- a/soc/vexriscv/VexRiscv_PerfCfu.v
+++ b/soc/vexriscv/VexRiscv_PerfCfu.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -86,6 +42,35 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -114,6 +99,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [7:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -196,179 +183,169 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -439,10 +416,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -450,46 +427,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -499,9 +478,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -515,20 +496,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -542,42 +522,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -586,6 +566,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -598,8 +579,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -611,7 +592,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -655,6 +636,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -723,6 +705,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -765,14 +748,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -814,18 +797,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -844,7 +827,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -891,45 +873,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -983,7 +965,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1003,7 +985,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1022,11 +1004,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1043,59 +1025,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1143,46 +1125,49 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367;
-  wire                when_GenCoreDefault_l367;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410;
+  wire                when_GenCoreDefault_l410;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_1;
-  wire                when_GenCoreDefault_l367_1;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_1;
+  wire                when_GenCoreDefault_l410_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_2;
-  wire                when_GenCoreDefault_l367_2;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_2;
+  wire                when_GenCoreDefault_l410_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_3;
-  wire                when_GenCoreDefault_l367_3;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_3;
+  wire                when_GenCoreDefault_l410_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_4;
-  wire                when_GenCoreDefault_l367_4;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_4;
+  wire                when_GenCoreDefault_l410_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_5;
-  wire                when_GenCoreDefault_l367_5;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_5;
+  wire                when_GenCoreDefault_l410_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_6;
-  wire                when_GenCoreDefault_l367_6;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_6;
+  wire                when_GenCoreDefault_l410_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_7;
-  wire                when_GenCoreDefault_l367_7;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_7;
+  wire                when_GenCoreDefault_l410_7;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1204,7 +1189,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1214,9 +1199,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1236,80 +1221,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1317,91 +1308,92 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1264_24;
+  wire                when_CsrPlugin_l1277_24;
   reg                 execute_CsrPlugin_csr_2820;
-  wire                when_CsrPlugin_l1264_25;
+  wire                when_CsrPlugin_l1277_25;
   reg                 execute_CsrPlugin_csr_2821;
-  wire                when_CsrPlugin_l1264_26;
+  wire                when_CsrPlugin_l1277_26;
   reg                 execute_CsrPlugin_csr_2822;
-  wire                when_CsrPlugin_l1264_27;
+  wire                when_CsrPlugin_l1277_27;
   reg                 execute_CsrPlugin_csr_2823;
-  wire                when_CsrPlugin_l1264_28;
+  wire                when_CsrPlugin_l1277_28;
   reg                 execute_CsrPlugin_csr_2824;
-  wire                when_CsrPlugin_l1264_29;
+  wire                when_CsrPlugin_l1277_29;
   reg                 execute_CsrPlugin_csr_2825;
-  wire                when_CsrPlugin_l1264_30;
+  wire                when_CsrPlugin_l1277_30;
   reg                 execute_CsrPlugin_csr_2826;
-  wire                when_CsrPlugin_l1264_31;
+  wire                when_CsrPlugin_l1277_31;
   reg                 execute_CsrPlugin_csr_2827;
-  wire                when_CsrPlugin_l1264_32;
+  wire                when_CsrPlugin_l1277_32;
   reg                 execute_CsrPlugin_csr_2828;
-  wire                when_CsrPlugin_l1264_33;
+  wire                when_CsrPlugin_l1277_33;
   reg                 execute_CsrPlugin_csr_2829;
-  wire                when_CsrPlugin_l1264_34;
+  wire                when_CsrPlugin_l1277_34;
   reg                 execute_CsrPlugin_csr_2830;
-  wire                when_CsrPlugin_l1264_35;
+  wire                when_CsrPlugin_l1277_35;
   reg                 execute_CsrPlugin_csr_2831;
-  wire                when_CsrPlugin_l1264_36;
+  wire                when_CsrPlugin_l1277_36;
   reg                 execute_CsrPlugin_csr_2832;
-  wire                when_CsrPlugin_l1264_37;
+  wire                when_CsrPlugin_l1277_37;
   reg                 execute_CsrPlugin_csr_2833;
-  wire                when_CsrPlugin_l1264_38;
+  wire                when_CsrPlugin_l1277_38;
   reg                 execute_CsrPlugin_csr_2834;
-  wire                when_CsrPlugin_l1264_39;
+  wire                when_CsrPlugin_l1277_39;
   reg                 execute_CsrPlugin_csr_2835;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
@@ -1428,8 +1420,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_38;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_39;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_40;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1518,7 +1510,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1532,7 +1524,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1547,7 +1539,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1559,6 +1551,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1632,172 +1626,160 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h00203050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00403050);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1821,899 +1803,882 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[7:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2757,6 +2722,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2791,6 +2758,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2811,14 +2780,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2894,10 +2862,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2908,7 +2876,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2945,10 +2913,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2970,6 +2938,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -3027,7 +2996,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -3040,7 +3009,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3068,27 +3037,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3122,7 +3094,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3140,7 +3112,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3171,10 +3143,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3185,29 +3157,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3215,21 +3189,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3270,9 +3244,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3295,7 +3269,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3357,24 +3331,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3399,7 +3379,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3445,7 +3425,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3493,7 +3473,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3574,12 +3554,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3597,7 +3577,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3616,9 +3596,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[7:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3628,12 +3610,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3646,7 +3628,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3656,7 +3638,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3675,7 +3657,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3688,8 +3670,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3702,7 +3684,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3754,7 +3736,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3767,7 +3749,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3787,11 +3769,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3806,8 +3789,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3839,10 +3822,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3853,10 +3836,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3867,13 +3850,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3932,13 +3915,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3991,7 +3974,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4108,9 +4091,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4128,13 +4111,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4207,10 +4190,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4222,7 +4205,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4257,11 +4240,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4312,14 +4295,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4328,9 +4311,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4374,28 +4357,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4403,7 +4386,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4441,14 +4424,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4610,18 +4593,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4629,20 +4612,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4655,20 +4638,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4677,9 +4660,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4690,8 +4673,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4784,12 +4767,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4823,7 +4809,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4834,24 +4820,24 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
-  assign when_GenCoreDefault_l367 = _zz_when_GenCoreDefault_l367[0];
-  assign when_GenCoreDefault_l367_1 = _zz_when_GenCoreDefault_l367_1[0];
-  assign when_GenCoreDefault_l367_2 = _zz_when_GenCoreDefault_l367_2[0];
-  assign when_GenCoreDefault_l367_3 = _zz_when_GenCoreDefault_l367_3[0];
-  assign when_GenCoreDefault_l367_4 = _zz_when_GenCoreDefault_l367_4[0];
-  assign when_GenCoreDefault_l367_5 = _zz_when_GenCoreDefault_l367_5[0];
-  assign when_GenCoreDefault_l367_6 = _zz_when_GenCoreDefault_l367_6[0];
-  assign when_GenCoreDefault_l367_7 = _zz_when_GenCoreDefault_l367_7[0];
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
+  assign when_GenCoreDefault_l410 = _zz_when_GenCoreDefault_l410[0];
+  assign when_GenCoreDefault_l410_1 = _zz_when_GenCoreDefault_l410_1[0];
+  assign when_GenCoreDefault_l410_2 = _zz_when_GenCoreDefault_l410_2[0];
+  assign when_GenCoreDefault_l410_3 = _zz_when_GenCoreDefault_l410_3[0];
+  assign when_GenCoreDefault_l410_4 = _zz_when_GenCoreDefault_l410_4[0];
+  assign when_GenCoreDefault_l410_5 = _zz_when_GenCoreDefault_l410_5[0];
+  assign when_GenCoreDefault_l410_6 = _zz_when_GenCoreDefault_l410_6[0];
+  assign when_GenCoreDefault_l410_7 = _zz_when_GenCoreDefault_l410_7[0];
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4888,64 +4874,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4972,46 +4961,46 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_28 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_29 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_30 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_31 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_32 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_33 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_34 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_35 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_36 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_37 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_38 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_39 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_28 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_29 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_30 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_31 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_32 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_33 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_34 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_35 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_36 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_37 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_38 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_39 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5049,12 +5038,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_15[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5240,8 +5230,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11) | (_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13)) | ((_zz_CsrPlugin_csrMapping_readDataInit_41 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26) | (_zz_CsrPlugin_csrMapping_readDataInit_27 | _zz_CsrPlugin_csrMapping_readDataInit_28)) | ((_zz_CsrPlugin_csrMapping_readDataInit_29 | _zz_CsrPlugin_csrMapping_readDataInit_30) | (_zz_CsrPlugin_csrMapping_readDataInit_31 | _zz_CsrPlugin_csrMapping_readDataInit_32))) | (((_zz_CsrPlugin_csrMapping_readDataInit_33 | _zz_CsrPlugin_csrMapping_readDataInit_34) | (_zz_CsrPlugin_csrMapping_readDataInit_35 | _zz_CsrPlugin_csrMapping_readDataInit_36)) | ((_zz_CsrPlugin_csrMapping_readDataInit_37 | _zz_CsrPlugin_csrMapping_readDataInit_38) | (_zz_CsrPlugin_csrMapping_readDataInit_39 | _zz_CsrPlugin_csrMapping_readDataInit_40)))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5297,11 +5287,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5313,6 +5301,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5345,16 +5335,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5372,13 +5362,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5387,7 +5377,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5396,7 +5386,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5405,7 +5395,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5428,51 +5418,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5481,7 +5475,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5492,8 +5486,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5503,7 +5497,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5514,16 +5508,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5552,9 +5546,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5562,6 +5562,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5618,10 +5638,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5634,21 +5650,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5687,28 +5703,28 @@ module VexRiscv (
     if(CfuPlugin_bus_rsp_ready) begin
       CfuPlugin_bus_rsp_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
     end
-    if(when_GenCoreDefault_l367) begin
+    if(when_GenCoreDefault_l410) begin
       _zz_CsrPlugin_csrMapping_readDataInit_2 <= (_zz_CsrPlugin_csrMapping_readDataInit_2 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_1) begin
+    if(when_GenCoreDefault_l410_1) begin
       _zz_CsrPlugin_csrMapping_readDataInit_3 <= (_zz_CsrPlugin_csrMapping_readDataInit_3 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_2) begin
+    if(when_GenCoreDefault_l410_2) begin
       _zz_CsrPlugin_csrMapping_readDataInit_4 <= (_zz_CsrPlugin_csrMapping_readDataInit_4 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_3) begin
+    if(when_GenCoreDefault_l410_3) begin
       _zz_CsrPlugin_csrMapping_readDataInit_5 <= (_zz_CsrPlugin_csrMapping_readDataInit_5 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_4) begin
+    if(when_GenCoreDefault_l410_4) begin
       _zz_CsrPlugin_csrMapping_readDataInit_6 <= (_zz_CsrPlugin_csrMapping_readDataInit_6 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_5) begin
+    if(when_GenCoreDefault_l410_5) begin
       _zz_CsrPlugin_csrMapping_readDataInit_7 <= (_zz_CsrPlugin_csrMapping_readDataInit_7 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_6) begin
+    if(when_GenCoreDefault_l410_6) begin
       _zz_CsrPlugin_csrMapping_readDataInit_8 <= (_zz_CsrPlugin_csrMapping_readDataInit_8 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_7) begin
+    if(when_GenCoreDefault_l410_7) begin
       _zz_CsrPlugin_csrMapping_readDataInit_9 <= (_zz_CsrPlugin_csrMapping_readDataInit_9 + 32'h00000001);
     end
     if(when_Pipeline_l124) begin
@@ -5790,234 +5806,243 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1264_24) begin
+    if(when_CsrPlugin_l1277_24) begin
       execute_CsrPlugin_csr_2820 <= (decode_INSTRUCTION[31 : 20] == 12'hb04);
     end
-    if(when_CsrPlugin_l1264_25) begin
+    if(when_CsrPlugin_l1277_25) begin
       execute_CsrPlugin_csr_2821 <= (decode_INSTRUCTION[31 : 20] == 12'hb05);
     end
-    if(when_CsrPlugin_l1264_26) begin
+    if(when_CsrPlugin_l1277_26) begin
       execute_CsrPlugin_csr_2822 <= (decode_INSTRUCTION[31 : 20] == 12'hb06);
     end
-    if(when_CsrPlugin_l1264_27) begin
+    if(when_CsrPlugin_l1277_27) begin
       execute_CsrPlugin_csr_2823 <= (decode_INSTRUCTION[31 : 20] == 12'hb07);
     end
-    if(when_CsrPlugin_l1264_28) begin
+    if(when_CsrPlugin_l1277_28) begin
       execute_CsrPlugin_csr_2824 <= (decode_INSTRUCTION[31 : 20] == 12'hb08);
     end
-    if(when_CsrPlugin_l1264_29) begin
+    if(when_CsrPlugin_l1277_29) begin
       execute_CsrPlugin_csr_2825 <= (decode_INSTRUCTION[31 : 20] == 12'hb09);
     end
-    if(when_CsrPlugin_l1264_30) begin
+    if(when_CsrPlugin_l1277_30) begin
       execute_CsrPlugin_csr_2826 <= (decode_INSTRUCTION[31 : 20] == 12'hb0a);
     end
-    if(when_CsrPlugin_l1264_31) begin
+    if(when_CsrPlugin_l1277_31) begin
       execute_CsrPlugin_csr_2827 <= (decode_INSTRUCTION[31 : 20] == 12'hb0b);
     end
-    if(when_CsrPlugin_l1264_32) begin
+    if(when_CsrPlugin_l1277_32) begin
       execute_CsrPlugin_csr_2828 <= (decode_INSTRUCTION[31 : 20] == 12'hb0c);
     end
-    if(when_CsrPlugin_l1264_33) begin
+    if(when_CsrPlugin_l1277_33) begin
       execute_CsrPlugin_csr_2829 <= (decode_INSTRUCTION[31 : 20] == 12'hb0d);
     end
-    if(when_CsrPlugin_l1264_34) begin
+    if(when_CsrPlugin_l1277_34) begin
       execute_CsrPlugin_csr_2830 <= (decode_INSTRUCTION[31 : 20] == 12'hb0e);
     end
-    if(when_CsrPlugin_l1264_35) begin
+    if(when_CsrPlugin_l1277_35) begin
       execute_CsrPlugin_csr_2831 <= (decode_INSTRUCTION[31 : 20] == 12'hb0f);
     end
-    if(when_CsrPlugin_l1264_36) begin
+    if(when_CsrPlugin_l1277_36) begin
       execute_CsrPlugin_csr_2832 <= (decode_INSTRUCTION[31 : 20] == 12'hb10);
     end
-    if(when_CsrPlugin_l1264_37) begin
+    if(when_CsrPlugin_l1277_37) begin
       execute_CsrPlugin_csr_2833 <= (decode_INSTRUCTION[31 : 20] == 12'hb11);
     end
-    if(when_CsrPlugin_l1264_38) begin
+    if(when_CsrPlugin_l1277_38) begin
       execute_CsrPlugin_csr_2834 <= (decode_INSTRUCTION[31 : 20] == 12'hb12);
     end
-    if(when_CsrPlugin_l1264_39) begin
+    if(when_CsrPlugin_l1277_39) begin
       execute_CsrPlugin_csr_2835 <= (decode_INSTRUCTION[31 : 20] == 12'hb13);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6052,26 +6077,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     if(execute_CsrPlugin_csr_2820) begin
       if(execute_CsrPlugin_writeEnable) begin
         _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
@@ -6079,7 +6084,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2821) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2822) begin
@@ -6089,7 +6094,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2823) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2824) begin
@@ -6099,7 +6104,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2825) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2826) begin
@@ -6109,7 +6114,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2827) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2828) begin
@@ -6119,7 +6124,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2829) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2830) begin
@@ -6129,7 +6134,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2831) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2832) begin
@@ -6139,7 +6144,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2833) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2834) begin
@@ -6149,7 +6154,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2835) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -6182,6 +6187,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -6205,6 +6211,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [7:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -6221,6 +6229,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [20:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [20:0]   _zz_ways_0_tags_port;
@@ -6262,40 +6271,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6305,33 +6314,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [18:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [8:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -6339,18 +6348,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6362,17 +6371,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:2047];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:2047];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6426,14 +6435,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6447,42 +6456,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 8'bxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[12 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 11'bxxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[12 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6492,7 +6501,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6502,7 +6511,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 8'bxxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[7:0];
     end
     if(loader_done) begin
@@ -6512,7 +6521,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6537,14 +6546,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6554,7 +6563,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6564,7 +6573,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[12 : 5],loader_counter_value};
     end
   end
@@ -6574,7 +6583,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6587,15 +6596,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6603,7 +6612,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6625,42 +6634,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 13] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6668,7 +6677,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6678,27 +6687,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[8]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[8]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[8]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6709,8 +6718,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6718,26 +6727,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6758,22 +6767,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6782,8 +6791,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6796,8 +6805,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6812,8 +6821,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6823,12 +6832,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6837,11 +6846,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6857,12 +6866,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6870,26 +6879,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6900,27 +6909,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6941,28 +6950,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 9'h001);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[8] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 9'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6973,7 +6988,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6981,7 +6996,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -7032,6 +7047,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [20:0]   _zz_ways_0_tags_port1;
   wire       [20:0]   _zz_ways_0_tags_port;
@@ -7049,7 +7065,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7095,8 +7111,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:2047];
-  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -7166,10 +7182,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7197,7 +7213,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[20 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 13]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_PerfCfuDebug.v
+++ b/soc/vexriscv/VexRiscv_PerfCfuDebug.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -94,6 +50,35 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -122,6 +107,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [7:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -204,6 +191,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
@@ -211,174 +200,163 @@ module VexRiscv (
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [27:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -450,10 +428,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -461,46 +439,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -510,9 +490,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -528,20 +510,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -555,42 +536,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -599,6 +580,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -611,8 +593,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -668,6 +650,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -728,7 +711,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l386;
+  reg                 _zz_when_DBusCachedPlugin_l393;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -737,6 +720,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  reg                 BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -782,14 +766,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -831,18 +815,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -861,7 +845,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -908,45 +891,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [34:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -1000,7 +983,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1020,7 +1003,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1039,11 +1022,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1060,59 +1043,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1175,60 +1158,63 @@ module VexRiscv (
   reg        [31:0]   DebugPlugin_busReadDataReg;
   reg                 _zz_when_DebugPlugin_l244;
   wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l256;
-  wire                when_DebugPlugin_l260;
-  wire                when_DebugPlugin_l260_1;
-  wire                when_DebugPlugin_l261;
-  wire                when_DebugPlugin_l261_1;
-  wire                when_DebugPlugin_l262;
-  wire                when_DebugPlugin_l263;
-  wire                when_DebugPlugin_l264;
-  wire                when_DebugPlugin_l264_1;
-  wire                when_DebugPlugin_l284;
-  wire                when_DebugPlugin_l287;
-  wire                when_DebugPlugin_l300;
+  wire       [5:0]    switch_DebugPlugin_l267;
+  wire                when_DebugPlugin_l271;
+  wire                when_DebugPlugin_l271_1;
+  wire                when_DebugPlugin_l272;
+  wire                when_DebugPlugin_l272_1;
+  wire                when_DebugPlugin_l273;
+  wire                when_DebugPlugin_l274;
+  wire                when_DebugPlugin_l275;
+  wire                when_DebugPlugin_l275_1;
+  wire                when_DebugPlugin_l295;
+  wire                when_DebugPlugin_l298;
+  wire                when_DebugPlugin_l311;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l316;
+  wire                when_DebugPlugin_l331;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367;
-  wire                when_GenCoreDefault_l367;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410;
+  wire                when_GenCoreDefault_l410;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_1;
-  wire                when_GenCoreDefault_l367_1;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_1;
+  wire                when_GenCoreDefault_l410_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_2;
-  wire                when_GenCoreDefault_l367_2;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_2;
+  wire                when_GenCoreDefault_l410_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_3;
-  wire                when_GenCoreDefault_l367_3;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_3;
+  wire                when_GenCoreDefault_l410_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_4;
-  wire                when_GenCoreDefault_l367_4;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_4;
+  wire                when_GenCoreDefault_l410_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_5;
-  wire                when_GenCoreDefault_l367_5;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_5;
+  wire                when_GenCoreDefault_l410_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_6;
-  wire                when_GenCoreDefault_l367_6;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_6;
+  wire                when_GenCoreDefault_l410_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_7;
-  wire                when_GenCoreDefault_l367_7;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_7;
+  wire                when_GenCoreDefault_l410_7;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1250,7 +1236,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1260,9 +1246,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1282,82 +1268,88 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg                 decode_to_execute_DO_EBREAK;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_DO_EBREAK;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_57;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_61;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_62;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_63;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_64;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_65;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_67;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1365,93 +1357,94 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l362;
-  wire                when_Fetcher_l378;
-  wire                when_CsrPlugin_l1264;
+  reg        [2:0]    switch_Fetcher_l365;
+  wire                when_Fetcher_l381;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1264_24;
+  wire                when_CsrPlugin_l1277_24;
   reg                 execute_CsrPlugin_csr_2820;
-  wire                when_CsrPlugin_l1264_25;
+  wire                when_CsrPlugin_l1277_25;
   reg                 execute_CsrPlugin_csr_2821;
-  wire                when_CsrPlugin_l1264_26;
+  wire                when_CsrPlugin_l1277_26;
   reg                 execute_CsrPlugin_csr_2822;
-  wire                when_CsrPlugin_l1264_27;
+  wire                when_CsrPlugin_l1277_27;
   reg                 execute_CsrPlugin_csr_2823;
-  wire                when_CsrPlugin_l1264_28;
+  wire                when_CsrPlugin_l1277_28;
   reg                 execute_CsrPlugin_csr_2824;
-  wire                when_CsrPlugin_l1264_29;
+  wire                when_CsrPlugin_l1277_29;
   reg                 execute_CsrPlugin_csr_2825;
-  wire                when_CsrPlugin_l1264_30;
+  wire                when_CsrPlugin_l1277_30;
   reg                 execute_CsrPlugin_csr_2826;
-  wire                when_CsrPlugin_l1264_31;
+  wire                when_CsrPlugin_l1277_31;
   reg                 execute_CsrPlugin_csr_2827;
-  wire                when_CsrPlugin_l1264_32;
+  wire                when_CsrPlugin_l1277_32;
   reg                 execute_CsrPlugin_csr_2828;
-  wire                when_CsrPlugin_l1264_33;
+  wire                when_CsrPlugin_l1277_33;
   reg                 execute_CsrPlugin_csr_2829;
-  wire                when_CsrPlugin_l1264_34;
+  wire                when_CsrPlugin_l1277_34;
   reg                 execute_CsrPlugin_csr_2830;
-  wire                when_CsrPlugin_l1264_35;
+  wire                when_CsrPlugin_l1277_35;
   reg                 execute_CsrPlugin_csr_2831;
-  wire                when_CsrPlugin_l1264_36;
+  wire                when_CsrPlugin_l1277_36;
   reg                 execute_CsrPlugin_csr_2832;
-  wire                when_CsrPlugin_l1264_37;
+  wire                when_CsrPlugin_l1277_37;
   reg                 execute_CsrPlugin_csr_2833;
-  wire                when_CsrPlugin_l1264_38;
+  wire                when_CsrPlugin_l1277_38;
   reg                 execute_CsrPlugin_csr_2834;
-  wire                when_CsrPlugin_l1264_39;
+  wire                when_CsrPlugin_l1277_39;
   reg                 execute_CsrPlugin_csr_2835;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
@@ -1478,8 +1471,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_38;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_39;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_40;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1568,7 +1561,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1582,7 +1575,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1597,7 +1590,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1609,6 +1602,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1681,175 +1676,164 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 32'h00100050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (((decode_INSTRUCTION & 32'h02004064) == 32'h02004020) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9} != 2'b00),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21}}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = 32'h00100040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = 32'h10103050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & 32'h02004074) == 32'h02000030));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = (|{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7)});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = {(|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10)),{(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26}}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (decode_INSTRUCTION & 32'h10203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = 32'h10000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = (decode_INSTRUCTION & 32'h00103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00100040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136}}};
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1873,901 +1857,884 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[7:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2812,6 +2779,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2846,6 +2815,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
   assign decode_IS_EBREAK = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
@@ -2868,14 +2839,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2951,10 +2921,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2965,7 +2935,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -3002,10 +2972,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -3027,6 +2997,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -3084,10 +3055,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -3104,7 +3075,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3132,30 +3103,33 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
+    if(when_DebugPlugin_l295) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3172,8 +3146,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3187,8 +3161,8 @@ module VexRiscv (
     if(_zz_when_1) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -3202,7 +3176,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3220,7 +3194,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3251,10 +3225,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3265,39 +3239,47 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l300) begin
+    if(when_DebugPlugin_l311) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    _zz_when_DBusCachedPlugin_l393 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l386 = 1'b1;
+      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    BranchPlugin_inDebugNoFetchFlag = 1'b0;
+    if(DebugPlugin_godmode) begin
+      BranchPlugin_inDebugNoFetchFlag = 1'b1;
     end
   end
 
@@ -3305,7 +3287,7 @@ module VexRiscv (
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3319,21 +3301,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3352,7 +3334,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l316) begin
+    if(when_DebugPlugin_l331) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3398,9 +3380,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3423,7 +3405,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3485,18 +3467,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3504,7 +3486,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3514,6 +3496,9 @@ module VexRiscv (
       default : begin
       end
     endcase
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
   end
 
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
@@ -3540,7 +3525,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3586,7 +3571,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3634,7 +3619,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3715,12 +3700,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3738,7 +3723,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3757,9 +3742,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[7:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3769,12 +3756,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3787,7 +3774,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3797,7 +3784,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3816,7 +3803,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3829,8 +3816,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3843,7 +3830,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3895,7 +3882,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3908,7 +3895,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3928,11 +3915,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1) != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2) == 32'h00100050)),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3947,8 +3935,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3980,10 +3968,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3994,10 +3982,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -4008,13 +3996,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -4073,13 +4061,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -4132,7 +4120,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4249,9 +4237,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4269,13 +4257,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4348,10 +4336,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4363,7 +4351,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4398,11 +4386,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4453,14 +4441,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4469,9 +4457,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4515,28 +4503,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4544,7 +4532,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4582,14 +4570,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4751,18 +4739,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4770,20 +4758,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4796,20 +4784,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4818,9 +4806,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4831,8 +4819,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4925,13 +4913,13 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
   assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l256)
+      case(switch_DebugPlugin_l267)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
@@ -4958,7 +4946,7 @@ module VexRiscv (
   always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l256)
+      case(switch_DebugPlugin_l267)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
@@ -4971,25 +4959,28 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -5023,7 +5014,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -5034,24 +5025,24 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
-  assign when_GenCoreDefault_l367 = _zz_when_GenCoreDefault_l367[0];
-  assign when_GenCoreDefault_l367_1 = _zz_when_GenCoreDefault_l367_1[0];
-  assign when_GenCoreDefault_l367_2 = _zz_when_GenCoreDefault_l367_2[0];
-  assign when_GenCoreDefault_l367_3 = _zz_when_GenCoreDefault_l367_3[0];
-  assign when_GenCoreDefault_l367_4 = _zz_when_GenCoreDefault_l367_4[0];
-  assign when_GenCoreDefault_l367_5 = _zz_when_GenCoreDefault_l367_5[0];
-  assign when_GenCoreDefault_l367_6 = _zz_when_GenCoreDefault_l367_6[0];
-  assign when_GenCoreDefault_l367_7 = _zz_when_GenCoreDefault_l367_7[0];
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
+  assign when_GenCoreDefault_l410 = _zz_when_GenCoreDefault_l410[0];
+  assign when_GenCoreDefault_l410_1 = _zz_when_GenCoreDefault_l410_1[0];
+  assign when_GenCoreDefault_l410_2 = _zz_when_GenCoreDefault_l410_2[0];
+  assign when_GenCoreDefault_l410_3 = _zz_when_GenCoreDefault_l410_3[0];
+  assign when_GenCoreDefault_l410_4 = _zz_when_GenCoreDefault_l410_4[0];
+  assign when_GenCoreDefault_l410_5 = _zz_when_GenCoreDefault_l410_5[0];
+  assign when_GenCoreDefault_l410_6 = _zz_when_GenCoreDefault_l410_6[0];
+  assign when_GenCoreDefault_l410_7 = _zz_when_GenCoreDefault_l410_7[0];
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -5088,65 +5079,68 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_64 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_67 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -5175,7 +5169,7 @@ module VexRiscv (
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -5184,47 +5178,47 @@ module VexRiscv (
     endcase
   end
 
-  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_28 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_29 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_30 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_31 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_32 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_33 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_34 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_35 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_36 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_37 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_38 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_39 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_28 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_29 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_30 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_31 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_32 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_33 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_34 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_35 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_36 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_37 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_38 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_39 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5262,12 +5256,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_15[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5453,8 +5448,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11) | (_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13)) | ((_zz_CsrPlugin_csrMapping_readDataInit_41 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26) | (_zz_CsrPlugin_csrMapping_readDataInit_27 | _zz_CsrPlugin_csrMapping_readDataInit_28)) | ((_zz_CsrPlugin_csrMapping_readDataInit_29 | _zz_CsrPlugin_csrMapping_readDataInit_30) | (_zz_CsrPlugin_csrMapping_readDataInit_31 | _zz_CsrPlugin_csrMapping_readDataInit_32))) | (((_zz_CsrPlugin_csrMapping_readDataInit_33 | _zz_CsrPlugin_csrMapping_readDataInit_34) | (_zz_CsrPlugin_csrMapping_readDataInit_35 | _zz_CsrPlugin_csrMapping_readDataInit_36)) | ((_zz_CsrPlugin_csrMapping_readDataInit_37 | _zz_CsrPlugin_csrMapping_readDataInit_38) | (_zz_CsrPlugin_csrMapping_readDataInit_39 | _zz_CsrPlugin_csrMapping_readDataInit_40)))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5510,11 +5505,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5526,6 +5519,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5545,7 +5540,7 @@ module VexRiscv (
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l362 <= 3'b000;
+      switch_Fetcher_l365 <= 3'b000;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
@@ -5559,16 +5554,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5586,13 +5581,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5601,7 +5596,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5610,7 +5605,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5619,7 +5614,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5642,51 +5637,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5695,7 +5694,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5706,8 +5705,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5717,7 +5716,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5728,16 +5727,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_62) begin
+      if(when_Pipeline_l124_65) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5758,25 +5757,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l362)
+      case(switch_Fetcher_l365)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l362 <= 3'b001;
+            switch_Fetcher_l365 <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l362 <= 3'b010;
+          switch_Fetcher_l365 <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l362 <= 3'b011;
+          switch_Fetcher_l365 <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l378) begin
-            switch_Fetcher_l362 <= 3'b100;
+          if(when_Fetcher_l381) begin
+            switch_Fetcher_l365 <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l362 <= 3'b000;
+          switch_Fetcher_l365 <= 3'b000;
         end
         default : begin
         end
@@ -5789,9 +5788,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5799,6 +5804,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5855,10 +5880,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5871,21 +5892,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5924,28 +5945,28 @@ module VexRiscv (
     if(CfuPlugin_bus_rsp_ready) begin
       CfuPlugin_bus_rsp_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
     end
-    if(when_GenCoreDefault_l367) begin
+    if(when_GenCoreDefault_l410) begin
       _zz_CsrPlugin_csrMapping_readDataInit_2 <= (_zz_CsrPlugin_csrMapping_readDataInit_2 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_1) begin
+    if(when_GenCoreDefault_l410_1) begin
       _zz_CsrPlugin_csrMapping_readDataInit_3 <= (_zz_CsrPlugin_csrMapping_readDataInit_3 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_2) begin
+    if(when_GenCoreDefault_l410_2) begin
       _zz_CsrPlugin_csrMapping_readDataInit_4 <= (_zz_CsrPlugin_csrMapping_readDataInit_4 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_3) begin
+    if(when_GenCoreDefault_l410_3) begin
       _zz_CsrPlugin_csrMapping_readDataInit_5 <= (_zz_CsrPlugin_csrMapping_readDataInit_5 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_4) begin
+    if(when_GenCoreDefault_l410_4) begin
       _zz_CsrPlugin_csrMapping_readDataInit_6 <= (_zz_CsrPlugin_csrMapping_readDataInit_6 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_5) begin
+    if(when_GenCoreDefault_l410_5) begin
       _zz_CsrPlugin_csrMapping_readDataInit_7 <= (_zz_CsrPlugin_csrMapping_readDataInit_7 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_6) begin
+    if(when_GenCoreDefault_l410_6) begin
       _zz_CsrPlugin_csrMapping_readDataInit_8 <= (_zz_CsrPlugin_csrMapping_readDataInit_8 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_7) begin
+    if(when_GenCoreDefault_l410_7) begin
       _zz_CsrPlugin_csrMapping_readDataInit_9 <= (_zz_CsrPlugin_csrMapping_readDataInit_9 + 32'h00000001);
     end
     if(when_Pipeline_l124) begin
@@ -6027,237 +6048,246 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
     if(when_Pipeline_l124_55) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_60) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_61) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_62) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_63) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_64) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_66) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_67) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1264_24) begin
+    if(when_CsrPlugin_l1277_24) begin
       execute_CsrPlugin_csr_2820 <= (decode_INSTRUCTION[31 : 20] == 12'hb04);
     end
-    if(when_CsrPlugin_l1264_25) begin
+    if(when_CsrPlugin_l1277_25) begin
       execute_CsrPlugin_csr_2821 <= (decode_INSTRUCTION[31 : 20] == 12'hb05);
     end
-    if(when_CsrPlugin_l1264_26) begin
+    if(when_CsrPlugin_l1277_26) begin
       execute_CsrPlugin_csr_2822 <= (decode_INSTRUCTION[31 : 20] == 12'hb06);
     end
-    if(when_CsrPlugin_l1264_27) begin
+    if(when_CsrPlugin_l1277_27) begin
       execute_CsrPlugin_csr_2823 <= (decode_INSTRUCTION[31 : 20] == 12'hb07);
     end
-    if(when_CsrPlugin_l1264_28) begin
+    if(when_CsrPlugin_l1277_28) begin
       execute_CsrPlugin_csr_2824 <= (decode_INSTRUCTION[31 : 20] == 12'hb08);
     end
-    if(when_CsrPlugin_l1264_29) begin
+    if(when_CsrPlugin_l1277_29) begin
       execute_CsrPlugin_csr_2825 <= (decode_INSTRUCTION[31 : 20] == 12'hb09);
     end
-    if(when_CsrPlugin_l1264_30) begin
+    if(when_CsrPlugin_l1277_30) begin
       execute_CsrPlugin_csr_2826 <= (decode_INSTRUCTION[31 : 20] == 12'hb0a);
     end
-    if(when_CsrPlugin_l1264_31) begin
+    if(when_CsrPlugin_l1277_31) begin
       execute_CsrPlugin_csr_2827 <= (decode_INSTRUCTION[31 : 20] == 12'hb0b);
     end
-    if(when_CsrPlugin_l1264_32) begin
+    if(when_CsrPlugin_l1277_32) begin
       execute_CsrPlugin_csr_2828 <= (decode_INSTRUCTION[31 : 20] == 12'hb0c);
     end
-    if(when_CsrPlugin_l1264_33) begin
+    if(when_CsrPlugin_l1277_33) begin
       execute_CsrPlugin_csr_2829 <= (decode_INSTRUCTION[31 : 20] == 12'hb0d);
     end
-    if(when_CsrPlugin_l1264_34) begin
+    if(when_CsrPlugin_l1277_34) begin
       execute_CsrPlugin_csr_2830 <= (decode_INSTRUCTION[31 : 20] == 12'hb0e);
     end
-    if(when_CsrPlugin_l1264_35) begin
+    if(when_CsrPlugin_l1277_35) begin
       execute_CsrPlugin_csr_2831 <= (decode_INSTRUCTION[31 : 20] == 12'hb0f);
     end
-    if(when_CsrPlugin_l1264_36) begin
+    if(when_CsrPlugin_l1277_36) begin
       execute_CsrPlugin_csr_2832 <= (decode_INSTRUCTION[31 : 20] == 12'hb10);
     end
-    if(when_CsrPlugin_l1264_37) begin
+    if(when_CsrPlugin_l1277_37) begin
       execute_CsrPlugin_csr_2833 <= (decode_INSTRUCTION[31 : 20] == 12'hb11);
     end
-    if(when_CsrPlugin_l1264_38) begin
+    if(when_CsrPlugin_l1277_38) begin
       execute_CsrPlugin_csr_2834 <= (decode_INSTRUCTION[31 : 20] == 12'hb12);
     end
-    if(when_CsrPlugin_l1264_39) begin
+    if(when_CsrPlugin_l1277_39) begin
       execute_CsrPlugin_csr_2835 <= (decode_INSTRUCTION[31 : 20] == 12'hb13);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6292,26 +6322,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     if(execute_CsrPlugin_csr_2820) begin
       if(execute_CsrPlugin_writeEnable) begin
         _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
@@ -6319,7 +6329,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2821) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2822) begin
@@ -6329,7 +6339,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2823) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2824) begin
@@ -6339,7 +6349,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2825) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2826) begin
@@ -6349,7 +6359,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2827) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2828) begin
@@ -6359,7 +6369,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2829) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2830) begin
@@ -6369,7 +6379,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2831) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2832) begin
@@ -6379,7 +6389,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2833) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2834) begin
@@ -6389,7 +6399,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2835) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -6407,7 +6417,7 @@ module VexRiscv (
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
     _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
-    if(when_DebugPlugin_l284) begin
+    if(when_DebugPlugin_l295) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -6430,32 +6440,32 @@ module VexRiscv (
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l256)
+        case(switch_DebugPlugin_l267)
           6'h0 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l260) begin
+              if(when_DebugPlugin_l271) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l260_1) begin
+              if(when_DebugPlugin_l271_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l261) begin
+              if(when_DebugPlugin_l272) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l261_1) begin
+              if(when_DebugPlugin_l272_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l262) begin
+              if(when_DebugPlugin_l273) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l263) begin
+              if(when_DebugPlugin_l274) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l264) begin
+              if(when_DebugPlugin_l275) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l264_1) begin
+              if(when_DebugPlugin_l275_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -6464,13 +6474,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l284) begin
-        if(when_DebugPlugin_l287) begin
+      if(when_DebugPlugin_l295) begin
+        if(when_DebugPlugin_l298) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l300) begin
+      if(when_DebugPlugin_l311) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -6504,6 +6514,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -6527,6 +6538,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [7:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -6543,6 +6556,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [20:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [20:0]   _zz_ways_0_tags_port;
@@ -6584,40 +6598,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6627,33 +6641,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [18:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [8:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -6661,18 +6675,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6684,17 +6698,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:2047];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:2047];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:2047];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6748,14 +6762,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6769,42 +6783,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 8'bxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[12 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 11'bxxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[12 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6814,7 +6828,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6824,7 +6838,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 8'bxxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[7:0];
     end
     if(loader_done) begin
@@ -6834,7 +6848,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6859,14 +6873,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6876,7 +6890,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6886,7 +6900,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[12 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[12 : 5],loader_counter_value};
     end
   end
@@ -6896,7 +6910,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6909,15 +6923,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6925,7 +6939,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6947,42 +6961,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 13] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6990,7 +7004,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -7000,27 +7014,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[8]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[8]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[8]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -7031,8 +7045,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -7040,26 +7054,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -7080,22 +7094,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -7104,8 +7118,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -7118,8 +7132,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -7134,8 +7148,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -7145,12 +7159,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -7159,11 +7173,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -7179,12 +7193,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -7192,26 +7206,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -7222,27 +7236,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -7263,28 +7277,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 9'h001);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[8] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 9'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -7295,7 +7315,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -7303,7 +7323,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -7351,11 +7371,12 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [2:0]    _zz_when_Fetcher_l401,
   input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [20:0]   _zz_ways_0_tags_port1;
   wire       [20:0]   _zz_ways_0_tags_port;
@@ -7373,7 +7394,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7419,9 +7440,9 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l398;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:2047];
-  (* ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
+  wire                when_Fetcher_l401;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:2047];
+  (* no_rw_check , ram_style = "block" *) reg [20:0] ways_0_tags [0:255];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -7491,10 +7512,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7522,7 +7543,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[20 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 13]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
@@ -7538,7 +7559,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -7608,7 +7629,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l398) begin
+    if(when_Fetcher_l401) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/soc/vexriscv/VexRiscv_SlimCfu.v
+++ b/soc/vexriscv/VexRiscv_SlimCfu.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -86,6 +42,35 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -114,6 +99,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -196,179 +183,169 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -439,10 +416,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -450,46 +427,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -499,9 +478,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -515,20 +496,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -542,42 +522,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -586,6 +566,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -598,8 +579,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -611,7 +592,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -655,6 +636,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -723,6 +705,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -765,14 +748,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -814,18 +797,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -844,7 +827,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -891,45 +873,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -983,7 +965,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1003,7 +985,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1022,11 +1004,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1043,59 +1025,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1143,22 +1125,25 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1180,7 +1165,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1190,9 +1175,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1212,80 +1197,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1293,59 +1284,60 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1364,8 +1356,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1454,7 +1446,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1468,7 +1460,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1483,7 +1475,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1495,6 +1487,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1568,172 +1562,160 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h00203050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00403050);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1757,899 +1739,882 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2693,6 +2658,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2727,6 +2694,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2747,14 +2716,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2830,10 +2798,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2844,7 +2812,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2881,10 +2849,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2906,6 +2874,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -2963,7 +2932,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2976,7 +2945,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3004,27 +2973,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3058,7 +3030,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3076,7 +3048,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3107,10 +3079,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3121,29 +3093,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3151,21 +3125,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3206,9 +3180,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3231,7 +3205,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3293,24 +3267,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3335,7 +3315,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3381,7 +3361,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3429,7 +3409,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3510,12 +3490,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3533,7 +3513,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3552,9 +3532,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3564,12 +3546,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3582,7 +3564,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3592,7 +3574,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3611,7 +3593,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3624,8 +3606,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3638,7 +3620,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3690,7 +3672,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3703,7 +3685,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3723,11 +3705,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3742,8 +3725,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3775,10 +3758,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3789,10 +3772,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3803,13 +3786,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3868,13 +3851,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3927,7 +3910,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4044,9 +4027,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4064,13 +4047,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4143,10 +4126,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4158,7 +4141,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4193,11 +4176,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4248,14 +4231,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4264,9 +4247,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4310,28 +4293,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4339,7 +4322,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4377,14 +4360,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4482,18 +4465,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4501,20 +4484,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4527,20 +4510,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4549,9 +4532,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4562,8 +4545,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4656,12 +4639,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4695,7 +4681,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4706,16 +4692,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4752,64 +4738,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4836,30 +4825,30 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4897,12 +4886,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5032,8 +5022,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5089,11 +5079,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5105,6 +5093,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5137,16 +5127,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5164,13 +5154,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5179,7 +5169,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5188,7 +5178,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5197,7 +5187,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5220,51 +5210,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5273,7 +5267,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5284,8 +5278,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5295,7 +5289,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5306,16 +5300,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5344,9 +5338,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5354,6 +5354,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5410,10 +5430,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5426,21 +5442,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5558,186 +5574,195 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5772,26 +5797,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -5822,6 +5827,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -5845,6 +5851,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5861,6 +5869,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -5902,40 +5911,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5945,33 +5954,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5979,18 +5988,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6002,17 +6011,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6066,14 +6075,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6087,42 +6096,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6132,7 +6141,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6142,7 +6151,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6152,7 +6161,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6177,14 +6186,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6194,7 +6203,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6204,7 +6213,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6214,7 +6223,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6227,15 +6236,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6243,7 +6252,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6265,42 +6274,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6308,7 +6317,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6318,27 +6327,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6349,8 +6358,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6358,26 +6367,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6398,22 +6407,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6422,8 +6431,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6436,8 +6445,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6452,8 +6461,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6463,12 +6472,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6477,11 +6486,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6497,12 +6506,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6510,26 +6519,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6540,27 +6549,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6581,28 +6590,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6613,7 +6628,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6621,7 +6636,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6672,6 +6687,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -6689,7 +6705,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6735,8 +6751,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -6806,10 +6822,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6837,7 +6853,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_SlimCfuDebug.v
+++ b/soc/vexriscv/VexRiscv_SlimCfuDebug.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -94,6 +50,35 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -122,6 +107,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -204,6 +191,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
@@ -211,174 +200,163 @@ module VexRiscv (
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [27:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -450,10 +428,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -461,46 +439,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -510,9 +490,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -528,20 +510,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -555,42 +536,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -599,6 +580,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -611,8 +593,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -668,6 +650,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -728,7 +711,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l386;
+  reg                 _zz_when_DBusCachedPlugin_l393;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -737,6 +720,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  reg                 BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -782,14 +766,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -831,18 +815,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -861,7 +845,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -908,45 +891,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [34:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -1000,7 +983,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1020,7 +1003,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1039,11 +1022,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1060,59 +1043,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1175,36 +1158,39 @@ module VexRiscv (
   reg        [31:0]   DebugPlugin_busReadDataReg;
   reg                 _zz_when_DebugPlugin_l244;
   wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l256;
-  wire                when_DebugPlugin_l260;
-  wire                when_DebugPlugin_l260_1;
-  wire                when_DebugPlugin_l261;
-  wire                when_DebugPlugin_l261_1;
-  wire                when_DebugPlugin_l262;
-  wire                when_DebugPlugin_l263;
-  wire                when_DebugPlugin_l264;
-  wire                when_DebugPlugin_l264_1;
-  wire                when_DebugPlugin_l284;
-  wire                when_DebugPlugin_l287;
-  wire                when_DebugPlugin_l300;
+  wire       [5:0]    switch_DebugPlugin_l267;
+  wire                when_DebugPlugin_l271;
+  wire                when_DebugPlugin_l271_1;
+  wire                when_DebugPlugin_l272;
+  wire                when_DebugPlugin_l272_1;
+  wire                when_DebugPlugin_l273;
+  wire                when_DebugPlugin_l274;
+  wire                when_DebugPlugin_l275;
+  wire                when_DebugPlugin_l275_1;
+  wire                when_DebugPlugin_l295;
+  wire                when_DebugPlugin_l298;
+  wire                when_DebugPlugin_l311;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l316;
+  wire                when_DebugPlugin_l331;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1226,7 +1212,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1236,9 +1222,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1258,82 +1244,88 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg                 decode_to_execute_DO_EBREAK;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_DO_EBREAK;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_57;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_61;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_62;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_63;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_64;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_65;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_67;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1341,61 +1333,62 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l362;
-  wire                when_Fetcher_l378;
-  wire                when_CsrPlugin_l1264;
+  reg        [2:0]    switch_Fetcher_l365;
+  wire                when_Fetcher_l381;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1414,8 +1407,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1504,7 +1497,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1518,7 +1511,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1533,7 +1526,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1545,6 +1538,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1617,175 +1612,164 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 32'h00100050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (((decode_INSTRUCTION & 32'h02004064) == 32'h02004020) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9} != 2'b00),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21}}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = 32'h00100040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = 32'h10103050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & 32'h02004074) == 32'h02000030));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = (|{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7)});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = {(|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10)),{(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26}}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (decode_INSTRUCTION & 32'h10203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = 32'h10000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = (decode_INSTRUCTION & 32'h00103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00100040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136}}};
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1809,901 +1793,884 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2748,6 +2715,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2782,6 +2751,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
   assign decode_IS_EBREAK = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
@@ -2804,14 +2775,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2887,10 +2857,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2901,7 +2871,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2938,10 +2908,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2963,6 +2933,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -3020,10 +2991,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -3040,7 +3011,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3068,30 +3039,33 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
+    if(when_DebugPlugin_l295) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3108,8 +3082,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3123,8 +3097,8 @@ module VexRiscv (
     if(_zz_when_1) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -3138,7 +3112,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3156,7 +3130,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3187,10 +3161,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3201,39 +3175,47 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l300) begin
+    if(when_DebugPlugin_l311) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    _zz_when_DBusCachedPlugin_l393 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l386 = 1'b1;
+      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    BranchPlugin_inDebugNoFetchFlag = 1'b0;
+    if(DebugPlugin_godmode) begin
+      BranchPlugin_inDebugNoFetchFlag = 1'b1;
     end
   end
 
@@ -3241,7 +3223,7 @@ module VexRiscv (
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3255,21 +3237,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3288,7 +3270,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l316) begin
+    if(when_DebugPlugin_l331) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3334,9 +3316,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3359,7 +3341,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3421,18 +3403,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3440,7 +3422,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3450,6 +3432,9 @@ module VexRiscv (
       default : begin
       end
     endcase
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
   end
 
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
@@ -3476,7 +3461,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3522,7 +3507,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3570,7 +3555,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3651,12 +3636,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3674,7 +3659,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3693,9 +3678,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3705,12 +3692,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3723,7 +3710,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3733,7 +3720,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3752,7 +3739,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3765,8 +3752,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3779,7 +3766,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3831,7 +3818,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3844,7 +3831,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3864,11 +3851,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1) != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2) == 32'h00100050)),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3883,8 +3871,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3916,10 +3904,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3930,10 +3918,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3944,13 +3932,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -4009,13 +3997,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -4068,7 +4056,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4185,9 +4173,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4205,13 +4193,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4284,10 +4272,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4299,7 +4287,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4334,11 +4322,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4389,14 +4377,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4405,9 +4393,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4451,28 +4439,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4480,7 +4468,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4518,14 +4506,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4623,18 +4611,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4642,20 +4630,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4668,20 +4656,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4690,9 +4678,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4703,8 +4691,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4797,13 +4785,13 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
   assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l256)
+      case(switch_DebugPlugin_l267)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
@@ -4830,7 +4818,7 @@ module VexRiscv (
   always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l256)
+      case(switch_DebugPlugin_l267)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
@@ -4843,25 +4831,28 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4895,7 +4886,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4906,16 +4897,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4952,65 +4943,68 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_64 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_67 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -5039,7 +5033,7 @@ module VexRiscv (
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -5048,31 +5042,31 @@ module VexRiscv (
     endcase
   end
 
-  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5110,12 +5104,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5245,8 +5240,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5302,11 +5297,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5318,6 +5311,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5337,7 +5332,7 @@ module VexRiscv (
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l362 <= 3'b000;
+      switch_Fetcher_l365 <= 3'b000;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
@@ -5351,16 +5346,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5378,13 +5373,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5393,7 +5388,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5402,7 +5397,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5411,7 +5406,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5434,51 +5429,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5487,7 +5486,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5498,8 +5497,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5509,7 +5508,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5520,16 +5519,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_62) begin
+      if(when_Pipeline_l124_65) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5550,25 +5549,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l362)
+      case(switch_Fetcher_l365)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l362 <= 3'b001;
+            switch_Fetcher_l365 <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l362 <= 3'b010;
+          switch_Fetcher_l365 <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l362 <= 3'b011;
+          switch_Fetcher_l365 <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l378) begin
-            switch_Fetcher_l362 <= 3'b100;
+          if(when_Fetcher_l381) begin
+            switch_Fetcher_l365 <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l362 <= 3'b000;
+          switch_Fetcher_l365 <= 3'b000;
         end
         default : begin
         end
@@ -5581,9 +5580,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5591,6 +5596,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5647,10 +5672,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5663,21 +5684,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5795,189 +5816,198 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
     if(when_Pipeline_l124_55) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_60) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_61) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_62) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_63) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_64) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_66) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_67) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6012,26 +6042,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -6047,7 +6057,7 @@ module VexRiscv (
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
     _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
-    if(when_DebugPlugin_l284) begin
+    if(when_DebugPlugin_l295) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -6070,32 +6080,32 @@ module VexRiscv (
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l256)
+        case(switch_DebugPlugin_l267)
           6'h0 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l260) begin
+              if(when_DebugPlugin_l271) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l260_1) begin
+              if(when_DebugPlugin_l271_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l261) begin
+              if(when_DebugPlugin_l272) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l261_1) begin
+              if(when_DebugPlugin_l272_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l262) begin
+              if(when_DebugPlugin_l273) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l263) begin
+              if(when_DebugPlugin_l274) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l264) begin
+              if(when_DebugPlugin_l275) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l264_1) begin
+              if(when_DebugPlugin_l275_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -6104,13 +6114,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l284) begin
-        if(when_DebugPlugin_l287) begin
+      if(when_DebugPlugin_l295) begin
+        if(when_DebugPlugin_l298) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l300) begin
+      if(when_DebugPlugin_l311) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -6144,6 +6154,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -6167,6 +6178,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -6183,6 +6196,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -6224,40 +6238,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6267,33 +6281,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -6301,18 +6315,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6324,17 +6338,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6388,14 +6402,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6409,42 +6423,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6454,7 +6468,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6464,7 +6478,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6474,7 +6488,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6499,14 +6513,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6516,7 +6530,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6526,7 +6540,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6536,7 +6550,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6549,15 +6563,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6565,7 +6579,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6587,42 +6601,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6630,7 +6644,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6640,27 +6654,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6671,8 +6685,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6680,26 +6694,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6720,22 +6734,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6744,8 +6758,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6758,8 +6772,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6774,8 +6788,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6785,12 +6799,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6799,11 +6813,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6819,12 +6833,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6832,26 +6846,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6862,27 +6876,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6903,28 +6917,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6935,7 +6955,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6943,7 +6963,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6991,11 +7011,12 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [2:0]    _zz_when_Fetcher_l401,
   input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -7013,7 +7034,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7059,9 +7080,9 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l398;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  wire                when_Fetcher_l401;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -7131,10 +7152,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7162,7 +7183,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
@@ -7178,7 +7199,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -7248,7 +7269,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l398) begin
+    if(when_Fetcher_l401) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/soc/vexriscv/VexRiscv_SlimPerfCfu.v
+++ b/soc/vexriscv/VexRiscv_SlimPerfCfu.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -86,6 +42,35 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -114,6 +99,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -196,179 +183,169 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -439,10 +416,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -450,46 +427,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -499,9 +478,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -515,20 +496,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -542,42 +522,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -586,6 +566,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -598,8 +579,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -611,7 +592,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -655,6 +636,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -723,6 +705,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -765,14 +748,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -814,18 +797,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -844,7 +827,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -891,45 +873,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -983,7 +965,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1003,7 +985,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1022,11 +1004,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1043,59 +1025,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1143,46 +1125,49 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367;
-  wire                when_GenCoreDefault_l367;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410;
+  wire                when_GenCoreDefault_l410;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_1;
-  wire                when_GenCoreDefault_l367_1;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_1;
+  wire                when_GenCoreDefault_l410_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_2;
-  wire                when_GenCoreDefault_l367_2;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_2;
+  wire                when_GenCoreDefault_l410_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_3;
-  wire                when_GenCoreDefault_l367_3;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_3;
+  wire                when_GenCoreDefault_l410_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_4;
-  wire                when_GenCoreDefault_l367_4;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_4;
+  wire                when_GenCoreDefault_l410_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_5;
-  wire                when_GenCoreDefault_l367_5;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_5;
+  wire                when_GenCoreDefault_l410_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_6;
-  wire                when_GenCoreDefault_l367_6;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_6;
+  wire                when_GenCoreDefault_l410_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_7;
-  wire                when_GenCoreDefault_l367_7;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_7;
+  wire                when_GenCoreDefault_l410_7;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1204,7 +1189,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1214,9 +1199,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1236,80 +1221,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1317,91 +1308,92 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1264_24;
+  wire                when_CsrPlugin_l1277_24;
   reg                 execute_CsrPlugin_csr_2820;
-  wire                when_CsrPlugin_l1264_25;
+  wire                when_CsrPlugin_l1277_25;
   reg                 execute_CsrPlugin_csr_2821;
-  wire                when_CsrPlugin_l1264_26;
+  wire                when_CsrPlugin_l1277_26;
   reg                 execute_CsrPlugin_csr_2822;
-  wire                when_CsrPlugin_l1264_27;
+  wire                when_CsrPlugin_l1277_27;
   reg                 execute_CsrPlugin_csr_2823;
-  wire                when_CsrPlugin_l1264_28;
+  wire                when_CsrPlugin_l1277_28;
   reg                 execute_CsrPlugin_csr_2824;
-  wire                when_CsrPlugin_l1264_29;
+  wire                when_CsrPlugin_l1277_29;
   reg                 execute_CsrPlugin_csr_2825;
-  wire                when_CsrPlugin_l1264_30;
+  wire                when_CsrPlugin_l1277_30;
   reg                 execute_CsrPlugin_csr_2826;
-  wire                when_CsrPlugin_l1264_31;
+  wire                when_CsrPlugin_l1277_31;
   reg                 execute_CsrPlugin_csr_2827;
-  wire                when_CsrPlugin_l1264_32;
+  wire                when_CsrPlugin_l1277_32;
   reg                 execute_CsrPlugin_csr_2828;
-  wire                when_CsrPlugin_l1264_33;
+  wire                when_CsrPlugin_l1277_33;
   reg                 execute_CsrPlugin_csr_2829;
-  wire                when_CsrPlugin_l1264_34;
+  wire                when_CsrPlugin_l1277_34;
   reg                 execute_CsrPlugin_csr_2830;
-  wire                when_CsrPlugin_l1264_35;
+  wire                when_CsrPlugin_l1277_35;
   reg                 execute_CsrPlugin_csr_2831;
-  wire                when_CsrPlugin_l1264_36;
+  wire                when_CsrPlugin_l1277_36;
   reg                 execute_CsrPlugin_csr_2832;
-  wire                when_CsrPlugin_l1264_37;
+  wire                when_CsrPlugin_l1277_37;
   reg                 execute_CsrPlugin_csr_2833;
-  wire                when_CsrPlugin_l1264_38;
+  wire                when_CsrPlugin_l1277_38;
   reg                 execute_CsrPlugin_csr_2834;
-  wire                when_CsrPlugin_l1264_39;
+  wire                when_CsrPlugin_l1277_39;
   reg                 execute_CsrPlugin_csr_2835;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
@@ -1428,8 +1420,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_38;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_39;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_40;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1518,7 +1510,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1532,7 +1524,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1547,7 +1539,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1559,6 +1551,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1632,172 +1626,160 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h00203050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00403050);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1821,899 +1803,882 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2757,6 +2722,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2791,6 +2758,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2811,14 +2780,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2894,10 +2862,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2908,7 +2876,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2945,10 +2913,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2970,6 +2938,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -3027,7 +2996,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -3040,7 +3009,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3068,27 +3037,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3122,7 +3094,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3140,7 +3112,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3171,10 +3143,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3185,29 +3157,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3215,21 +3189,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3270,9 +3244,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3295,7 +3269,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3357,24 +3331,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3399,7 +3379,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3445,7 +3425,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3493,7 +3473,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3574,12 +3554,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3597,7 +3577,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3616,9 +3596,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3628,12 +3610,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3646,7 +3628,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3656,7 +3638,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3675,7 +3657,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3688,8 +3670,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3702,7 +3684,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3754,7 +3736,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3767,7 +3749,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3787,11 +3769,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3806,8 +3789,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3839,10 +3822,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3853,10 +3836,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3867,13 +3850,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3932,13 +3915,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3991,7 +3974,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4108,9 +4091,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4128,13 +4111,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4207,10 +4190,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4222,7 +4205,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4257,11 +4240,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4312,14 +4295,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4328,9 +4311,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4374,28 +4357,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4403,7 +4386,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4441,14 +4424,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4610,18 +4593,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4629,20 +4612,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4655,20 +4638,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4677,9 +4660,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4690,8 +4673,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4784,12 +4767,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4823,7 +4809,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4834,24 +4820,24 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
-  assign when_GenCoreDefault_l367 = _zz_when_GenCoreDefault_l367[0];
-  assign when_GenCoreDefault_l367_1 = _zz_when_GenCoreDefault_l367_1[0];
-  assign when_GenCoreDefault_l367_2 = _zz_when_GenCoreDefault_l367_2[0];
-  assign when_GenCoreDefault_l367_3 = _zz_when_GenCoreDefault_l367_3[0];
-  assign when_GenCoreDefault_l367_4 = _zz_when_GenCoreDefault_l367_4[0];
-  assign when_GenCoreDefault_l367_5 = _zz_when_GenCoreDefault_l367_5[0];
-  assign when_GenCoreDefault_l367_6 = _zz_when_GenCoreDefault_l367_6[0];
-  assign when_GenCoreDefault_l367_7 = _zz_when_GenCoreDefault_l367_7[0];
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
+  assign when_GenCoreDefault_l410 = _zz_when_GenCoreDefault_l410[0];
+  assign when_GenCoreDefault_l410_1 = _zz_when_GenCoreDefault_l410_1[0];
+  assign when_GenCoreDefault_l410_2 = _zz_when_GenCoreDefault_l410_2[0];
+  assign when_GenCoreDefault_l410_3 = _zz_when_GenCoreDefault_l410_3[0];
+  assign when_GenCoreDefault_l410_4 = _zz_when_GenCoreDefault_l410_4[0];
+  assign when_GenCoreDefault_l410_5 = _zz_when_GenCoreDefault_l410_5[0];
+  assign when_GenCoreDefault_l410_6 = _zz_when_GenCoreDefault_l410_6[0];
+  assign when_GenCoreDefault_l410_7 = _zz_when_GenCoreDefault_l410_7[0];
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4888,64 +4874,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4972,46 +4961,46 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_28 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_29 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_30 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_31 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_32 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_33 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_34 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_35 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_36 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_37 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_38 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_39 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_28 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_29 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_30 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_31 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_32 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_33 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_34 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_35 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_36 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_37 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_38 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_39 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5049,12 +5038,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_15[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5240,8 +5230,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11) | (_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13)) | ((_zz_CsrPlugin_csrMapping_readDataInit_41 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26) | (_zz_CsrPlugin_csrMapping_readDataInit_27 | _zz_CsrPlugin_csrMapping_readDataInit_28)) | ((_zz_CsrPlugin_csrMapping_readDataInit_29 | _zz_CsrPlugin_csrMapping_readDataInit_30) | (_zz_CsrPlugin_csrMapping_readDataInit_31 | _zz_CsrPlugin_csrMapping_readDataInit_32))) | (((_zz_CsrPlugin_csrMapping_readDataInit_33 | _zz_CsrPlugin_csrMapping_readDataInit_34) | (_zz_CsrPlugin_csrMapping_readDataInit_35 | _zz_CsrPlugin_csrMapping_readDataInit_36)) | ((_zz_CsrPlugin_csrMapping_readDataInit_37 | _zz_CsrPlugin_csrMapping_readDataInit_38) | (_zz_CsrPlugin_csrMapping_readDataInit_39 | _zz_CsrPlugin_csrMapping_readDataInit_40)))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5297,11 +5287,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5313,6 +5301,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5345,16 +5335,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5372,13 +5362,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5387,7 +5377,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5396,7 +5386,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5405,7 +5395,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5428,51 +5418,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5481,7 +5475,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5492,8 +5486,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5503,7 +5497,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5514,16 +5508,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5552,9 +5546,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5562,6 +5562,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5618,10 +5638,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5634,21 +5650,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5687,28 +5703,28 @@ module VexRiscv (
     if(CfuPlugin_bus_rsp_ready) begin
       CfuPlugin_bus_rsp_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
     end
-    if(when_GenCoreDefault_l367) begin
+    if(when_GenCoreDefault_l410) begin
       _zz_CsrPlugin_csrMapping_readDataInit_2 <= (_zz_CsrPlugin_csrMapping_readDataInit_2 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_1) begin
+    if(when_GenCoreDefault_l410_1) begin
       _zz_CsrPlugin_csrMapping_readDataInit_3 <= (_zz_CsrPlugin_csrMapping_readDataInit_3 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_2) begin
+    if(when_GenCoreDefault_l410_2) begin
       _zz_CsrPlugin_csrMapping_readDataInit_4 <= (_zz_CsrPlugin_csrMapping_readDataInit_4 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_3) begin
+    if(when_GenCoreDefault_l410_3) begin
       _zz_CsrPlugin_csrMapping_readDataInit_5 <= (_zz_CsrPlugin_csrMapping_readDataInit_5 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_4) begin
+    if(when_GenCoreDefault_l410_4) begin
       _zz_CsrPlugin_csrMapping_readDataInit_6 <= (_zz_CsrPlugin_csrMapping_readDataInit_6 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_5) begin
+    if(when_GenCoreDefault_l410_5) begin
       _zz_CsrPlugin_csrMapping_readDataInit_7 <= (_zz_CsrPlugin_csrMapping_readDataInit_7 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_6) begin
+    if(when_GenCoreDefault_l410_6) begin
       _zz_CsrPlugin_csrMapping_readDataInit_8 <= (_zz_CsrPlugin_csrMapping_readDataInit_8 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_7) begin
+    if(when_GenCoreDefault_l410_7) begin
       _zz_CsrPlugin_csrMapping_readDataInit_9 <= (_zz_CsrPlugin_csrMapping_readDataInit_9 + 32'h00000001);
     end
     if(when_Pipeline_l124) begin
@@ -5790,234 +5806,243 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1264_24) begin
+    if(when_CsrPlugin_l1277_24) begin
       execute_CsrPlugin_csr_2820 <= (decode_INSTRUCTION[31 : 20] == 12'hb04);
     end
-    if(when_CsrPlugin_l1264_25) begin
+    if(when_CsrPlugin_l1277_25) begin
       execute_CsrPlugin_csr_2821 <= (decode_INSTRUCTION[31 : 20] == 12'hb05);
     end
-    if(when_CsrPlugin_l1264_26) begin
+    if(when_CsrPlugin_l1277_26) begin
       execute_CsrPlugin_csr_2822 <= (decode_INSTRUCTION[31 : 20] == 12'hb06);
     end
-    if(when_CsrPlugin_l1264_27) begin
+    if(when_CsrPlugin_l1277_27) begin
       execute_CsrPlugin_csr_2823 <= (decode_INSTRUCTION[31 : 20] == 12'hb07);
     end
-    if(when_CsrPlugin_l1264_28) begin
+    if(when_CsrPlugin_l1277_28) begin
       execute_CsrPlugin_csr_2824 <= (decode_INSTRUCTION[31 : 20] == 12'hb08);
     end
-    if(when_CsrPlugin_l1264_29) begin
+    if(when_CsrPlugin_l1277_29) begin
       execute_CsrPlugin_csr_2825 <= (decode_INSTRUCTION[31 : 20] == 12'hb09);
     end
-    if(when_CsrPlugin_l1264_30) begin
+    if(when_CsrPlugin_l1277_30) begin
       execute_CsrPlugin_csr_2826 <= (decode_INSTRUCTION[31 : 20] == 12'hb0a);
     end
-    if(when_CsrPlugin_l1264_31) begin
+    if(when_CsrPlugin_l1277_31) begin
       execute_CsrPlugin_csr_2827 <= (decode_INSTRUCTION[31 : 20] == 12'hb0b);
     end
-    if(when_CsrPlugin_l1264_32) begin
+    if(when_CsrPlugin_l1277_32) begin
       execute_CsrPlugin_csr_2828 <= (decode_INSTRUCTION[31 : 20] == 12'hb0c);
     end
-    if(when_CsrPlugin_l1264_33) begin
+    if(when_CsrPlugin_l1277_33) begin
       execute_CsrPlugin_csr_2829 <= (decode_INSTRUCTION[31 : 20] == 12'hb0d);
     end
-    if(when_CsrPlugin_l1264_34) begin
+    if(when_CsrPlugin_l1277_34) begin
       execute_CsrPlugin_csr_2830 <= (decode_INSTRUCTION[31 : 20] == 12'hb0e);
     end
-    if(when_CsrPlugin_l1264_35) begin
+    if(when_CsrPlugin_l1277_35) begin
       execute_CsrPlugin_csr_2831 <= (decode_INSTRUCTION[31 : 20] == 12'hb0f);
     end
-    if(when_CsrPlugin_l1264_36) begin
+    if(when_CsrPlugin_l1277_36) begin
       execute_CsrPlugin_csr_2832 <= (decode_INSTRUCTION[31 : 20] == 12'hb10);
     end
-    if(when_CsrPlugin_l1264_37) begin
+    if(when_CsrPlugin_l1277_37) begin
       execute_CsrPlugin_csr_2833 <= (decode_INSTRUCTION[31 : 20] == 12'hb11);
     end
-    if(when_CsrPlugin_l1264_38) begin
+    if(when_CsrPlugin_l1277_38) begin
       execute_CsrPlugin_csr_2834 <= (decode_INSTRUCTION[31 : 20] == 12'hb12);
     end
-    if(when_CsrPlugin_l1264_39) begin
+    if(when_CsrPlugin_l1277_39) begin
       execute_CsrPlugin_csr_2835 <= (decode_INSTRUCTION[31 : 20] == 12'hb13);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6052,26 +6077,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     if(execute_CsrPlugin_csr_2820) begin
       if(execute_CsrPlugin_writeEnable) begin
         _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
@@ -6079,7 +6084,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2821) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2822) begin
@@ -6089,7 +6094,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2823) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2824) begin
@@ -6099,7 +6104,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2825) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2826) begin
@@ -6109,7 +6114,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2827) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2828) begin
@@ -6119,7 +6124,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2829) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2830) begin
@@ -6129,7 +6134,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2831) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2832) begin
@@ -6139,7 +6144,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2833) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2834) begin
@@ -6149,7 +6154,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2835) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -6182,6 +6187,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -6205,6 +6211,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -6221,6 +6229,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -6262,40 +6271,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6305,33 +6314,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -6339,18 +6348,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6362,17 +6371,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6426,14 +6435,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6447,42 +6456,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6492,7 +6501,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6502,7 +6511,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6512,7 +6521,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6537,14 +6546,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6554,7 +6563,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6564,7 +6573,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6574,7 +6583,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6587,15 +6596,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6603,7 +6612,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6625,42 +6634,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6668,7 +6677,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6678,27 +6687,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6709,8 +6718,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6718,26 +6727,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6758,22 +6767,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6782,8 +6791,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6796,8 +6805,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6812,8 +6821,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6823,12 +6832,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6837,11 +6846,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6857,12 +6866,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6870,26 +6879,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6900,27 +6909,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6941,28 +6950,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6973,7 +6988,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6981,7 +6996,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -7032,6 +7047,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -7049,7 +7065,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7095,8 +7111,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -7166,10 +7182,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7197,7 +7213,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_SlimPerfCfuDebug.v
+++ b/soc/vexriscv/VexRiscv_SlimPerfCfuDebug.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 22555b464a02d8b7f8ed23cbb87c57aa9acddc90
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -94,6 +50,35 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -122,6 +107,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -204,6 +191,8 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
@@ -211,174 +200,163 @@ module VexRiscv (
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [27:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -450,10 +428,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -461,46 +439,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -510,9 +490,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -528,20 +510,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -555,42 +536,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -599,6 +580,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -611,8 +593,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -668,6 +650,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -728,7 +711,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_when_DBusCachedPlugin_l386;
+  reg                 _zz_when_DBusCachedPlugin_l393;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -737,6 +720,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  reg                 BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -782,14 +766,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -831,18 +815,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -861,7 +845,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -908,45 +891,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [34:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -1000,7 +983,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1020,7 +1003,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1039,11 +1022,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1060,59 +1043,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1175,60 +1158,63 @@ module VexRiscv (
   reg        [31:0]   DebugPlugin_busReadDataReg;
   reg                 _zz_when_DebugPlugin_l244;
   wire                when_DebugPlugin_l244;
-  wire       [5:0]    switch_DebugPlugin_l256;
-  wire                when_DebugPlugin_l260;
-  wire                when_DebugPlugin_l260_1;
-  wire                when_DebugPlugin_l261;
-  wire                when_DebugPlugin_l261_1;
-  wire                when_DebugPlugin_l262;
-  wire                when_DebugPlugin_l263;
-  wire                when_DebugPlugin_l264;
-  wire                when_DebugPlugin_l264_1;
-  wire                when_DebugPlugin_l284;
-  wire                when_DebugPlugin_l287;
-  wire                when_DebugPlugin_l300;
+  wire       [5:0]    switch_DebugPlugin_l267;
+  wire                when_DebugPlugin_l271;
+  wire                when_DebugPlugin_l271_1;
+  wire                when_DebugPlugin_l272;
+  wire                when_DebugPlugin_l272_1;
+  wire                when_DebugPlugin_l273;
+  wire                when_DebugPlugin_l274;
+  wire                when_DebugPlugin_l275;
+  wire                when_DebugPlugin_l275_1;
+  wire                when_DebugPlugin_l295;
+  wire                when_DebugPlugin_l298;
+  wire                when_DebugPlugin_l311;
   reg                 DebugPlugin_resetIt_regNext;
-  wire                when_DebugPlugin_l316;
+  wire                when_DebugPlugin_l331;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367;
-  wire                when_GenCoreDefault_l367;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410;
+  wire                when_GenCoreDefault_l410;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_1;
-  wire                when_GenCoreDefault_l367_1;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_1;
+  wire                when_GenCoreDefault_l410_1;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_2;
-  wire                when_GenCoreDefault_l367_2;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_2;
+  wire                when_GenCoreDefault_l410_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_3;
-  wire                when_GenCoreDefault_l367_3;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_3;
+  wire                when_GenCoreDefault_l410_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_4;
-  wire                when_GenCoreDefault_l367_4;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_4;
+  wire                when_GenCoreDefault_l410_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_5;
-  wire                when_GenCoreDefault_l367_5;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_5;
+  wire                when_GenCoreDefault_l410_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_6;
-  wire                when_GenCoreDefault_l367_6;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_6;
+  wire                when_GenCoreDefault_l410_6;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
-  reg        [31:0]   _zz_when_GenCoreDefault_l367_7;
-  wire                when_GenCoreDefault_l367_7;
+  reg        [31:0]   _zz_when_GenCoreDefault_l410_7;
+  wire                when_GenCoreDefault_l410_7;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1250,7 +1236,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1260,9 +1246,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1282,82 +1268,88 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg                 decode_to_execute_DO_EBREAK;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_DO_EBREAK;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_57;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_61;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_62;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_63;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_64;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_65;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_67;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1365,93 +1357,94 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  reg        [2:0]    switch_Fetcher_l362;
-  wire                when_Fetcher_l378;
-  wire                when_CsrPlugin_l1264;
+  reg        [2:0]    switch_Fetcher_l365;
+  wire                when_Fetcher_l381;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
-  wire                when_CsrPlugin_l1264_24;
+  wire                when_CsrPlugin_l1277_24;
   reg                 execute_CsrPlugin_csr_2820;
-  wire                when_CsrPlugin_l1264_25;
+  wire                when_CsrPlugin_l1277_25;
   reg                 execute_CsrPlugin_csr_2821;
-  wire                when_CsrPlugin_l1264_26;
+  wire                when_CsrPlugin_l1277_26;
   reg                 execute_CsrPlugin_csr_2822;
-  wire                when_CsrPlugin_l1264_27;
+  wire                when_CsrPlugin_l1277_27;
   reg                 execute_CsrPlugin_csr_2823;
-  wire                when_CsrPlugin_l1264_28;
+  wire                when_CsrPlugin_l1277_28;
   reg                 execute_CsrPlugin_csr_2824;
-  wire                when_CsrPlugin_l1264_29;
+  wire                when_CsrPlugin_l1277_29;
   reg                 execute_CsrPlugin_csr_2825;
-  wire                when_CsrPlugin_l1264_30;
+  wire                when_CsrPlugin_l1277_30;
   reg                 execute_CsrPlugin_csr_2826;
-  wire                when_CsrPlugin_l1264_31;
+  wire                when_CsrPlugin_l1277_31;
   reg                 execute_CsrPlugin_csr_2827;
-  wire                when_CsrPlugin_l1264_32;
+  wire                when_CsrPlugin_l1277_32;
   reg                 execute_CsrPlugin_csr_2828;
-  wire                when_CsrPlugin_l1264_33;
+  wire                when_CsrPlugin_l1277_33;
   reg                 execute_CsrPlugin_csr_2829;
-  wire                when_CsrPlugin_l1264_34;
+  wire                when_CsrPlugin_l1277_34;
   reg                 execute_CsrPlugin_csr_2830;
-  wire                when_CsrPlugin_l1264_35;
+  wire                when_CsrPlugin_l1277_35;
   reg                 execute_CsrPlugin_csr_2831;
-  wire                when_CsrPlugin_l1264_36;
+  wire                when_CsrPlugin_l1277_36;
   reg                 execute_CsrPlugin_csr_2832;
-  wire                when_CsrPlugin_l1264_37;
+  wire                when_CsrPlugin_l1277_37;
   reg                 execute_CsrPlugin_csr_2833;
-  wire                when_CsrPlugin_l1264_38;
+  wire                when_CsrPlugin_l1277_38;
   reg                 execute_CsrPlugin_csr_2834;
-  wire                when_CsrPlugin_l1264_39;
+  wire                when_CsrPlugin_l1277_39;
   reg                 execute_CsrPlugin_csr_2835;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_10;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_11;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_12;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_13;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_14;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_15;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_16;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_17;
@@ -1478,8 +1471,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_38;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_39;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_40;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1568,7 +1561,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1582,7 +1575,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1597,7 +1590,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1609,6 +1602,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1681,175 +1676,164 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 32'h00100050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (((decode_INSTRUCTION & 32'h02004064) == 32'h02004020) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9} != 2'b00),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21}}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = 32'h00100040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = 32'h10103050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & 32'h02004074) == 32'h02000030));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = (|{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7)});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = {(|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10)),{(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26}}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (decode_INSTRUCTION & 32'h10203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = 32'h10000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = (decode_INSTRUCTION & 32'h00103050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00100040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136}}};
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_168 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_167 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1873,901 +1857,884 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    ._zz_when_Fetcher_l398                    (switch_Fetcher_l362                                   ), //i
-    ._zz_io_cpu_fetch_data_regNextWhen        (IBusCachedPlugin_injectionPort_payload                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    ._zz_when_Fetcher_l401                 (switch_Fetcher_l365[2:0]                                  ), //i
+    ._zz_io_cpu_fetch_data_regNextWhen     (IBusCachedPlugin_injectionPort_payload[31:0]              ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2812,6 +2779,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2846,6 +2815,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
   assign decode_IS_EBREAK = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[32];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
@@ -2868,14 +2839,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2951,10 +2921,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2965,7 +2935,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -3002,10 +2972,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -3027,6 +2997,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -3084,10 +3055,10 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -3104,7 +3075,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3132,30 +3103,33 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
+    if(when_DebugPlugin_l295) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3172,8 +3146,8 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3187,8 +3161,8 @@ module VexRiscv (
     if(_zz_when_1) begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -3202,7 +3176,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3220,7 +3194,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3251,10 +3225,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3265,39 +3239,47 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l284) begin
-      if(when_DebugPlugin_l287) begin
+    if(when_DebugPlugin_l295) begin
+      if(when_DebugPlugin_l298) begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_DebugPlugin_l300) begin
+    if(when_DebugPlugin_l311) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
   always @(*) begin
-    _zz_when_DBusCachedPlugin_l386 = 1'b0;
+    _zz_when_DBusCachedPlugin_l393 = 1'b0;
     if(DebugPlugin_godmode) begin
-      _zz_when_DBusCachedPlugin_l386 = 1'b1;
+      _zz_when_DBusCachedPlugin_l393 = 1'b1;
+    end
+  end
+
+  always @(*) begin
+    BranchPlugin_inDebugNoFetchFlag = 1'b0;
+    if(DebugPlugin_godmode) begin
+      BranchPlugin_inDebugNoFetchFlag = 1'b1;
     end
   end
 
@@ -3305,7 +3287,7 @@ module VexRiscv (
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3319,21 +3301,21 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3352,7 +3334,7 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_allowInterrupts = 1'b1;
-    if(when_DebugPlugin_l316) begin
+    if(when_DebugPlugin_l331) begin
       CsrPlugin_allowInterrupts = 1'b0;
     end
   end
@@ -3398,9 +3380,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3423,7 +3405,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3485,18 +3467,18 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
@@ -3504,7 +3486,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @(*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3514,6 +3496,9 @@ module VexRiscv (
       default : begin
       end
     endcase
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
   end
 
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
@@ -3540,7 +3525,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3586,7 +3571,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3634,7 +3619,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3715,12 +3700,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3738,7 +3723,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3757,9 +3742,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3769,12 +3756,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (_zz_when_DBusCachedPlugin_l386 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (_zz_when_DBusCachedPlugin_l393 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3787,7 +3774,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3797,7 +3784,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3816,7 +3803,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3829,8 +3816,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3843,7 +3830,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3895,7 +3882,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3908,7 +3895,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3928,11 +3915,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1) != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2) == 32'h00100050)),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3947,8 +3935,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[34 : 34];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3980,10 +3968,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3994,10 +3982,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -4008,13 +3996,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -4073,13 +4061,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -4132,7 +4120,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4249,9 +4237,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4269,13 +4257,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4348,10 +4336,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4363,7 +4351,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4398,11 +4386,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4453,14 +4441,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4469,9 +4457,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4515,28 +4503,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4544,7 +4532,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4582,14 +4570,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4751,18 +4739,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4770,20 +4758,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4796,20 +4784,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4818,9 +4806,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4831,8 +4819,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4925,13 +4913,13 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
   assign when_DebugPlugin_l225 = (DebugPlugin_haltIt && (! DebugPlugin_isPipBusy));
   assign DebugPlugin_allowEBreak = (DebugPlugin_debugUsed && (! DebugPlugin_disableEbreak));
   always @(*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l256)
+      case(switch_DebugPlugin_l267)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
@@ -4958,7 +4946,7 @@ module VexRiscv (
   always @(*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid) begin
-      case(switch_DebugPlugin_l256)
+      case(switch_DebugPlugin_l267)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr) begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
@@ -4971,25 +4959,28 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign switch_DebugPlugin_l256 = debug_bus_cmd_payload_address[7 : 2];
-  assign when_DebugPlugin_l260 = debug_bus_cmd_payload_data[16];
-  assign when_DebugPlugin_l260_1 = debug_bus_cmd_payload_data[24];
-  assign when_DebugPlugin_l261 = debug_bus_cmd_payload_data[17];
-  assign when_DebugPlugin_l261_1 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l262 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l263 = debug_bus_cmd_payload_data[25];
-  assign when_DebugPlugin_l264 = debug_bus_cmd_payload_data[18];
-  assign when_DebugPlugin_l264_1 = debug_bus_cmd_payload_data[26];
-  assign when_DebugPlugin_l284 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign when_DebugPlugin_l287 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign when_DebugPlugin_l300 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign switch_DebugPlugin_l267 = debug_bus_cmd_payload_address[7 : 2];
+  assign when_DebugPlugin_l271 = debug_bus_cmd_payload_data[16];
+  assign when_DebugPlugin_l271_1 = debug_bus_cmd_payload_data[24];
+  assign when_DebugPlugin_l272 = debug_bus_cmd_payload_data[17];
+  assign when_DebugPlugin_l272_1 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l273 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l274 = debug_bus_cmd_payload_data[25];
+  assign when_DebugPlugin_l275 = debug_bus_cmd_payload_data[18];
+  assign when_DebugPlugin_l275_1 = debug_bus_cmd_payload_data[26];
+  assign when_DebugPlugin_l295 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign when_DebugPlugin_l298 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign when_DebugPlugin_l311 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign when_DebugPlugin_l316 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign when_DebugPlugin_l331 = (DebugPlugin_haltIt || DebugPlugin_stepIt);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -5023,7 +5014,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -5034,24 +5025,24 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
-  assign when_GenCoreDefault_l367 = _zz_when_GenCoreDefault_l367[0];
-  assign when_GenCoreDefault_l367_1 = _zz_when_GenCoreDefault_l367_1[0];
-  assign when_GenCoreDefault_l367_2 = _zz_when_GenCoreDefault_l367_2[0];
-  assign when_GenCoreDefault_l367_3 = _zz_when_GenCoreDefault_l367_3[0];
-  assign when_GenCoreDefault_l367_4 = _zz_when_GenCoreDefault_l367_4[0];
-  assign when_GenCoreDefault_l367_5 = _zz_when_GenCoreDefault_l367_5[0];
-  assign when_GenCoreDefault_l367_6 = _zz_when_GenCoreDefault_l367_6[0];
-  assign when_GenCoreDefault_l367_7 = _zz_when_GenCoreDefault_l367_7[0];
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
+  assign when_GenCoreDefault_l410 = _zz_when_GenCoreDefault_l410[0];
+  assign when_GenCoreDefault_l410_1 = _zz_when_GenCoreDefault_l410_1[0];
+  assign when_GenCoreDefault_l410_2 = _zz_when_GenCoreDefault_l410_2[0];
+  assign when_GenCoreDefault_l410_3 = _zz_when_GenCoreDefault_l410_3[0];
+  assign when_GenCoreDefault_l410_4 = _zz_when_GenCoreDefault_l410_4[0];
+  assign when_GenCoreDefault_l410_5 = _zz_when_GenCoreDefault_l410_5[0];
+  assign when_GenCoreDefault_l410_6 = _zz_when_GenCoreDefault_l410_6[0];
+  assign when_GenCoreDefault_l410_7 = _zz_when_GenCoreDefault_l410_7[0];
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -5088,65 +5079,68 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_56 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_58 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_61 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_63 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_64 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_67 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -5175,7 +5169,7 @@ module VexRiscv (
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
   always @(*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(switch_Fetcher_l362)
+    case(switch_Fetcher_l365)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -5184,47 +5178,47 @@ module VexRiscv (
     endcase
   end
 
-  assign when_Fetcher_l378 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_24 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_25 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_26 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_27 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_28 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_29 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_30 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_31 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_32 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_33 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_34 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_35 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_36 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_37 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_38 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_39 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l381 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_24 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_25 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_26 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_27 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_28 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_29 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_30 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_31 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_32 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_33 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_34 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_35 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_36 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_37 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_38 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_39 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -5262,12 +5256,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_15[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_15[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_15[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5453,8 +5448,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_10 | _zz_CsrPlugin_csrMapping_readDataInit_11) | (_zz_CsrPlugin_csrMapping_readDataInit_12 | _zz_CsrPlugin_csrMapping_readDataInit_13)) | ((_zz_CsrPlugin_csrMapping_readDataInit_41 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24)))) | ((((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_26) | (_zz_CsrPlugin_csrMapping_readDataInit_27 | _zz_CsrPlugin_csrMapping_readDataInit_28)) | ((_zz_CsrPlugin_csrMapping_readDataInit_29 | _zz_CsrPlugin_csrMapping_readDataInit_30) | (_zz_CsrPlugin_csrMapping_readDataInit_31 | _zz_CsrPlugin_csrMapping_readDataInit_32))) | (((_zz_CsrPlugin_csrMapping_readDataInit_33 | _zz_CsrPlugin_csrMapping_readDataInit_34) | (_zz_CsrPlugin_csrMapping_readDataInit_35 | _zz_CsrPlugin_csrMapping_readDataInit_36)) | ((_zz_CsrPlugin_csrMapping_readDataInit_37 | _zz_CsrPlugin_csrMapping_readDataInit_38) | (_zz_CsrPlugin_csrMapping_readDataInit_39 | _zz_CsrPlugin_csrMapping_readDataInit_40)))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5510,11 +5505,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5526,6 +5519,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5545,7 +5540,7 @@ module VexRiscv (
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      switch_Fetcher_l362 <= 3'b000;
+      switch_Fetcher_l365 <= 3'b000;
       execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
       _zz_iBusWishbone_ADR <= 3'b000;
       _zz_iBus_rsp_valid <= 1'b0;
@@ -5559,16 +5554,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5586,13 +5581,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5601,7 +5596,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5610,7 +5605,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5619,7 +5614,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5642,51 +5637,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5695,7 +5694,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5706,8 +5705,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5717,7 +5716,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5728,16 +5727,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_62) begin
+      if(when_Pipeline_l124_65) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5758,25 +5757,25 @@ module VexRiscv (
       if(when_Pipeline_l154_2) begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(switch_Fetcher_l362)
+      case(switch_Fetcher_l365)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid) begin
-            switch_Fetcher_l362 <= 3'b001;
+            switch_Fetcher_l365 <= 3'b001;
           end
         end
         3'b001 : begin
-          switch_Fetcher_l362 <= 3'b010;
+          switch_Fetcher_l365 <= 3'b010;
         end
         3'b010 : begin
-          switch_Fetcher_l362 <= 3'b011;
+          switch_Fetcher_l365 <= 3'b011;
         end
         3'b011 : begin
-          if(when_Fetcher_l378) begin
-            switch_Fetcher_l362 <= 3'b100;
+          if(when_Fetcher_l381) begin
+            switch_Fetcher_l365 <= 3'b100;
           end
         end
         3'b100 : begin
-          switch_Fetcher_l362 <= 3'b000;
+          switch_Fetcher_l365 <= 3'b000;
         end
         default : begin
         end
@@ -5789,9 +5788,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5799,6 +5804,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5855,10 +5880,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5871,21 +5892,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5924,28 +5945,28 @@ module VexRiscv (
     if(CfuPlugin_bus_rsp_ready) begin
       CfuPlugin_bus_rsp_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
     end
-    if(when_GenCoreDefault_l367) begin
+    if(when_GenCoreDefault_l410) begin
       _zz_CsrPlugin_csrMapping_readDataInit_2 <= (_zz_CsrPlugin_csrMapping_readDataInit_2 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_1) begin
+    if(when_GenCoreDefault_l410_1) begin
       _zz_CsrPlugin_csrMapping_readDataInit_3 <= (_zz_CsrPlugin_csrMapping_readDataInit_3 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_2) begin
+    if(when_GenCoreDefault_l410_2) begin
       _zz_CsrPlugin_csrMapping_readDataInit_4 <= (_zz_CsrPlugin_csrMapping_readDataInit_4 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_3) begin
+    if(when_GenCoreDefault_l410_3) begin
       _zz_CsrPlugin_csrMapping_readDataInit_5 <= (_zz_CsrPlugin_csrMapping_readDataInit_5 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_4) begin
+    if(when_GenCoreDefault_l410_4) begin
       _zz_CsrPlugin_csrMapping_readDataInit_6 <= (_zz_CsrPlugin_csrMapping_readDataInit_6 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_5) begin
+    if(when_GenCoreDefault_l410_5) begin
       _zz_CsrPlugin_csrMapping_readDataInit_7 <= (_zz_CsrPlugin_csrMapping_readDataInit_7 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_6) begin
+    if(when_GenCoreDefault_l410_6) begin
       _zz_CsrPlugin_csrMapping_readDataInit_8 <= (_zz_CsrPlugin_csrMapping_readDataInit_8 + 32'h00000001);
     end
-    if(when_GenCoreDefault_l367_7) begin
+    if(when_GenCoreDefault_l410_7) begin
       _zz_CsrPlugin_csrMapping_readDataInit_9 <= (_zz_CsrPlugin_csrMapping_readDataInit_9 + 32'h00000001);
     end
     if(when_Pipeline_l124) begin
@@ -6027,237 +6048,246 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
     if(when_Pipeline_l124_55) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_60) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_61) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_62) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_63) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_64) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_66) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_67) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(when_CsrPlugin_l1264_24) begin
+    if(when_CsrPlugin_l1277_24) begin
       execute_CsrPlugin_csr_2820 <= (decode_INSTRUCTION[31 : 20] == 12'hb04);
     end
-    if(when_CsrPlugin_l1264_25) begin
+    if(when_CsrPlugin_l1277_25) begin
       execute_CsrPlugin_csr_2821 <= (decode_INSTRUCTION[31 : 20] == 12'hb05);
     end
-    if(when_CsrPlugin_l1264_26) begin
+    if(when_CsrPlugin_l1277_26) begin
       execute_CsrPlugin_csr_2822 <= (decode_INSTRUCTION[31 : 20] == 12'hb06);
     end
-    if(when_CsrPlugin_l1264_27) begin
+    if(when_CsrPlugin_l1277_27) begin
       execute_CsrPlugin_csr_2823 <= (decode_INSTRUCTION[31 : 20] == 12'hb07);
     end
-    if(when_CsrPlugin_l1264_28) begin
+    if(when_CsrPlugin_l1277_28) begin
       execute_CsrPlugin_csr_2824 <= (decode_INSTRUCTION[31 : 20] == 12'hb08);
     end
-    if(when_CsrPlugin_l1264_29) begin
+    if(when_CsrPlugin_l1277_29) begin
       execute_CsrPlugin_csr_2825 <= (decode_INSTRUCTION[31 : 20] == 12'hb09);
     end
-    if(when_CsrPlugin_l1264_30) begin
+    if(when_CsrPlugin_l1277_30) begin
       execute_CsrPlugin_csr_2826 <= (decode_INSTRUCTION[31 : 20] == 12'hb0a);
     end
-    if(when_CsrPlugin_l1264_31) begin
+    if(when_CsrPlugin_l1277_31) begin
       execute_CsrPlugin_csr_2827 <= (decode_INSTRUCTION[31 : 20] == 12'hb0b);
     end
-    if(when_CsrPlugin_l1264_32) begin
+    if(when_CsrPlugin_l1277_32) begin
       execute_CsrPlugin_csr_2828 <= (decode_INSTRUCTION[31 : 20] == 12'hb0c);
     end
-    if(when_CsrPlugin_l1264_33) begin
+    if(when_CsrPlugin_l1277_33) begin
       execute_CsrPlugin_csr_2829 <= (decode_INSTRUCTION[31 : 20] == 12'hb0d);
     end
-    if(when_CsrPlugin_l1264_34) begin
+    if(when_CsrPlugin_l1277_34) begin
       execute_CsrPlugin_csr_2830 <= (decode_INSTRUCTION[31 : 20] == 12'hb0e);
     end
-    if(when_CsrPlugin_l1264_35) begin
+    if(when_CsrPlugin_l1277_35) begin
       execute_CsrPlugin_csr_2831 <= (decode_INSTRUCTION[31 : 20] == 12'hb0f);
     end
-    if(when_CsrPlugin_l1264_36) begin
+    if(when_CsrPlugin_l1277_36) begin
       execute_CsrPlugin_csr_2832 <= (decode_INSTRUCTION[31 : 20] == 12'hb10);
     end
-    if(when_CsrPlugin_l1264_37) begin
+    if(when_CsrPlugin_l1277_37) begin
       execute_CsrPlugin_csr_2833 <= (decode_INSTRUCTION[31 : 20] == 12'hb11);
     end
-    if(when_CsrPlugin_l1264_38) begin
+    if(when_CsrPlugin_l1277_38) begin
       execute_CsrPlugin_csr_2834 <= (decode_INSTRUCTION[31 : 20] == 12'hb12);
     end
-    if(when_CsrPlugin_l1264_39) begin
+    if(when_CsrPlugin_l1277_39) begin
       execute_CsrPlugin_csr_2835 <= (decode_INSTRUCTION[31 : 20] == 12'hb13);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -6292,26 +6322,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     if(execute_CsrPlugin_csr_2820) begin
       if(execute_CsrPlugin_writeEnable) begin
         _zz_CsrPlugin_csrMapping_readDataInit_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
@@ -6319,7 +6329,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2821) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2822) begin
@@ -6329,7 +6339,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2823) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_1 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2824) begin
@@ -6339,7 +6349,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2825) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_2 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2826) begin
@@ -6349,7 +6359,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2827) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_3 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2828) begin
@@ -6359,7 +6369,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2829) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_4 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2830) begin
@@ -6369,7 +6379,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2831) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_5 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2832) begin
@@ -6379,7 +6389,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2833) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_6 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     if(execute_CsrPlugin_csr_2834) begin
@@ -6389,7 +6399,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_2835) begin
       if(execute_CsrPlugin_writeEnable) begin
-        _zz_when_GenCoreDefault_l367_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        _zz_when_GenCoreDefault_l410_7 <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
@@ -6407,7 +6417,7 @@ module VexRiscv (
       DebugPlugin_busReadDataReg <= _zz_decode_RS2_2;
     end
     _zz_when_DebugPlugin_l244 <= debug_bus_cmd_payload_address[2];
-    if(when_DebugPlugin_l284) begin
+    if(when_DebugPlugin_l295) begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -6430,32 +6440,32 @@ module VexRiscv (
         DebugPlugin_debugUsed <= 1'b1;
       end
       if(debug_bus_cmd_valid) begin
-        case(switch_DebugPlugin_l256)
+        case(switch_DebugPlugin_l267)
           6'h0 : begin
             if(debug_bus_cmd_payload_wr) begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(when_DebugPlugin_l260) begin
+              if(when_DebugPlugin_l271) begin
                 DebugPlugin_resetIt <= 1'b1;
               end
-              if(when_DebugPlugin_l260_1) begin
+              if(when_DebugPlugin_l271_1) begin
                 DebugPlugin_resetIt <= 1'b0;
               end
-              if(when_DebugPlugin_l261) begin
+              if(when_DebugPlugin_l272) begin
                 DebugPlugin_haltIt <= 1'b1;
               end
-              if(when_DebugPlugin_l261_1) begin
+              if(when_DebugPlugin_l272_1) begin
                 DebugPlugin_haltIt <= 1'b0;
               end
-              if(when_DebugPlugin_l262) begin
+              if(when_DebugPlugin_l273) begin
                 DebugPlugin_haltedByBreak <= 1'b0;
               end
-              if(when_DebugPlugin_l263) begin
+              if(when_DebugPlugin_l274) begin
                 DebugPlugin_godmode <= 1'b0;
               end
-              if(when_DebugPlugin_l264) begin
+              if(when_DebugPlugin_l275) begin
                 DebugPlugin_disableEbreak <= 1'b1;
               end
-              if(when_DebugPlugin_l264_1) begin
+              if(when_DebugPlugin_l275_1) begin
                 DebugPlugin_disableEbreak <= 1'b0;
               end
             end
@@ -6464,13 +6474,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_DebugPlugin_l284) begin
-        if(when_DebugPlugin_l287) begin
+      if(when_DebugPlugin_l295) begin
+        if(when_DebugPlugin_l298) begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(when_DebugPlugin_l300) begin
+      if(when_DebugPlugin_l311) begin
         if(decode_arbitration_isValid) begin
           DebugPlugin_haltIt <= 1'b1;
         end
@@ -6504,6 +6514,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -6527,6 +6538,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -6543,6 +6556,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -6584,40 +6598,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6627,33 +6641,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -6661,18 +6675,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6684,17 +6698,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6748,14 +6762,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6769,42 +6783,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6814,7 +6828,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6824,7 +6838,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6834,7 +6848,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6859,14 +6873,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6876,7 +6890,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6886,7 +6900,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6896,7 +6910,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6909,15 +6923,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6925,7 +6939,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6947,42 +6961,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6990,7 +7004,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -7000,27 +7014,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -7031,8 +7045,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -7040,26 +7054,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -7080,22 +7094,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -7104,8 +7118,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -7118,8 +7132,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -7134,8 +7148,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -7145,12 +7159,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -7159,11 +7173,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -7179,12 +7193,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -7192,26 +7206,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -7222,27 +7236,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -7263,28 +7277,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -7295,7 +7315,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -7303,7 +7323,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -7351,11 +7371,12 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_when_Fetcher_l398,
+  input      [2:0]    _zz_when_Fetcher_l401,
   input      [31:0]   _zz_io_cpu_fetch_data_regNextWhen,
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -7373,7 +7394,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -7419,9 +7440,9 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  wire                when_Fetcher_l398;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  wire                when_Fetcher_l401;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -7491,10 +7512,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7522,7 +7543,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;
@@ -7538,7 +7559,7 @@ module InstructionCache (
   assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
   assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
   assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  assign when_Fetcher_l398 = (_zz_when_Fetcher_l398 != 3'b000);
+  assign when_Fetcher_l401 = (_zz_when_Fetcher_l401 != 3'b000);
   always @(posedge clk) begin
     if(reset) begin
       lineLoader_valid <= 1'b0;
@@ -7608,7 +7629,7 @@ module InstructionCache (
     if(when_InstructionCache_l459_2) begin
       decodeStage_hit_error <= fetchStage_hit_error;
     end
-    if(when_Fetcher_l398) begin
+    if(when_Fetcher_l401) begin
       io_cpu_fetch_data_regNextWhen <= _zz_io_cpu_fetch_data_regNextWhen;
     end
   end

--- a/soc/vexriscv/VexRiscv_SlimoptCfu.v
+++ b/soc/vexriscv/VexRiscv_SlimoptCfu.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 5faa2eb26b83d3074089934f54d9526fa856225c
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -86,6 +42,35 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -114,6 +99,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg                 streamFifoLowLatency_1_io_pop_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
@@ -201,179 +188,169 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -444,10 +421,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -455,46 +432,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -504,9 +483,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -520,20 +501,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -547,42 +527,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -591,6 +571,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -603,8 +584,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -616,7 +597,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -660,6 +641,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -728,6 +710,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -770,14 +753,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -819,18 +802,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -849,7 +832,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -896,45 +878,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -988,7 +970,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1008,7 +990,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1027,11 +1009,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1048,59 +1030,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1148,17 +1130,20 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1180,7 +1165,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1190,9 +1175,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1212,80 +1197,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1293,59 +1284,60 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1364,8 +1356,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1454,7 +1446,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1468,7 +1460,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1483,7 +1475,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1495,6 +1487,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1568,172 +1562,160 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h00203050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00403050);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1757,911 +1739,894 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   StreamFifoLowLatency streamFifoLowLatency_1 (
-    .io_push_valid                (CfuPlugin_bus_rsp_valid                          ), //i
-    .io_push_ready                (streamFifoLowLatency_1_io_push_ready             ), //o
-    .io_push_payload_outputs_0    (CfuPlugin_bus_rsp_payload_outputs_0              ), //i
-    .io_pop_valid                 (streamFifoLowLatency_1_io_pop_valid              ), //o
-    .io_pop_ready                 (streamFifoLowLatency_1_io_pop_ready              ), //i
-    .io_pop_payload_outputs_0     (streamFifoLowLatency_1_io_pop_payload_outputs_0  ), //o
-    .io_flush                     (1'b0                                             ), //i
-    .io_occupancy                 (streamFifoLowLatency_1_io_occupancy              ), //o
-    .clk                          (clk                                              ), //i
-    .reset                        (reset                                            )  //i
+    .io_push_valid             (CfuPlugin_bus_rsp_valid                              ), //i
+    .io_push_ready             (streamFifoLowLatency_1_io_push_ready                 ), //o
+    .io_push_payload_outputs_0 (CfuPlugin_bus_rsp_payload_outputs_0[31:0]            ), //i
+    .io_pop_valid              (streamFifoLowLatency_1_io_pop_valid                  ), //o
+    .io_pop_ready              (streamFifoLowLatency_1_io_pop_ready                  ), //i
+    .io_pop_payload_outputs_0  (streamFifoLowLatency_1_io_pop_payload_outputs_0[31:0]), //o
+    .io_flush                  (1'b0                                                 ), //i
+    .io_occupancy              (streamFifoLowLatency_1_io_occupancy[1:0]             ), //o
+    .clk                       (clk                                                  ), //i
+    .reset                     (reset                                                )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2705,6 +2670,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2739,6 +2706,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2759,14 +2728,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2842,10 +2810,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2893,10 +2861,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2918,6 +2886,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -2975,7 +2944,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2988,7 +2957,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3016,27 +2985,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3070,7 +3042,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3088,7 +3060,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3119,10 +3091,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3133,29 +3105,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3163,21 +3137,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3218,9 +3192,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3243,7 +3217,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3305,24 +3279,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3347,7 +3327,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3393,7 +3373,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3441,7 +3421,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3522,12 +3502,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3545,7 +3525,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3564,9 +3544,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3576,12 +3558,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3594,7 +3576,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3604,7 +3586,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3623,7 +3605,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3636,8 +3618,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3650,7 +3632,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3702,7 +3684,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3715,7 +3697,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3735,11 +3717,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3754,8 +3737,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3787,10 +3770,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3801,10 +3784,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3815,13 +3798,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3880,13 +3863,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3939,7 +3922,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4056,9 +4039,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4076,13 +4059,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4155,10 +4138,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4170,7 +4153,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4205,11 +4188,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4260,14 +4243,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4276,9 +4259,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4322,28 +4305,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4351,7 +4334,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4389,14 +4372,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4494,18 +4477,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4513,20 +4496,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4539,20 +4522,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4561,9 +4544,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4574,8 +4557,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4668,12 +4651,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4707,7 +4693,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4725,7 +4711,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CfuPlugin_l208 = (! streamFifoLowLatency_1_io_pop_valid);
+  assign when_CfuPlugin_l237 = (! streamFifoLowLatency_1_io_pop_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4762,64 +4748,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4846,30 +4835,30 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4907,12 +4896,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5042,8 +5032,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5099,11 +5089,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5115,6 +5103,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5146,16 +5136,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5173,13 +5163,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5188,7 +5178,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5197,7 +5187,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5206,7 +5196,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5229,51 +5219,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5282,7 +5276,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5293,8 +5287,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5304,7 +5298,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5315,10 +5309,10 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5347,9 +5341,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5357,6 +5357,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5413,10 +5433,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5429,21 +5445,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5558,186 +5574,195 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5772,26 +5797,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -5811,8 +5816,9 @@ module StreamFifoLowLatency (
   input               clk,
   input               reset
 );
+
   wire       [31:0]   _zz_ram_port0;
-  wire       [31:0]   _zz_io_pop_payload_outputs_0;
+  wire       [31:0]   _zz_readed_outputs_0;
   reg                 _zz_1;
   reg                 pushPtr_willIncrement;
   reg                 pushPtr_willClear;
@@ -5832,12 +5838,13 @@ module StreamFifoLowLatency (
   wire                full;
   wire                pushing;
   wire                popping;
-  wire                when_Stream_l995;
-  wire                when_Stream_l1008;
+  wire       [31:0]   readed_outputs_0;
+  wire                when_Stream_l1178;
+  wire                when_Stream_l1191;
   wire       [0:0]    ptrDif;
   (* ram_style = "distributed" *) reg [31:0] ram [0:1];
 
-  assign _zz_io_pop_payload_outputs_0 = _zz_ram_port0[31 : 0];
+  assign _zz_readed_outputs_0 = _zz_ram_port0[31 : 0];
   assign _zz_ram_port0 = ram[popPtr_value];
   always @(posedge clk) begin
     if(_zz_1) begin
@@ -5904,9 +5911,10 @@ module StreamFifoLowLatency (
   assign pushing = (io_push_valid && io_push_ready);
   assign popping = (io_pop_valid && io_pop_ready);
   assign io_push_ready = (! full);
-  assign when_Stream_l995 = (! empty);
+  assign readed_outputs_0 = _zz_readed_outputs_0[31 : 0];
+  assign when_Stream_l1178 = (! empty);
   always @(*) begin
-    if(when_Stream_l995) begin
+    if(when_Stream_l1178) begin
       io_pop_valid = 1'b1;
     end else begin
       io_pop_valid = io_push_valid;
@@ -5914,14 +5922,14 @@ module StreamFifoLowLatency (
   end
 
   always @(*) begin
-    if(when_Stream_l995) begin
-      io_pop_payload_outputs_0 = _zz_io_pop_payload_outputs_0[31 : 0];
+    if(when_Stream_l1178) begin
+      io_pop_payload_outputs_0 = readed_outputs_0;
     end else begin
       io_pop_payload_outputs_0 = io_push_payload_outputs_0;
     end
   end
 
-  assign when_Stream_l1008 = (pushing != popping);
+  assign when_Stream_l1191 = (pushing != popping);
   assign ptrDif = (pushPtr_value - popPtr_value);
   assign io_occupancy = {(risingOccupancy && ptrMatch),ptrDif};
   always @(posedge clk) begin
@@ -5932,7 +5940,7 @@ module StreamFifoLowLatency (
     end else begin
       pushPtr_value <= pushPtr_valueNext;
       popPtr_value <= popPtr_valueNext;
-      if(when_Stream_l1008) begin
+      if(when_Stream_l1191) begin
         risingOccupancy <= pushing;
       end
       if(io_flush) begin
@@ -5967,6 +5975,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -5990,6 +5999,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [6:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -6006,6 +6017,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -6047,40 +6059,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -6090,33 +6102,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [7:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -6124,18 +6136,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6147,17 +6159,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6211,14 +6223,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6232,42 +6244,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 7'bxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6277,7 +6289,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6287,7 +6299,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 7'bxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
     end
     if(loader_done) begin
@@ -6297,7 +6309,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6322,14 +6334,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6339,7 +6351,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6349,7 +6361,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
     end
   end
@@ -6359,7 +6371,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6372,15 +6384,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6388,7 +6400,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6410,42 +6422,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6453,7 +6465,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6463,27 +6475,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[7]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6494,8 +6506,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6503,26 +6515,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6543,22 +6555,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6567,8 +6579,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
@@ -6581,8 +6593,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6597,8 +6609,8 @@ module DataCache (
     io_mem_cmd_payload_size = {1'd0, stageB_request_size};
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 3'b101;
           end
         end
@@ -6608,12 +6620,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6622,11 +6634,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6642,12 +6654,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6655,26 +6667,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6685,27 +6697,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6726,28 +6738,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[7] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 8'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6758,7 +6776,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6766,7 +6784,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6817,6 +6835,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [21:0]   _zz_ways_0_tags_port1;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -6834,7 +6853,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6880,8 +6899,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -6951,10 +6970,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6982,7 +7001,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;

--- a/soc/vexriscv/VexRiscv_dbpl8Cfu.v
+++ b/soc/vexriscv/VexRiscv_dbpl8Cfu.v
@@ -1,52 +1,8 @@
-// Generator : SpinalHDL v1.6.0    git head : 73c8d8e2b86b45646e9d0b2e729291f2b65e6be3
+// Generator : SpinalHDL v1.7.1    git head : 0444bb76ab1d6e19f0ec46bc03c4769776deb7d5
 // Component : VexRiscv
-// Git hash  : 7921edb2cddbc3b048c85c03554d299ad3111bec
+// Git hash  : aed4e3554313dff5ba711d4fd1ce9a97a9f53b82
 
-
-`define Input2Kind_binary_sequential_type [0:0]
-`define Input2Kind_binary_sequential_RS 1'b0
-`define Input2Kind_binary_sequential_IMM_I 1'b1
-
-`define EnvCtrlEnum_binary_sequential_type [1:0]
-`define EnvCtrlEnum_binary_sequential_NONE 2'b00
-`define EnvCtrlEnum_binary_sequential_XRET 2'b01
-`define EnvCtrlEnum_binary_sequential_WFI 2'b10
-`define EnvCtrlEnum_binary_sequential_ECALL 2'b11
-
-`define BranchCtrlEnum_binary_sequential_type [1:0]
-`define BranchCtrlEnum_binary_sequential_INC 2'b00
-`define BranchCtrlEnum_binary_sequential_B 2'b01
-`define BranchCtrlEnum_binary_sequential_JAL 2'b10
-`define BranchCtrlEnum_binary_sequential_JALR 2'b11
-
-`define ShiftCtrlEnum_binary_sequential_type [1:0]
-`define ShiftCtrlEnum_binary_sequential_DISABLE_1 2'b00
-`define ShiftCtrlEnum_binary_sequential_SLL_1 2'b01
-`define ShiftCtrlEnum_binary_sequential_SRL_1 2'b10
-`define ShiftCtrlEnum_binary_sequential_SRA_1 2'b11
-
-`define AluBitwiseCtrlEnum_binary_sequential_type [1:0]
-`define AluBitwiseCtrlEnum_binary_sequential_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_binary_sequential_OR_1 2'b01
-`define AluBitwiseCtrlEnum_binary_sequential_AND_1 2'b10
-
-`define Src2CtrlEnum_binary_sequential_type [1:0]
-`define Src2CtrlEnum_binary_sequential_RS 2'b00
-`define Src2CtrlEnum_binary_sequential_IMI 2'b01
-`define Src2CtrlEnum_binary_sequential_IMS 2'b10
-`define Src2CtrlEnum_binary_sequential_PC 2'b11
-
-`define AluCtrlEnum_binary_sequential_type [1:0]
-`define AluCtrlEnum_binary_sequential_ADD_SUB 2'b00
-`define AluCtrlEnum_binary_sequential_SLT_SLTU 2'b01
-`define AluCtrlEnum_binary_sequential_BITWISE 2'b10
-
-`define Src1CtrlEnum_binary_sequential_type [1:0]
-`define Src1CtrlEnum_binary_sequential_RS 2'b00
-`define Src1CtrlEnum_binary_sequential_IMU 2'b01
-`define Src1CtrlEnum_binary_sequential_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_binary_sequential_URS1 2'b11
-
+`timescale 1ns/1ps
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -86,6 +42,35 @@ module VexRiscv (
   input               clk,
   input               reset
 );
+  localparam ShiftCtrlEnum_DISABLE_1 = 2'd0;
+  localparam ShiftCtrlEnum_SLL_1 = 2'd1;
+  localparam ShiftCtrlEnum_SRL_1 = 2'd2;
+  localparam ShiftCtrlEnum_SRA_1 = 2'd3;
+  localparam Input2Kind_RS = 1'd0;
+  localparam Input2Kind_IMM_I = 1'd1;
+  localparam EnvCtrlEnum_NONE = 2'd0;
+  localparam EnvCtrlEnum_XRET = 2'd1;
+  localparam EnvCtrlEnum_WFI = 2'd2;
+  localparam EnvCtrlEnum_ECALL = 2'd3;
+  localparam BranchCtrlEnum_INC = 2'd0;
+  localparam BranchCtrlEnum_B = 2'd1;
+  localparam BranchCtrlEnum_JAL = 2'd2;
+  localparam BranchCtrlEnum_JALR = 2'd3;
+  localparam AluBitwiseCtrlEnum_XOR_1 = 2'd0;
+  localparam AluBitwiseCtrlEnum_OR_1 = 2'd1;
+  localparam AluBitwiseCtrlEnum_AND_1 = 2'd2;
+  localparam Src2CtrlEnum_RS = 2'd0;
+  localparam Src2CtrlEnum_IMI = 2'd1;
+  localparam Src2CtrlEnum_IMS = 2'd2;
+  localparam Src2CtrlEnum_PC = 2'd3;
+  localparam AluCtrlEnum_ADD_SUB = 2'd0;
+  localparam AluCtrlEnum_SLT_SLTU = 2'd1;
+  localparam AluCtrlEnum_BITWISE = 2'd2;
+  localparam Src1CtrlEnum_RS = 2'd0;
+  localparam Src1CtrlEnum_IMU = 2'd1;
+  localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
+  localparam Src1CtrlEnum_URS1 = 2'd3;
+
   wire                IBusCachedPlugin_cache_io_flush;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
@@ -114,6 +99,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_writeBack_fence_PI;
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
+  wire                dataCache_1_io_cpu_flush_payload_singleLine;
+  wire       [8:0]    dataCache_1_io_cpu_flush_payload_lineId;
   wire                dataCache_1_io_mem_cmd_ready;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
   reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
@@ -196,179 +183,169 @@ module VexRiscv (
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
   wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
+  wire       [28:0]   _zz_io_cpu_flush_payload_lineId;
+  wire       [28:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted;
   wire       [1:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_1;
   reg        [7:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_2;
   wire       [0:0]    _zz_writeBack_DBusCachedPlugin_rspShifted_3;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6;
-  wire       [26:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
+  wire       [25:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
-  wire       [22:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
+  wire       [21:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33;
-  wire       [19:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
+  wire       [18:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41;
+  wire       [15:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45;
-  wire       [16:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53;
+  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63;
+  wire       [12:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
-  wire       [13:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98;
   wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100;
-  wire       [10:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106;
+  wire       [9:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116;
+  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
-  wire       [7:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
+  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
-  wire       [5:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
-  wire       [2:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137;
+  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139;
+  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
-  wire       [3:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
-  wire                _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147;
+  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149;
+  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150;
+  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152;
   wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153;
   wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162;
-  wire       [1:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164;
-  wire       [31:0]   _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165;
-  wire       [0:0]    _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -439,10 +416,10 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
-  wire       `Input2Kind_binary_sequential_type decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [0:0]    decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1;
   wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -450,46 +427,48 @@ module VexRiscv (
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_to_writeBack_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_to_memory_ENV_CTRL_1;
-  wire       `EnvCtrlEnum_binary_sequential_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_to_execute_ENV_CTRL_1;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_memory_to_writeBack_ENV_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_ENV_CTRL_1;
+  wire       [1:0]    decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ENV_CTRL_1;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_to_execute_BRANCH_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_to_memory_SHIFT_CTRL_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_to_execute_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_BRANCH_CTRL_1;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_to_memory_SHIFT_CTRL_1;
+  wire       [1:0]    decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SHIFT_CTRL_1;
+  wire       [1:0]    decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
+  wire                execute_HAS_SIDE_EFFECT;
+  wire                decode_HAS_SIDE_EFFECT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `Src2CtrlEnum_binary_sequential_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_to_execute_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_to_execute_SRC1_CTRL_1;
+  wire       [1:0]    decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC2_CTRL_1;
+  wire       [1:0]    decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_ALU_CTRL_1;
+  wire       [1:0]    decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL;
+  wire       [1:0]    _zz_decode_to_execute_SRC1_CTRL_1;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
@@ -499,9 +478,11 @@ module VexRiscv (
   reg                 _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg                 _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   wire                memory_CfuPlugin_CFU_IN_FLIGHT;
-  wire       `Input2Kind_binary_sequential_type execute_CfuPlugin_CFU_INPUT_2_KIND;
-  wire       `Input2Kind_binary_sequential_type _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       [0:0]    _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                execute_CfuPlugin_CFU_ENABLE;
+  wire                writeBack_HAS_SIDE_EFFECT;
+  wire                memory_HAS_SIDE_EFFECT;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -515,20 +496,19 @@ module VexRiscv (
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
-  wire       `EnvCtrlEnum_binary_sequential_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_writeBack_ENV_CTRL;
+  wire       [1:0]    memory_ENV_CTRL;
+  wire       [1:0]    _zz_memory_ENV_CTRL;
+  wire       [1:0]    execute_ENV_CTRL;
+  wire       [1:0]    _zz_execute_ENV_CTRL;
+  wire       [1:0]    writeBack_ENV_CTRL;
+  wire       [1:0]    _zz_writeBack_ENV_CTRL;
   wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
-  wire       `BranchCtrlEnum_binary_sequential_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_execute_BRANCH_CTRL;
+  wire       [1:0]    execute_BRANCH_CTRL;
+  wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   reg        [31:0]   _zz_decode_RS2;
@@ -542,42 +522,42 @@ module VexRiscv (
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
   reg        [31:0]   _zz_decode_RS2_1;
-  wire       `ShiftCtrlEnum_binary_sequential_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_execute_SHIFT_CTRL;
+  wire       [1:0]    memory_SHIFT_CTRL;
+  wire       [1:0]    _zz_memory_SHIFT_CTRL;
+  wire       [1:0]    execute_SHIFT_CTRL;
+  wire       [1:0]    _zz_execute_SHIFT_CTRL;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
   wire       [31:0]   _zz_execute_SRC2;
-  wire       `Src2CtrlEnum_binary_sequential_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_execute_SRC2_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_execute_SRC1_CTRL;
+  wire       [1:0]    execute_SRC2_CTRL;
+  wire       [1:0]    _zz_execute_SRC2_CTRL;
+  wire       [1:0]    execute_SRC1_CTRL;
+  wire       [1:0]    _zz_execute_SRC1_CTRL;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
-  wire       `AluCtrlEnum_binary_sequential_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_execute_ALU_CTRL;
+  wire       [1:0]    execute_ALU_CTRL;
+  wire       [1:0]    _zz_execute_ALU_CTRL;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    execute_ALU_BITWISE_CTRL;
+  wire       [1:0]    _zz_execute_ALU_BITWISE_CTRL;
   wire       [31:0]   _zz_lastStageRegFileWrite_payload_address;
   wire                _zz_lastStageRegFileWrite_valid;
   reg                 _zz_1;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_1;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_1;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_1;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_1;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_1;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_1;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  wire       [1:0]    _zz_decode_ENV_CTRL_1;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_1;
+  wire       [1:0]    _zz_decode_ALU_CTRL_1;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_1;
   reg        [31:0]   _zz_decode_RS2_2;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_MEMORY_STORE_DATA_RF;
@@ -586,6 +566,7 @@ module VexRiscv (
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_FORCE_CONSTISTENCY;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -598,8 +579,8 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_3;
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
-  wire       `BranchCtrlEnum_binary_sequential_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_1;
+  wire       [1:0]    decode_BRANCH_CTRL;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   wire       [31:0]   decode_INSTRUCTION;
   reg        [31:0]   _zz_execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   _zz_decode_to_execute_FORMAL_PC_NEXT;
@@ -611,7 +592,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  wire                decode_arbitration_isValid;
+  reg                 decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -655,6 +636,7 @@ module VexRiscv (
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
   reg                 IBusCachedPlugin_fetcherHalt;
+  wire                IBusCachedPlugin_forceNoDecodeCond;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
   (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
@@ -723,6 +705,7 @@ module VexRiscv (
   reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
+  wire                BranchPlugin_inDebugNoFetchFlag;
   wire       [31:0]   CsrPlugin_csrMapping_readDataSignal;
   wire       [31:0]   CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   CsrPlugin_csrMapping_writeDataSignal;
@@ -765,14 +748,14 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
   reg                 IBusCachedPlugin_fetchPc_booted;
   reg                 IBusCachedPlugin_fetchPc_inc;
-  wire                when_Fetcher_l131;
+  wire                when_Fetcher_l134;
   wire                IBusCachedPlugin_fetchPc_output_fire_1;
-  wire                when_Fetcher_l131_1;
+  wire                when_Fetcher_l134_1;
   reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
   wire                IBusCachedPlugin_fetchPc_redo_valid;
   wire       [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
   reg                 IBusCachedPlugin_fetchPc_flushed;
-  wire                when_Fetcher_l158;
+  wire                when_Fetcher_l161;
   reg                 IBusCachedPlugin_iBusRsp_redoFetch;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
   wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
@@ -814,18 +797,18 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                when_Fetcher_l240;
-  wire                when_Fetcher_l320;
+  wire                when_Fetcher_l243;
+  wire                when_Fetcher_l323;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  wire                when_Fetcher_l329;
+  wire                when_Fetcher_l332;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  wire                when_Fetcher_l329_1;
+  wire                when_Fetcher_l332_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  wire                when_Fetcher_l329_2;
+  wire                when_Fetcher_l332_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  wire                when_Fetcher_l329_3;
+  wire                when_Fetcher_l332_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                when_Fetcher_l329_4;
+  wire                when_Fetcher_l332_4;
   wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
   wire                _zz_2;
@@ -844,7 +827,6 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_IBusCachedPlugin_rspCounter;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -891,45 +873,45 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [1:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l342;
-  wire       [31:0]   _zz_DBusCachedPlugin_rspCounter;
+  wire                when_Stream_l368;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
-  wire                when_DBusCachedPlugin_l303;
+  wire                when_DBusCachedPlugin_l308;
   wire       [1:0]    execute_DBusCachedPlugin_size;
   reg        [31:0]   _zz_execute_MEMORY_STORE_DATA_RF;
   wire                dataCache_1_io_cpu_flush_isStall;
-  wire                when_DBusCachedPlugin_l343;
-  wire                when_DBusCachedPlugin_l359;
-  wire                when_DBusCachedPlugin_l386;
-  wire                when_DBusCachedPlugin_l438;
-  wire                when_DBusCachedPlugin_l458;
+  wire                when_DBusCachedPlugin_l350;
+  wire                when_DBusCachedPlugin_l366;
+  wire                when_DBusCachedPlugin_l393;
+  wire                when_DBusCachedPlugin_l446;
+  wire                when_DBusCachedPlugin_l466;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_0;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_1;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_2;
   wire       [7:0]    writeBack_DBusCachedPlugin_rspSplits_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
   wire       [31:0]   writeBack_DBusCachedPlugin_rspRf;
-  wire       [1:0]    switch_Misc_l200;
+  wire       [1:0]    switch_Misc_l210;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_1;
   wire                _zz_writeBack_DBusCachedPlugin_rspFormated_2;
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire                when_DBusCachedPlugin_l484;
+  wire                when_DBusCachedPlugin_l492;
   wire       [33:0]   _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6;
   wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7;
-  wire       `Src1CtrlEnum_binary_sequential_type _zz_decode_SRC1_CTRL_2;
-  wire       `AluCtrlEnum_binary_sequential_type _zz_decode_ALU_CTRL_2;
-  wire       `Src2CtrlEnum_binary_sequential_type _zz_decode_SRC2_CTRL_2;
-  wire       `AluBitwiseCtrlEnum_binary_sequential_type _zz_decode_ALU_BITWISE_CTRL_2;
-  wire       `ShiftCtrlEnum_binary_sequential_type _zz_decode_SHIFT_CTRL_2;
-  wire       `BranchCtrlEnum_binary_sequential_type _zz_decode_BRANCH_CTRL_2;
-  wire       `EnvCtrlEnum_binary_sequential_type _zz_decode_ENV_CTRL_2;
-  wire       `Input2Kind_binary_sequential_type _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire                _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  wire       [1:0]    _zz_decode_SRC1_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_CTRL_2;
+  wire       [1:0]    _zz_decode_SRC2_CTRL_2;
+  wire       [1:0]    _zz_decode_ALU_BITWISE_CTRL_2;
+  wire       [1:0]    _zz_decode_SHIFT_CTRL_2;
+  wire       [1:0]    _zz_decode_BRANCH_CTRL_2;
+  wire       [1:0]    _zz_decode_ENV_CTRL_2;
+  wire       [0:0]    _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   wire                when_RegFilePlugin_l63;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
@@ -983,7 +965,7 @@ module VexRiscv (
   wire                when_HazardSimplePlugin_l108;
   wire                when_HazardSimplePlugin_l113;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    switch_Misc_l200_1;
+  wire       [2:0]    switch_Misc_l210_1;
   reg                 _zz_execute_BRANCH_COND_RESULT;
   reg                 _zz_execute_BRANCH_COND_RESULT_1;
   wire                _zz_execute_BranchPlugin_missAlignedTarget;
@@ -1003,7 +985,7 @@ module VexRiscv (
   wire                _zz_execute_BranchPlugin_branch_src2_4;
   reg        [18:0]   _zz_execute_BranchPlugin_branch_src2_5;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  wire                when_BranchPlugin_l296;
+  wire                when_BranchPlugin_l302;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -1022,11 +1004,11 @@ module VexRiscv (
   reg                 CsrPlugin_mcause_interrupt;
   reg        [3:0]    CsrPlugin_mcause_exceptionCode;
   reg        [31:0]   CsrPlugin_mtval;
-  reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_when_CsrPlugin_l952;
-  wire                _zz_when_CsrPlugin_l952_1;
-  wire                _zz_when_CsrPlugin_l952_2;
+  reg        [63:0]   CsrPlugin_mcycle;
+  reg        [63:0]   CsrPlugin_minstret;
+  wire                _zz_when_CsrPlugin_l965;
+  wire                _zz_when_CsrPlugin_l965_1;
+  wire                _zz_when_CsrPlugin_l965_2;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1043,59 +1025,59 @@ module VexRiscv (
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_2;
   wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_3;
-  wire                when_CsrPlugin_l909;
-  wire                when_CsrPlugin_l909_1;
-  wire                when_CsrPlugin_l909_2;
-  wire                when_CsrPlugin_l909_3;
   wire                when_CsrPlugin_l922;
+  wire                when_CsrPlugin_l922_1;
+  wire                when_CsrPlugin_l922_2;
+  wire                when_CsrPlugin_l922_3;
+  wire                when_CsrPlugin_l935;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
-  wire                when_CsrPlugin_l946;
-  wire                when_CsrPlugin_l952;
-  wire                when_CsrPlugin_l952_1;
-  wire                when_CsrPlugin_l952_2;
+  wire                when_CsrPlugin_l959;
+  wire                when_CsrPlugin_l965;
+  wire                when_CsrPlugin_l965_1;
+  wire                when_CsrPlugin_l965_2;
   wire                CsrPlugin_exception;
   reg                 CsrPlugin_lastStageWasWfi;
   reg                 CsrPlugin_pipelineLiberator_pcValids_0;
   reg                 CsrPlugin_pipelineLiberator_pcValids_1;
   reg                 CsrPlugin_pipelineLiberator_pcValids_2;
   wire                CsrPlugin_pipelineLiberator_active;
-  wire                when_CsrPlugin_l980;
-  wire                when_CsrPlugin_l980_1;
-  wire                when_CsrPlugin_l980_2;
-  wire                when_CsrPlugin_l985;
+  wire                when_CsrPlugin_l993;
+  wire                when_CsrPlugin_l993_1;
+  wire                when_CsrPlugin_l993_2;
+  wire                when_CsrPlugin_l998;
   reg                 CsrPlugin_pipelineLiberator_done;
-  wire                when_CsrPlugin_l991;
+  wire                when_CsrPlugin_l1004;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
   reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
   reg        [29:0]   CsrPlugin_xtvec_base;
-  wire                when_CsrPlugin_l1019;
-  wire                when_CsrPlugin_l1064;
-  wire       [1:0]    switch_CsrPlugin_l1068;
+  wire                when_CsrPlugin_l1032;
+  wire                when_CsrPlugin_l1077;
+  wire       [1:0]    switch_CsrPlugin_l1081;
   reg                 execute_CsrPlugin_wfiWake;
-  wire                when_CsrPlugin_l1108;
-  wire                when_CsrPlugin_l1110;
-  wire                when_CsrPlugin_l1116;
+  wire                when_CsrPlugin_l1121;
+  wire                when_CsrPlugin_l1123;
+  wire                when_CsrPlugin_l1129;
   wire                execute_CsrPlugin_blockedBySideEffects;
   reg                 execute_CsrPlugin_illegalAccess;
   reg                 execute_CsrPlugin_illegalInstruction;
-  wire                when_CsrPlugin_l1129;
-  wire                when_CsrPlugin_l1136;
-  wire                when_CsrPlugin_l1137;
-  wire                when_CsrPlugin_l1144;
+  wire                when_CsrPlugin_l1142;
+  wire                when_CsrPlugin_l1149;
+  wire                when_CsrPlugin_l1150;
+  wire                when_CsrPlugin_l1157;
   reg                 execute_CsrPlugin_writeInstruction;
   reg                 execute_CsrPlugin_readInstruction;
   wire                execute_CsrPlugin_writeEnable;
   wire                execute_CsrPlugin_readEnable;
   wire       [31:0]   execute_CsrPlugin_readToWriteData;
-  wire                switch_Misc_l200_2;
+  wire                switch_Misc_l210_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_writeDataSignal;
-  wire                when_CsrPlugin_l1176;
-  wire                when_CsrPlugin_l1180;
+  wire                when_CsrPlugin_l1189;
+  wire                when_CsrPlugin_l1193;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg                 execute_MulPlugin_aSigned;
   reg                 execute_MulPlugin_bSigned;
@@ -1143,22 +1125,25 @@ module VexRiscv (
   reg        [31:0]   externalInterruptArray_regNext;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_1;
+  wire                execute_CfuPlugin_hazard;
+  wire                execute_CfuPlugin_scheduleWish;
   wire                execute_CfuPlugin_schedule;
+  wire                when_CfuPlugin_l194;
   reg                 execute_CfuPlugin_hold;
   reg                 execute_CfuPlugin_fired;
   wire                CfuPlugin_bus_cmd_fire;
-  wire                when_CfuPlugin_l171;
-  wire                when_CfuPlugin_l175;
+  wire                when_CfuPlugin_l197;
+  wire                when_CfuPlugin_l201;
   wire       [9:0]    execute_CfuPlugin_functionsIds_0;
   wire                _zz_CfuPlugin_bus_cmd_payload_inputs_1;
   reg        [23:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_1;
   reg        [31:0]   _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
-  wire                CfuPlugin_bus_rsp_rsp_valid;
-  reg                 CfuPlugin_bus_rsp_rsp_ready;
-  wire       [31:0]   CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
   reg                 CfuPlugin_bus_rsp_rValid;
   reg        [31:0]   CfuPlugin_bus_rsp_rData_outputs_0;
-  wire                when_CfuPlugin_l208;
+  wire                when_CfuPlugin_l237;
   wire                when_Pipeline_l124;
   reg        [31:0]   decode_to_execute_PC;
   wire                when_Pipeline_l124_1;
@@ -1180,7 +1165,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_9;
   reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   wire                when_Pipeline_l124_10;
-  reg        `Src1CtrlEnum_binary_sequential_type decode_to_execute_SRC1_CTRL;
+  reg        [1:0]    decode_to_execute_SRC1_CTRL;
   wire                when_Pipeline_l124_11;
   reg                 decode_to_execute_SRC_USE_SUB_LESS;
   wire                when_Pipeline_l124_12;
@@ -1190,9 +1175,9 @@ module VexRiscv (
   wire                when_Pipeline_l124_14;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
   wire                when_Pipeline_l124_15;
-  reg        `AluCtrlEnum_binary_sequential_type decode_to_execute_ALU_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_CTRL;
   wire                when_Pipeline_l124_16;
-  reg        `Src2CtrlEnum_binary_sequential_type decode_to_execute_SRC2_CTRL;
+  reg        [1:0]    decode_to_execute_SRC2_CTRL;
   wire                when_Pipeline_l124_17;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   wire                when_Pipeline_l124_18;
@@ -1212,80 +1197,86 @@ module VexRiscv (
   wire                when_Pipeline_l124_25;
   reg                 memory_to_writeBack_MEMORY_WR;
   wire                when_Pipeline_l124_26;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_27;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 execute_to_memory_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_28;
-  reg        `AluBitwiseCtrlEnum_binary_sequential_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg                 memory_to_writeBack_HAS_SIDE_EFFECT;
   wire                when_Pipeline_l124_29;
-  reg        `ShiftCtrlEnum_binary_sequential_type decode_to_execute_SHIFT_CTRL;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
   wire                when_Pipeline_l124_30;
-  reg        `ShiftCtrlEnum_binary_sequential_type execute_to_memory_SHIFT_CTRL;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   wire                when_Pipeline_l124_31;
-  reg        `BranchCtrlEnum_binary_sequential_type decode_to_execute_BRANCH_CTRL;
+  reg        [1:0]    decode_to_execute_ALU_BITWISE_CTRL;
   wire                when_Pipeline_l124_32;
-  reg                 decode_to_execute_IS_CSR;
+  reg        [1:0]    decode_to_execute_SHIFT_CTRL;
   wire                when_Pipeline_l124_33;
-  reg        `EnvCtrlEnum_binary_sequential_type decode_to_execute_ENV_CTRL;
+  reg        [1:0]    execute_to_memory_SHIFT_CTRL;
   wire                when_Pipeline_l124_34;
-  reg        `EnvCtrlEnum_binary_sequential_type execute_to_memory_ENV_CTRL;
+  reg        [1:0]    decode_to_execute_BRANCH_CTRL;
   wire                when_Pipeline_l124_35;
-  reg        `EnvCtrlEnum_binary_sequential_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   wire                when_Pipeline_l124_36;
-  reg                 decode_to_execute_IS_MUL;
+  reg        [1:0]    decode_to_execute_ENV_CTRL;
   wire                when_Pipeline_l124_37;
-  reg                 execute_to_memory_IS_MUL;
+  reg        [1:0]    execute_to_memory_ENV_CTRL;
   wire                when_Pipeline_l124_38;
-  reg                 memory_to_writeBack_IS_MUL;
+  reg        [1:0]    memory_to_writeBack_ENV_CTRL;
   wire                when_Pipeline_l124_39;
-  reg                 decode_to_execute_IS_DIV;
+  reg                 decode_to_execute_IS_MUL;
   wire                when_Pipeline_l124_40;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 execute_to_memory_IS_MUL;
   wire                when_Pipeline_l124_41;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 memory_to_writeBack_IS_MUL;
   wire                when_Pipeline_l124_42;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
   wire                when_Pipeline_l124_43;
-  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg                 execute_to_memory_IS_DIV;
   wire                when_Pipeline_l124_44;
-  reg        `Input2Kind_binary_sequential_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   wire                when_Pipeline_l124_45;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   wire                when_Pipeline_l124_46;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
   wire                when_Pipeline_l124_47;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg        [0:0]    decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   wire                when_Pipeline_l124_48;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_RS1;
   wire                when_Pipeline_l124_49;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg        [31:0]   decode_to_execute_RS2;
   wire                when_Pipeline_l124_50;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   wire                when_Pipeline_l124_52;
-  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
   wire                when_Pipeline_l124_54;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_55;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   memory_to_writeBack_MEMORY_STORE_DATA_RF;
   wire                when_Pipeline_l124_56;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_57;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   wire                when_Pipeline_l124_58;
-  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
   wire                when_Pipeline_l124_59;
-  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   wire                when_Pipeline_l124_60;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   wire                when_Pipeline_l124_61;
-  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HL;
   wire                when_Pipeline_l124_62;
-  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  reg        [33:0]   execute_to_memory_MUL_HH;
   wire                when_Pipeline_l124_63;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  wire                when_Pipeline_l124_64;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_65;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                when_Pipeline_l124_66;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
   wire                when_Pipeline_l151;
   wire                when_Pipeline_l154;
@@ -1293,59 +1284,60 @@ module VexRiscv (
   wire                when_Pipeline_l154_1;
   wire                when_Pipeline_l151_2;
   wire                when_Pipeline_l154_2;
-  wire                when_CsrPlugin_l1264;
+  wire                when_CsrPlugin_l1277;
   reg                 execute_CsrPlugin_csr_3264;
-  wire                when_CsrPlugin_l1264_1;
+  wire                when_CsrPlugin_l1277_1;
   reg                 execute_CsrPlugin_csr_3857;
-  wire                when_CsrPlugin_l1264_2;
+  wire                when_CsrPlugin_l1277_2;
   reg                 execute_CsrPlugin_csr_3858;
-  wire                when_CsrPlugin_l1264_3;
+  wire                when_CsrPlugin_l1277_3;
   reg                 execute_CsrPlugin_csr_3859;
-  wire                when_CsrPlugin_l1264_4;
+  wire                when_CsrPlugin_l1277_4;
   reg                 execute_CsrPlugin_csr_3860;
-  wire                when_CsrPlugin_l1264_5;
+  wire                when_CsrPlugin_l1277_5;
   reg                 execute_CsrPlugin_csr_769;
-  wire                when_CsrPlugin_l1264_6;
+  wire                when_CsrPlugin_l1277_6;
   reg                 execute_CsrPlugin_csr_768;
-  wire                when_CsrPlugin_l1264_7;
+  wire                when_CsrPlugin_l1277_7;
   reg                 execute_CsrPlugin_csr_836;
-  wire                when_CsrPlugin_l1264_8;
+  wire                when_CsrPlugin_l1277_8;
   reg                 execute_CsrPlugin_csr_772;
-  wire                when_CsrPlugin_l1264_9;
+  wire                when_CsrPlugin_l1277_9;
   reg                 execute_CsrPlugin_csr_773;
-  wire                when_CsrPlugin_l1264_10;
+  wire                when_CsrPlugin_l1277_10;
   reg                 execute_CsrPlugin_csr_833;
-  wire                when_CsrPlugin_l1264_11;
+  wire                when_CsrPlugin_l1277_11;
   reg                 execute_CsrPlugin_csr_832;
-  wire                when_CsrPlugin_l1264_12;
+  wire                when_CsrPlugin_l1277_12;
   reg                 execute_CsrPlugin_csr_834;
-  wire                when_CsrPlugin_l1264_13;
+  wire                when_CsrPlugin_l1277_13;
   reg                 execute_CsrPlugin_csr_835;
-  wire                when_CsrPlugin_l1264_14;
+  wire                when_CsrPlugin_l1277_14;
   reg                 execute_CsrPlugin_csr_2816;
-  wire                when_CsrPlugin_l1264_15;
+  wire                when_CsrPlugin_l1277_15;
   reg                 execute_CsrPlugin_csr_2944;
-  wire                when_CsrPlugin_l1264_16;
+  wire                when_CsrPlugin_l1277_16;
   reg                 execute_CsrPlugin_csr_2818;
-  wire                when_CsrPlugin_l1264_17;
+  wire                when_CsrPlugin_l1277_17;
   reg                 execute_CsrPlugin_csr_2946;
-  wire                when_CsrPlugin_l1264_18;
+  wire                when_CsrPlugin_l1277_18;
   reg                 execute_CsrPlugin_csr_3072;
-  wire                when_CsrPlugin_l1264_19;
+  wire                when_CsrPlugin_l1277_19;
   reg                 execute_CsrPlugin_csr_3200;
-  wire                when_CsrPlugin_l1264_20;
+  wire                when_CsrPlugin_l1277_20;
   reg                 execute_CsrPlugin_csr_3074;
-  wire                when_CsrPlugin_l1264_21;
+  wire                when_CsrPlugin_l1277_21;
   reg                 execute_CsrPlugin_csr_3202;
-  wire                when_CsrPlugin_l1264_22;
+  wire                when_CsrPlugin_l1277_22;
   reg                 execute_CsrPlugin_csr_3008;
-  wire                when_CsrPlugin_l1264_23;
+  wire                when_CsrPlugin_l1277_23;
   reg                 execute_CsrPlugin_csr_4032;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_2;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_3;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_4;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_5;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_6;
+  wire       [1:0]    switch_CsrPlugin_l723;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_7;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_8;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_9;
@@ -1364,8 +1356,8 @@ module VexRiscv (
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_22;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_23;
   reg        [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire                when_CsrPlugin_l1297;
-  wire                when_CsrPlugin_l1302;
+  wire                when_CsrPlugin_l1310;
+  wire                when_CsrPlugin_l1315;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
   reg                 _zz_iBus_rsp_valid;
@@ -1454,7 +1446,7 @@ module VexRiscv (
   reg [71:0] _zz_decode_SHIFT_CTRL_2_string;
   reg [31:0] _zz_decode_BRANCH_CTRL_2_string;
   reg [39:0] _zz_decode_ENV_CTRL_2_string;
-  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string;
+  reg [39:0] _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1468,7 +1460,7 @@ module VexRiscv (
   reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
-  (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
+  (* no_rw_check , ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
   assign _zz_when = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
   assign _zz_when_1 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
@@ -1483,7 +1475,7 @@ module VexRiscv (
   assign _zz_memory_MUL_LOW_7 = {{2{_zz_memory_MUL_LOW_8[49]}}, _zz_memory_MUL_LOW_8};
   assign _zz_execute_SHIFT_RIGHT_1 = ($signed(_zz_execute_SHIFT_RIGHT_2) >>> execute_FullBarrelShifterPlugin_amplitude);
   assign _zz_execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT_1[31 : 0];
-  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
   assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
@@ -1495,6 +1487,8 @@ module VexRiscv (
   assign _zz__zz_6_1 = {{_zz_5,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
   assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
+  assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code_1 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
   assign _zz__zz_execute_REGFILE_WRITE_DATA = execute_SRC_LESS;
@@ -1568,172 +1562,160 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[31];
   assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h02000030) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19}}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h02004074;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2 = (|((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3) == 32'h00000050));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7 = {(|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10}),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23}}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_3 = 32'h00203050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_5 = (decode_INSTRUCTION & 32'h00403050);
   assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_6 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00001050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = 32'h00002050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h00005010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = 32'h00005020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31) == 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40) != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = 32'h00007034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h02007054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00001000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = 32'h00002000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48) == 32'h00004004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = ({_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00005000;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = 32'h00004054;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57) == 32'h00002040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79}} != 6'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90} != 5'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126}}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = 32'h00000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = 32'h00000064;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = 32'h00002040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = 32'h00001040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75) == 32'h00000008);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = 6'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = 32'h00000050;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = (decode_INSTRUCTION & 32'h00400040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = 32'h00000008;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = 32'h00000040;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 != 1'b0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = 32'h00004020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85) == 32'h00000010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h00002030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98) == 32'h00002020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00000020);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = 32'h00001010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129) == 32'h00004010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139} != 4'b0000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = 32'h00000030;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h02000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = 32'h02002060;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h02003020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = 32'h00000010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00000020;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = 32'h00004014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = 32'h00002010;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146) == 32'h0);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153}} != 3'b000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_155 = ({_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158} != 2'b00);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_159 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163),(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166)};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = 32'h00000044;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = 32'h0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = 32'h00000058;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152) == 32'h00002010);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h40000030);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_156 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157) == 32'h00000004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_158 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_160 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_163 = 2'b00;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_164 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165) == 32'h00001004);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_166 = 1'b0;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00002014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h40000034;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_157 = 32'h00000014;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_161 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_162 = 32'h00000004;
-  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_165 = 32'h00005054;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_8 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9) == 32'h00001050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_10 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11) == 32'h00002050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_12 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_15 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_18 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_23 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_9 = 32'h00001050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_11 = 32'h00002050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_13 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_14 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_16 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_17 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_19 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20) == 32'h00005010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_21 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22) == 32'h00005020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_24 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_29 = (|(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31));
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_32 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_34 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_20 = 32'h00007034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_22 = 32'h02007064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_25 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_26 = 32'h40001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_27 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_28 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_30 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_31 = 32'h00000024;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_33 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_35 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_37 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_40 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_42 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_36 = 32'h00003000;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_38 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_39 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_41 = ((decode_INSTRUCTION & 32'h00004054) == 32'h00004004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_43 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_48 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_61 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_64 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_44 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_46 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_49 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50) == 32'h00002040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_51 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_54 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_62 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_65 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_80 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_93 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_107 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_45 = 32'h00000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_47 = 32'h00000064;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_50 = 32'h00002040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_52 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_53 = 32'h00001040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_55 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_57 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_60 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_63 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_66 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67) == 32'h00000008);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_68 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_71 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_81 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_82 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_94 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_108 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_113 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_117 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_56 = 32'h00000050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_58 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_59 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_67 = 32'h00000008;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_69 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_70 = 32'h00000040;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_72 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_75 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_83 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_85 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_88 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_95 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_98 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_109 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_110 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_114 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_118 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_121 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_125 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_73 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_74 = 32'h00004020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_76 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77) == 32'h00000010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_78 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_84 = 32'h00002030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_86 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_87 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_89 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90) == 32'h00002020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_91 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92) == 32'h00000020);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_96 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_97 = 32'h00001010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_99 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_101 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_104 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_111 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_112 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_115 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_119 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120) == 32'h00004010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_122 = (_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_126 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_135 = (|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_138 = {_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_77 = 32'h00000030;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_79 = 32'h02000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_90 = 32'h02002060;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_92 = 32'h02003020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_100 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_102 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_103 = 32'h00000010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_105 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_106 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_116 = 32'h00000020;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_120 = 32'h00004014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_123 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_124 = 32'h00002010;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_127 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_129 = {_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133}}};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_136 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137) == 32'h0);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_139 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143}});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_145 = (|{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148});
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_149 = {(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150),(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153)};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_128 = 32'h00000044;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_130 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_131 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132) == 32'h00001000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_133 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134) == 32'h00004000);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_137 = 32'h00000058;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_140 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_141 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142) == 32'h00002010);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_143 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144) == 32'h40000030);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_146 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147) == 32'h00000004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_148 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_150 = {(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 == _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152),_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3};
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_153 = ((decode_INSTRUCTION & _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154) == 32'h00001004);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_132 = 32'h00005004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_134 = 32'h00004050;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_142 = 32'h00002014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_144 = 32'h40000034;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_147 = 32'h00000014;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_151 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_152 = 32'h00000004;
+  assign _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_154 = 32'h00005054;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[7];
@@ -1757,899 +1739,882 @@ module VexRiscv (
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (IBusCachedPlugin_cache_io_flush                       ), //i
-    .io_cpu_prefetch_isValid                  (IBusCachedPlugin_cache_io_cpu_prefetch_isValid        ), //i
-    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt         ), //o
-    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload       ), //i
-    .io_cpu_fetch_isValid                     (IBusCachedPlugin_cache_io_cpu_fetch_isValid           ), //i
-    .io_cpu_fetch_isStuck                     (IBusCachedPlugin_cache_io_cpu_fetch_isStuck           ), //i
-    .io_cpu_fetch_isRemoved                   (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved         ), //i
-    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload       ), //i
-    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data              ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress           ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                ), //i
-    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                  ), //i
-    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                 ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute              ), //i
-    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                 ), //i
-    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                 ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation         ), //i
-    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress   ), //o
-    .io_cpu_decode_isValid                    (IBusCachedPlugin_cache_io_cpu_decode_isValid          ), //i
-    .io_cpu_decode_isStuck                    (IBusCachedPlugin_cache_io_cpu_decode_isStuck          ), //i
-    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload       ), //i
-    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //o
-    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data             ), //o
-    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss        ), //o
-    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error            ), //o
-    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling     ), //o
-    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException     ), //o
-    .io_cpu_decode_isUser                     (IBusCachedPlugin_cache_io_cpu_decode_isUser           ), //i
-    .io_cpu_fill_valid                        (IBusCachedPlugin_cache_io_cpu_fill_valid              ), //i
-    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress  ), //i
-    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid               ), //o
-    .io_mem_cmd_ready                         (iBus_cmd_ready                                        ), //i
-    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address     ), //o
-    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size        ), //o
-    .io_mem_rsp_valid                         (iBus_rsp_valid                                        ), //i
-    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data                                 ), //i
-    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                ), //i
-    .clk                                      (clk                                                   ), //i
-    .reset                                    (reset                                                 )  //i
+    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
+    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
+    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
+    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
+    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
+    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
+    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
+    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
+    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
+    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
+    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
+    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
+    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
+    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
+    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
+    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
+    .io_cpu_decode_pc                      (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]     ), //i
+    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
+    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
+    .io_cpu_decode_cacheMiss               (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss            ), //o
+    .io_cpu_decode_error                   (IBusCachedPlugin_cache_io_cpu_decode_error                ), //o
+    .io_cpu_decode_mmuRefilling            (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling         ), //o
+    .io_cpu_decode_mmuException            (IBusCachedPlugin_cache_io_cpu_decode_mmuException         ), //o
+    .io_cpu_decode_isUser                  (IBusCachedPlugin_cache_io_cpu_decode_isUser               ), //i
+    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
+    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //i
+    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
+    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
+    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
+    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
+    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
+    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
+    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
+    .clk                                   (clk                                                       ), //i
+    .reset                                 (reset                                                     )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (dataCache_1_io_cpu_execute_isValid             ), //i
-    .io_cpu_execute_address                    (dataCache_1_io_cpu_execute_address             ), //i
-    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt              ), //o
-    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                              ), //i
-    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size                  ), //i
-    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY              ), //i
-    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling           ), //o
-    .io_cpu_memory_isValid                     (dataCache_1_io_cpu_memory_isValid              ), //i
-    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                     ), //i
-    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite              ), //o
-    .io_cpu_memory_address                     (dataCache_1_io_cpu_memory_address              ), //i
-    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress    ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess    ), //i
-    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging           ), //i
-    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead          ), //i
-    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite         ), //i
-    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute       ), //i
-    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception          ), //i
-    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling          ), //i
-    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation  ), //i
-    .io_cpu_writeBack_isValid                  (dataCache_1_io_cpu_writeBack_isValid           ), //i
-    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                  ), //i
-    .io_cpu_writeBack_isUser                   (dataCache_1_io_cpu_writeBack_isUser            ), //i
-    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt            ), //o
-    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite           ), //o
-    .io_cpu_writeBack_storeData                (dataCache_1_io_cpu_writeBack_storeData         ), //i
-    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data              ), //o
-    .io_cpu_writeBack_address                  (dataCache_1_io_cpu_writeBack_address           ), //i
-    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException      ), //o
-    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess   ), //o
-    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError       ), //o
-    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData    ), //o
-    .io_cpu_writeBack_fence_SW                 (dataCache_1_io_cpu_writeBack_fence_SW          ), //i
-    .io_cpu_writeBack_fence_SR                 (dataCache_1_io_cpu_writeBack_fence_SR          ), //i
-    .io_cpu_writeBack_fence_SO                 (dataCache_1_io_cpu_writeBack_fence_SO          ), //i
-    .io_cpu_writeBack_fence_SI                 (dataCache_1_io_cpu_writeBack_fence_SI          ), //i
-    .io_cpu_writeBack_fence_PW                 (dataCache_1_io_cpu_writeBack_fence_PW          ), //i
-    .io_cpu_writeBack_fence_PR                 (dataCache_1_io_cpu_writeBack_fence_PR          ), //i
-    .io_cpu_writeBack_fence_PO                 (dataCache_1_io_cpu_writeBack_fence_PO          ), //i
-    .io_cpu_writeBack_fence_PI                 (dataCache_1_io_cpu_writeBack_fence_PI          ), //i
-    .io_cpu_writeBack_fence_FM                 (dataCache_1_io_cpu_writeBack_fence_FM          ), //i
-    .io_cpu_writeBack_exclusiveOk              (dataCache_1_io_cpu_writeBack_exclusiveOk       ), //o
-    .io_cpu_redo                               (dataCache_1_io_cpu_redo                        ), //o
-    .io_cpu_flush_valid                        (dataCache_1_io_cpu_flush_valid                 ), //i
-    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                 ), //o
-    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                          (dataCache_1_io_mem_cmd_ready                   ), //i
-    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr              ), //o
-    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached        ), //o
-    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address         ), //o
-    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data            ), //o
-    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask            ), //o
-    .io_mem_cmd_payload_size                   (dataCache_1_io_mem_cmd_payload_size            ), //o
-    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last            ), //o
-    .io_mem_rsp_valid                          (dBus_rsp_valid                                 ), //i
-    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                          ), //i
-    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data                          ), //i
-    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                         ), //i
-    .clk                                       (clk                                            ), //i
-    .reset                                     (reset                                          )  //i
+    .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
+    .io_cpu_execute_address                 (dataCache_1_io_cpu_execute_address[31:0]         ), //i
+    .io_cpu_execute_haltIt                  (dataCache_1_io_cpu_execute_haltIt                ), //o
+    .io_cpu_execute_args_wr                 (execute_MEMORY_WR                                ), //i
+    .io_cpu_execute_args_size               (execute_DBusCachedPlugin_size[1:0]               ), //i
+    .io_cpu_execute_args_totalyConsistent   (execute_MEMORY_FORCE_CONSTISTENCY                ), //i
+    .io_cpu_execute_refilling               (dataCache_1_io_cpu_execute_refilling             ), //o
+    .io_cpu_memory_isValid                  (dataCache_1_io_cpu_memory_isValid                ), //i
+    .io_cpu_memory_isStuck                  (memory_arbitration_isStuck                       ), //i
+    .io_cpu_memory_isWrite                  (dataCache_1_io_cpu_memory_isWrite                ), //o
+    .io_cpu_memory_address                  (dataCache_1_io_cpu_memory_address[31:0]          ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress   (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]), //i
+    .io_cpu_memory_mmuRsp_isIoAccess        (dataCache_1_io_cpu_memory_mmuRsp_isIoAccess      ), //i
+    .io_cpu_memory_mmuRsp_isPaging          (DBusCachedPlugin_mmuBus_rsp_isPaging             ), //i
+    .io_cpu_memory_mmuRsp_allowRead         (DBusCachedPlugin_mmuBus_rsp_allowRead            ), //i
+    .io_cpu_memory_mmuRsp_allowWrite        (DBusCachedPlugin_mmuBus_rsp_allowWrite           ), //i
+    .io_cpu_memory_mmuRsp_allowExecute      (DBusCachedPlugin_mmuBus_rsp_allowExecute         ), //i
+    .io_cpu_memory_mmuRsp_exception         (DBusCachedPlugin_mmuBus_rsp_exception            ), //i
+    .io_cpu_memory_mmuRsp_refilling         (DBusCachedPlugin_mmuBus_rsp_refilling            ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation (DBusCachedPlugin_mmuBus_rsp_bypassTranslation    ), //i
+    .io_cpu_writeBack_isValid               (dataCache_1_io_cpu_writeBack_isValid             ), //i
+    .io_cpu_writeBack_isStuck               (writeBack_arbitration_isStuck                    ), //i
+    .io_cpu_writeBack_isFiring              (writeBack_arbitration_isFiring                   ), //i
+    .io_cpu_writeBack_isUser                (dataCache_1_io_cpu_writeBack_isUser              ), //i
+    .io_cpu_writeBack_haltIt                (dataCache_1_io_cpu_writeBack_haltIt              ), //o
+    .io_cpu_writeBack_isWrite               (dataCache_1_io_cpu_writeBack_isWrite             ), //o
+    .io_cpu_writeBack_storeData             (dataCache_1_io_cpu_writeBack_storeData[31:0]     ), //i
+    .io_cpu_writeBack_data                  (dataCache_1_io_cpu_writeBack_data[31:0]          ), //o
+    .io_cpu_writeBack_address               (dataCache_1_io_cpu_writeBack_address[31:0]       ), //i
+    .io_cpu_writeBack_mmuException          (dataCache_1_io_cpu_writeBack_mmuException        ), //o
+    .io_cpu_writeBack_unalignedAccess       (dataCache_1_io_cpu_writeBack_unalignedAccess     ), //o
+    .io_cpu_writeBack_accessError           (dataCache_1_io_cpu_writeBack_accessError         ), //o
+    .io_cpu_writeBack_keepMemRspData        (dataCache_1_io_cpu_writeBack_keepMemRspData      ), //o
+    .io_cpu_writeBack_fence_SW              (dataCache_1_io_cpu_writeBack_fence_SW            ), //i
+    .io_cpu_writeBack_fence_SR              (dataCache_1_io_cpu_writeBack_fence_SR            ), //i
+    .io_cpu_writeBack_fence_SO              (dataCache_1_io_cpu_writeBack_fence_SO            ), //i
+    .io_cpu_writeBack_fence_SI              (dataCache_1_io_cpu_writeBack_fence_SI            ), //i
+    .io_cpu_writeBack_fence_PW              (dataCache_1_io_cpu_writeBack_fence_PW            ), //i
+    .io_cpu_writeBack_fence_PR              (dataCache_1_io_cpu_writeBack_fence_PR            ), //i
+    .io_cpu_writeBack_fence_PO              (dataCache_1_io_cpu_writeBack_fence_PO            ), //i
+    .io_cpu_writeBack_fence_PI              (dataCache_1_io_cpu_writeBack_fence_PI            ), //i
+    .io_cpu_writeBack_fence_FM              (dataCache_1_io_cpu_writeBack_fence_FM[3:0]       ), //i
+    .io_cpu_writeBack_exclusiveOk           (dataCache_1_io_cpu_writeBack_exclusiveOk         ), //o
+    .io_cpu_redo                            (dataCache_1_io_cpu_redo                          ), //o
+    .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
+    .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
+    .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[8:0]     ), //i
+    .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                       (dataCache_1_io_mem_cmd_ready                     ), //i
+    .io_mem_cmd_payload_wr                  (dataCache_1_io_mem_cmd_payload_wr                ), //o
+    .io_mem_cmd_payload_uncached            (dataCache_1_io_mem_cmd_payload_uncached          ), //o
+    .io_mem_cmd_payload_address             (dataCache_1_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_data                (dataCache_1_io_mem_cmd_payload_data[31:0]        ), //o
+    .io_mem_cmd_payload_mask                (dataCache_1_io_mem_cmd_payload_mask[3:0]         ), //o
+    .io_mem_cmd_payload_size                (dataCache_1_io_mem_cmd_payload_size[1:0]         ), //o
+    .io_mem_cmd_payload_last                (dataCache_1_io_mem_cmd_payload_last              ), //o
+    .io_mem_rsp_valid                       (dBus_rsp_valid                                   ), //i
+    .io_mem_rsp_payload_last                (dBus_rsp_payload_last                            ), //i
+    .io_mem_rsp_payload_data                (dBus_rsp_payload_data[31:0]                      ), //i
+    .io_mem_rsp_payload_error               (dBus_rsp_payload_error                           ), //i
+    .clk                                    (clk                                              ), //i
+    .reset                                  (reset                                            )  //i
   );
   always @(*) begin
     case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      end
-      2'b01 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      end
-      2'b10 : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      end
-      default : begin
-        _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
-      end
+      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_1)
-      2'b00 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
-      end
-      2'b01 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      2'b10 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      2'b00 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_0;
+      2'b01 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_1;
+      2'b10 : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_2;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   always @(*) begin
     case(_zz_writeBack_DBusCachedPlugin_rspShifted_3)
-      1'b0 : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
-      end
-      default : begin
-        _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
-      end
+      1'b0 : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_1;
+      default : _zz_writeBack_DBusCachedPlugin_rspShifted_2 = writeBack_DBusCachedPlugin_rspSplits_3;
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
     case(decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_to_writeBack_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_to_writeBack_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_to_writeBack_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_to_writeBack_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_to_writeBack_ENV_CTRL_1_string = "ECALL";
       default : _zz_memory_to_writeBack_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_to_memory_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_to_memory_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_to_memory_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_to_memory_ENV_CTRL_1_string = "ECALL";
       default : _zz_execute_to_memory_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_ENV_CTRL_string = "ECALL";
       default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_string = "ECALL";
       default : _zz_decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_to_execute_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_to_execute_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_to_execute_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_to_execute_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_to_execute_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_to_execute_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_to_execute_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_to_execute_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_to_execute_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_to_memory_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_to_memory_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_execute_to_memory_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_to_execute_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_to_execute_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_to_execute_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_SRC2_CTRL_string = "PC ";
       default : decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_string = "PC ";
       default : _zz_decode_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_to_execute_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_to_execute_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_to_execute_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_to_execute_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
       default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_to_execute_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_to_execute_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_to_execute_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_to_execute_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_SRC1_CTRL_string = "URS1        ";
       default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_to_execute_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_to_execute_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_to_execute_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_to_execute_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_to_execute_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_to_execute_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : _zz_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_ENV_CTRL_string = "ECALL";
       default : memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_memory_ENV_CTRL_string = "ECALL";
       default : _zz_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_ENV_CTRL_string = "ECALL";
       default : execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_execute_ENV_CTRL_string = "ECALL";
       default : _zz_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : writeBack_ENV_CTRL_string = "ECALL";
       default : writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_writeBack_ENV_CTRL_string = "ECALL";
       default : _zz_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : execute_BRANCH_CTRL_string = "JALR";
       default : execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_execute_BRANCH_CTRL_string = "JALR";
       default : _zz_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : memory_SHIFT_CTRL_string = "SRA_1    ";
       default : memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : _zz_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : execute_SRC2_CTRL_string = "PC ";
       default : execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : _zz_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : _zz_execute_SRC2_CTRL_string = "PC ";
       default : _zz_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : execute_SRC1_CTRL_string = "URS1        ";
       default : execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_execute_SRC1_CTRL_string = "URS1        ";
       default : _zz_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : execute_ALU_CTRL_string = "BITWISE ";
       default : execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_execute_ALU_CTRL_string = "BITWISE ";
       default : _zz_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : _zz_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "IMM_I";
       default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_1)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_1_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_1_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_1_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_1_string = "ECALL";
       default : _zz_decode_ENV_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_1)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_1_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_1_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_1_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_1_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_1_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_1)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_1_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_1)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_1_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_1_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_1_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_1_string = "PC ";
       default : _zz_decode_SRC2_CTRL_1_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_1)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_1_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_1_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_1_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_1_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_1)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_1_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_1_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_1_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_1_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_1_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_BRANCH_CTRL_string = "JALR";
       default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_1)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_1_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_1_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_1_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_1_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_1_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC1_CTRL_2)
-      `Src1CtrlEnum_binary_sequential_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
+      Src1CtrlEnum_RS : _zz_decode_SRC1_CTRL_2_string = "RS          ";
+      Src1CtrlEnum_IMU : _zz_decode_SRC1_CTRL_2_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : _zz_decode_SRC1_CTRL_2_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : _zz_decode_SRC1_CTRL_2_string = "URS1        ";
       default : _zz_decode_SRC1_CTRL_2_string = "????????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_CTRL_2)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : _zz_decode_ALU_CTRL_2_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : _zz_decode_ALU_CTRL_2_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : _zz_decode_ALU_CTRL_2_string = "BITWISE ";
       default : _zz_decode_ALU_CTRL_2_string = "????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SRC2_CTRL_2)
-      `Src2CtrlEnum_binary_sequential_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
+      Src2CtrlEnum_RS : _zz_decode_SRC2_CTRL_2_string = "RS ";
+      Src2CtrlEnum_IMI : _zz_decode_SRC2_CTRL_2_string = "IMI";
+      Src2CtrlEnum_IMS : _zz_decode_SRC2_CTRL_2_string = "IMS";
+      Src2CtrlEnum_PC : _zz_decode_SRC2_CTRL_2_string = "PC ";
       default : _zz_decode_SRC2_CTRL_2_string = "???";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ALU_BITWISE_CTRL_2)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : _zz_decode_ALU_BITWISE_CTRL_2_string = "AND_1";
       default : _zz_decode_ALU_BITWISE_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_SHIFT_CTRL_2)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : _zz_decode_SHIFT_CTRL_2_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : _zz_decode_SHIFT_CTRL_2_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : _zz_decode_SHIFT_CTRL_2_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : _zz_decode_SHIFT_CTRL_2_string = "SRA_1    ";
       default : _zz_decode_SHIFT_CTRL_2_string = "?????????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_BRANCH_CTRL_2)
-      `BranchCtrlEnum_binary_sequential_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
+      BranchCtrlEnum_INC : _zz_decode_BRANCH_CTRL_2_string = "INC ";
+      BranchCtrlEnum_B : _zz_decode_BRANCH_CTRL_2_string = "B   ";
+      BranchCtrlEnum_JAL : _zz_decode_BRANCH_CTRL_2_string = "JAL ";
+      BranchCtrlEnum_JALR : _zz_decode_BRANCH_CTRL_2_string = "JALR";
       default : _zz_decode_BRANCH_CTRL_2_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_decode_ENV_CTRL_2)
-      `EnvCtrlEnum_binary_sequential_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
+      EnvCtrlEnum_NONE : _zz_decode_ENV_CTRL_2_string = "NONE ";
+      EnvCtrlEnum_XRET : _zz_decode_ENV_CTRL_2_string = "XRET ";
+      EnvCtrlEnum_WFI : _zz_decode_ENV_CTRL_2_string = "WFI  ";
+      EnvCtrlEnum_ECALL : _zz_decode_ENV_CTRL_2_string = "ECALL";
       default : _zz_decode_ENV_CTRL_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8)
-      `Input2Kind_binary_sequential_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "IMM_I";
-      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8_string = "?????";
+    case(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9)
+      Input2Kind_RS : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "RS   ";
+      Input2Kind_IMM_I : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "IMM_I";
+      default : _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_binary_sequential_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_binary_sequential_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      Src1CtrlEnum_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      Src1CtrlEnum_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      Src1CtrlEnum_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      Src1CtrlEnum_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_binary_sequential_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      AluCtrlEnum_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      AluCtrlEnum_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      AluCtrlEnum_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_binary_sequential_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_binary_sequential_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_binary_sequential_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      Src2CtrlEnum_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      Src2CtrlEnum_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      Src2CtrlEnum_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      Src2CtrlEnum_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      AluBitwiseCtrlEnum_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      AluBitwiseCtrlEnum_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      AluBitwiseCtrlEnum_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_binary_sequential_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_binary_sequential_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_binary_sequential_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      ShiftCtrlEnum_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      ShiftCtrlEnum_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      ShiftCtrlEnum_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      ShiftCtrlEnum_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_binary_sequential_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_binary_sequential_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_binary_sequential_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      BranchCtrlEnum_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      BranchCtrlEnum_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      BranchCtrlEnum_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      BranchCtrlEnum_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
       default : decode_to_execute_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
       default : execute_to_memory_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_binary_sequential_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_binary_sequential_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_binary_sequential_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_binary_sequential_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      EnvCtrlEnum_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      EnvCtrlEnum_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      EnvCtrlEnum_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      EnvCtrlEnum_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
     case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
-      `Input2Kind_binary_sequential_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      Input2Kind_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      Input2Kind_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
       default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
     endcase
   end
@@ -2693,6 +2658,8 @@ module VexRiscv (
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
   assign decode_SRC_LESS_UNSIGNED = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[17];
   assign decode_MEMORY_MANAGMENT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[16];
+  assign execute_HAS_SIDE_EFFECT = decode_to_execute_HAS_SIDE_EFFECT;
+  assign decode_HAS_SIDE_EFFECT = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[14];
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
   assign decode_MEMORY_WR = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[13];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
@@ -2727,6 +2694,8 @@ module VexRiscv (
   assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
   assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
+  assign writeBack_HAS_SIDE_EFFECT = memory_to_writeBack_HAS_SIDE_EFFECT;
+  assign memory_HAS_SIDE_EFFECT = execute_to_memory_HAS_SIDE_EFFECT;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2747,14 +2716,13 @@ module VexRiscv (
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[15];
   assign decode_RS1_USE = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[5];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
-    if(when_CsrPlugin_l1176) begin
+    if(when_CsrPlugin_l1189) begin
       _zz_decode_RS2 = CsrPlugin_csrMapping_readDataSignal;
     end
   end
@@ -2830,10 +2798,10 @@ module VexRiscv (
     _zz_decode_RS2_1 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid) begin
       case(memory_SHIFT_CTRL)
-        `ShiftCtrlEnum_binary_sequential_SLL_1 : begin
+        ShiftCtrlEnum_SLL_1 : begin
           _zz_decode_RS2_1 = _zz_decode_RS2_3;
         end
-        `ShiftCtrlEnum_binary_sequential_SRL_1, `ShiftCtrlEnum_binary_sequential_SRA_1 : begin
+        ShiftCtrlEnum_SRL_1, ShiftCtrlEnum_SRA_1 : begin
           _zz_decode_RS2_1 = memory_SHIFT_RIGHT;
         end
         default : begin
@@ -2844,7 +2812,7 @@ module VexRiscv (
       _zz_decode_RS2_1 = memory_DivPlugin_div_result;
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      _zz_decode_RS2_1 = CfuPlugin_bus_rsp_rsp_payload_outputs_0;
+      _zz_decode_RS2_1 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
@@ -2881,10 +2849,10 @@ module VexRiscv (
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}} != 22'h0);
+  assign decode_LEGAL_INSTRUCTION = (|{((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_decode_LEGAL_INSTRUCTION) == 32'h00000003),{(_zz_decode_LEGAL_INSTRUCTION_1 == _zz_decode_LEGAL_INSTRUCTION_2),{_zz_decode_LEGAL_INSTRUCTION_3,{_zz_decode_LEGAL_INSTRUCTION_4,_zz_decode_LEGAL_INSTRUCTION_5}}}}}}});
   always @(*) begin
     _zz_decode_RS2_2 = writeBack_REGFILE_WRITE_DATA;
-    if(when_DBusCachedPlugin_l484) begin
+    if(when_DBusCachedPlugin_l492) begin
       _zz_decode_RS2_2 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if(when_MulPlugin_l147) begin
@@ -2906,6 +2874,7 @@ module VexRiscv (
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  assign execute_RS1 = decode_to_execute_RS1;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
@@ -2963,7 +2932,7 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l303) begin
+    if(when_DBusCachedPlugin_l308) begin
       decode_arbitration_haltItself = 1'b1;
     end
   end
@@ -2976,7 +2945,7 @@ module VexRiscv (
     if(CsrPlugin_pipelineLiberator_active) begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(when_CsrPlugin_l1116) begin
+    if(when_CsrPlugin_l1129) begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3004,27 +2973,30 @@ module VexRiscv (
 
   always @(*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l343) begin
+    if(when_DBusCachedPlugin_l350) begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(when_CsrPlugin_l1108) begin
-      if(when_CsrPlugin_l1110) begin
+    if(when_CsrPlugin_l1121) begin
+      if(when_CsrPlugin_l1123) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CsrPlugin_l1180) begin
+    if(when_CsrPlugin_l1193) begin
       if(execute_CsrPlugin_blockedBySideEffects) begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(when_CfuPlugin_l175) begin
+    if(when_CfuPlugin_l194) begin
+      execute_arbitration_haltItself = 1'b1;
+    end
+    if(when_CfuPlugin_l201) begin
       execute_arbitration_haltItself = 1'b1;
     end
   end
 
   always @(*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(when_DBusCachedPlugin_l359) begin
+    if(when_DBusCachedPlugin_l366) begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3058,7 +3030,7 @@ module VexRiscv (
       end
     end
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      if(when_CfuPlugin_l208) begin
+      if(when_CfuPlugin_l237) begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -3076,7 +3048,7 @@ module VexRiscv (
   assign memory_arbitration_flushNext = 1'b0;
   always @(*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(when_DBusCachedPlugin_l458) begin
+    if(when_DBusCachedPlugin_l466) begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3107,10 +3079,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3121,29 +3093,31 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(when_CsrPlugin_l922) begin
+    if(when_CsrPlugin_l935) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
 
+  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
     IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(when_Fetcher_l240) begin
+    if(when_Fetcher_l243) begin
       IBusCachedPlugin_incomingInstruction = 1'b1;
     end
   end
 
+  assign BranchPlugin_inDebugNoFetchFlag = 1'b0;
   assign CsrPlugin_csrMapping_allowCsrSignal = 1'b0;
   assign CsrPlugin_csrMapping_readDataSignal = CsrPlugin_csrMapping_readDataInit;
   always @(*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(when_CsrPlugin_l1108) begin
+    if(when_CsrPlugin_l1121) begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3151,21 +3125,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @(*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1064) begin
+    if(when_CsrPlugin_l1077) begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_jumpInterface_payload = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(when_CsrPlugin_l1064) begin
-      case(switch_CsrPlugin_l1068)
+    if(when_CsrPlugin_l1077) begin
+      case(switch_CsrPlugin_l1081)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3206,9 +3180,9 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l131 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l134 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
   assign IBusCachedPlugin_fetchPc_output_fire_1 = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign when_Fetcher_l131_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l134_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
   always @(*) begin
     IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
     if(IBusCachedPlugin_fetchPc_redo_valid) begin
@@ -3231,7 +3205,7 @@ module VexRiscv (
     end
   end
 
-  assign when_Fetcher_l158 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
+  assign when_Fetcher_l161 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
   assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @(*) begin
@@ -3293,24 +3267,30 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = IBusCachedPlugin_iBusRsp_stages_1_output_m2sPipe_payload;
   always @(*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(when_Fetcher_l320) begin
+    if(when_Fetcher_l323) begin
       IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign when_Fetcher_l240 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
-  assign when_Fetcher_l320 = (! IBusCachedPlugin_pcValids_0);
-  assign when_Fetcher_l329 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
-  assign when_Fetcher_l329_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
-  assign when_Fetcher_l329_2 = (! execute_arbitration_isStuck);
-  assign when_Fetcher_l329_3 = (! memory_arbitration_isStuck);
-  assign when_Fetcher_l329_4 = (! writeBack_arbitration_isStuck);
+  assign when_Fetcher_l243 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid || IBusCachedPlugin_iBusRsp_stages_2_input_valid);
+  assign when_Fetcher_l323 = (! IBusCachedPlugin_pcValids_0);
+  assign when_Fetcher_l332 = (! (! IBusCachedPlugin_iBusRsp_stages_1_input_ready));
+  assign when_Fetcher_l332_1 = (! (! IBusCachedPlugin_iBusRsp_stages_2_input_ready));
+  assign when_Fetcher_l332_2 = (! execute_arbitration_isStuck);
+  assign when_Fetcher_l332_3 = (! memory_arbitration_isStuck);
+  assign when_Fetcher_l332_4 = (! writeBack_arbitration_isStuck);
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
-  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  always @(*) begin
+    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+    if(IBusCachedPlugin_forceNoDecodeCond) begin
+      decode_arbitration_isValid = 1'b0;
+    end
+  end
+
   assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
     _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
@@ -3335,7 +3315,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
     if(_zz_6) begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
@@ -3381,7 +3361,7 @@ module VexRiscv (
 
   always @(*) begin
     case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_6 = _zz__zz_6[1];
       end
       default : begin
@@ -3429,7 +3409,7 @@ module VexRiscv (
     _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_5,_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @(*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3510,12 +3490,12 @@ module VexRiscv (
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_rValid ? dataCache_1_io_mem_cmd_rData_last : dataCache_1_io_mem_cmd_payload_last);
   always @(*) begin
     dataCache_1_io_mem_cmd_s2mPipe_ready = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l342) begin
+    if(when_Stream_l368) begin
       dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l342 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l368 = (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3533,7 +3513,7 @@ module VexRiscv (
   assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
   assign dBus_cmd_payload_size = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_size;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  assign when_DBusCachedPlugin_l303 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l308 = ((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE);
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   assign dataCache_1_io_cpu_execute_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_execute_address = execute_SRC_ADD;
@@ -3552,9 +3532,11 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[8:0];
   assign dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
-  assign when_DBusCachedPlugin_l343 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
-  assign when_DBusCachedPlugin_l359 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
+  assign when_DBusCachedPlugin_l350 = (dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
+  assign when_DBusCachedPlugin_l366 = (dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid);
   assign dataCache_1_io_cpu_memory_isValid = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
   assign dataCache_1_io_cpu_memory_address = memory_REGFILE_WRITE_DATA;
   assign DBusCachedPlugin_mmuBus_cmd_0_isValid = dataCache_1_io_cpu_memory_isValid;
@@ -3564,12 +3546,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @(*) begin
     dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if(when_DBusCachedPlugin_l386) begin
+    if(when_DBusCachedPlugin_l393) begin
       dataCache_1_io_cpu_memory_mmuRsp_isIoAccess = 1'b1;
     end
   end
 
-  assign when_DBusCachedPlugin_l386 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
+  assign when_DBusCachedPlugin_l393 = (1'b0 && (! dataCache_1_io_cpu_memory_isWrite));
   always @(*) begin
     dataCache_1_io_cpu_writeBack_isValid = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_arbitration_haltByOther) begin
@@ -3582,7 +3564,7 @@ module VexRiscv (
   assign dataCache_1_io_cpu_writeBack_storeData[31 : 0] = writeBack_MEMORY_STORE_DATA_RF;
   always @(*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_redo) begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3592,7 +3574,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3611,7 +3593,7 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @(*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(when_DBusCachedPlugin_l438) begin
+    if(when_DBusCachedPlugin_l446) begin
       if(dataCache_1_io_cpu_writeBack_accessError) begin
         DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_DBusCachedPlugin_exceptionBus_payload_code};
       end
@@ -3624,8 +3606,8 @@ module VexRiscv (
     end
   end
 
-  assign when_DBusCachedPlugin_l438 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign when_DBusCachedPlugin_l458 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
+  assign when_DBusCachedPlugin_l446 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l466 = (dataCache_1_io_cpu_writeBack_isValid && dataCache_1_io_cpu_writeBack_haltIt);
   assign writeBack_DBusCachedPlugin_rspSplits_0 = dataCache_1_io_cpu_writeBack_data[7 : 0];
   assign writeBack_DBusCachedPlugin_rspSplits_1 = dataCache_1_io_cpu_writeBack_data[15 : 8];
   assign writeBack_DBusCachedPlugin_rspSplits_2 = dataCache_1_io_cpu_writeBack_data[23 : 16];
@@ -3638,7 +3620,7 @@ module VexRiscv (
   end
 
   assign writeBack_DBusCachedPlugin_rspRf = writeBack_DBusCachedPlugin_rspShifted[31 : 0];
-  assign switch_Misc_l200 = writeBack_INSTRUCTION[13 : 12];
+  assign switch_Misc_l210 = writeBack_INSTRUCTION[13 : 12];
   assign _zz_writeBack_DBusCachedPlugin_rspFormated = (writeBack_DBusCachedPlugin_rspRf[7] && (! writeBack_INSTRUCTION[14]));
   always @(*) begin
     _zz_writeBack_DBusCachedPlugin_rspFormated_1[31] = _zz_writeBack_DBusCachedPlugin_rspFormated;
@@ -3690,7 +3672,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    case(switch_Misc_l200)
+    case(switch_Misc_l210)
       2'b00 : begin
         writeBack_DBusCachedPlugin_rspFormated = _zz_writeBack_DBusCachedPlugin_rspFormated_1;
       end
@@ -3703,7 +3685,7 @@ module VexRiscv (
     endcase
   end
 
-  assign when_DBusCachedPlugin_l484 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign when_DBusCachedPlugin_l492 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
   assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3723,11 +3705,12 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
   assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_3 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 != 1'b0),{(_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 != _zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}};
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_6 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2 = {1'b0,{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_7),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2),{(|_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_1),{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_2,{_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_4,_zz__zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2_7}}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
   assign _zz_decode_ALU_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[7 : 6];
@@ -3742,8 +3725,8 @@ module VexRiscv (
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
   assign _zz_decode_ENV_CTRL_2 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[27 : 26];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_8;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_2[33 : 33];
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1 = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_9;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
@@ -3775,10 +3758,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_binary_sequential_AND_1 : begin
+      AluBitwiseCtrlEnum_AND_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 & execute_SRC2);
       end
-      `AluBitwiseCtrlEnum_binary_sequential_OR_1 : begin
+      AluBitwiseCtrlEnum_OR_1 : begin
         execute_IntAluPlugin_bitwise = (execute_SRC1 | execute_SRC2);
       end
       default : begin
@@ -3789,10 +3772,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_ALU_CTRL)
-      `AluCtrlEnum_binary_sequential_BITWISE : begin
+      AluCtrlEnum_BITWISE : begin
         _zz_execute_REGFILE_WRITE_DATA = execute_IntAluPlugin_bitwise;
       end
-      `AluCtrlEnum_binary_sequential_SLT_SLTU : begin
+      AluCtrlEnum_SLT_SLTU : begin
         _zz_execute_REGFILE_WRITE_DATA = {31'd0, _zz__zz_execute_REGFILE_WRITE_DATA};
       end
       default : begin
@@ -3803,13 +3786,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC1_CTRL)
-      `Src1CtrlEnum_binary_sequential_RS : begin
+      Src1CtrlEnum_RS : begin
         _zz_execute_SRC1 = execute_RS1;
       end
-      `Src1CtrlEnum_binary_sequential_PC_INCREMENT : begin
+      Src1CtrlEnum_PC_INCREMENT : begin
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
-      `Src1CtrlEnum_binary_sequential_IMU : begin
+      Src1CtrlEnum_IMU : begin
         _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
@@ -3868,13 +3851,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_SRC2_CTRL)
-      `Src2CtrlEnum_binary_sequential_RS : begin
+      Src2CtrlEnum_RS : begin
         _zz_execute_SRC2_5 = execute_RS2;
       end
-      `Src2CtrlEnum_binary_sequential_IMI : begin
+      Src2CtrlEnum_IMI : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_2,execute_INSTRUCTION[31 : 20]};
       end
-      `Src2CtrlEnum_binary_sequential_IMS : begin
+      Src2CtrlEnum_IMS : begin
         _zz_execute_SRC2_5 = {_zz_execute_SRC2_4,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
@@ -3927,7 +3910,7 @@ module VexRiscv (
     _zz_execute_FullBarrelShifterPlugin_reversed[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_binary_sequential_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == ShiftCtrlEnum_SLL_1) ? _zz_execute_FullBarrelShifterPlugin_reversed : execute_SRC1);
   always @(*) begin
     _zz_decode_RS2_3[0] = memory_SHIFT_RIGHT[31];
     _zz_decode_RS2_3[1] = memory_SHIFT_RIGHT[30];
@@ -4044,9 +4027,9 @@ module VexRiscv (
   assign when_HazardSimplePlugin_l108 = (! decode_RS2_USE);
   assign when_HazardSimplePlugin_l113 = (decode_arbitration_isValid && (HazardSimplePlugin_src0Hazard || HazardSimplePlugin_src1Hazard));
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign switch_Misc_l200_1 = execute_INSTRUCTION[14 : 12];
+  assign switch_Misc_l210_1 = execute_INSTRUCTION[14 : 12];
   always @(*) begin
-    casez(switch_Misc_l200_1)
+    casez(switch_Misc_l210_1)
       3'b000 : begin
         _zz_execute_BRANCH_COND_RESULT = execute_BranchPlugin_eq;
       end
@@ -4064,13 +4047,13 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_INC : begin
+      BranchCtrlEnum_INC : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b0;
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BRANCH_COND_RESULT_1 = 1'b1;
       end
       default : begin
@@ -4143,10 +4126,10 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = (_zz__zz_execute_BranchPlugin_missAlignedTarget_6[1] ^ execute_RS1[1]);
       end
-      `BranchCtrlEnum_binary_sequential_JAL : begin
+      BranchCtrlEnum_JAL : begin
         _zz_execute_BranchPlugin_missAlignedTarget_6 = _zz__zz_execute_BranchPlugin_missAlignedTarget_6_1[1];
       end
       default : begin
@@ -4158,7 +4141,7 @@ module VexRiscv (
   assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_execute_BranchPlugin_missAlignedTarget_6);
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src1 = execute_RS1;
       end
       default : begin
@@ -4193,11 +4176,11 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_binary_sequential_JALR : begin
+      BranchCtrlEnum_JALR : begin
         execute_BranchPlugin_branch_src2 = {_zz_execute_BranchPlugin_branch_src2_1,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_binary_sequential_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_7,_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_9};
         end
@@ -4248,14 +4231,14 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
   always @(*) begin
     BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
-    if(when_BranchPlugin_l296) begin
+    if(when_BranchPlugin_l302) begin
       BranchPlugin_branchExceptionPort_valid = 1'b0;
     end
   end
 
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
-  assign when_BranchPlugin_l296 = 1'b0;
+  assign when_BranchPlugin_l302 = 1'b0;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4264,9 +4247,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_when_CsrPlugin_l952 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_when_CsrPlugin_l952_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_when_CsrPlugin_l952_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_when_CsrPlugin_l965 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_when_CsrPlugin_l965_1 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_when_CsrPlugin_l965_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
   assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
@@ -4310,28 +4293,28 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l909 = (! decode_arbitration_isStuck);
-  assign when_CsrPlugin_l909_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l909_2 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l909_3 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l922 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
+  assign when_CsrPlugin_l922 = (! decode_arbitration_isStuck);
+  assign when_CsrPlugin_l922_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l922_2 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l922_3 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l935 = ({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000);
   assign CsrPlugin_exceptionPendings_0 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
   assign CsrPlugin_exceptionPendings_1 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
   assign CsrPlugin_exceptionPendings_2 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
   assign CsrPlugin_exceptionPendings_3 = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack;
-  assign when_CsrPlugin_l946 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign when_CsrPlugin_l952 = ((_zz_when_CsrPlugin_l952 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_1 = ((_zz_when_CsrPlugin_l952_1 && 1'b1) && (! 1'b0));
-  assign when_CsrPlugin_l952_2 = ((_zz_when_CsrPlugin_l952_2 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l959 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign when_CsrPlugin_l965 = ((_zz_when_CsrPlugin_l965 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_1 = ((_zz_when_CsrPlugin_l965_1 && 1'b1) && (! 1'b0));
+  assign when_CsrPlugin_l965_2 = ((_zz_when_CsrPlugin_l965_2 && 1'b1) && (! 1'b0));
   assign CsrPlugin_exception = (CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack && CsrPlugin_allowException);
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
-  assign when_CsrPlugin_l980 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l980_1 = (! memory_arbitration_isStuck);
-  assign when_CsrPlugin_l980_2 = (! writeBack_arbitration_isStuck);
-  assign when_CsrPlugin_l985 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
+  assign when_CsrPlugin_l993 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l993_1 = (! memory_arbitration_isStuck);
+  assign when_CsrPlugin_l993_2 = (! writeBack_arbitration_isStuck);
+  assign when_CsrPlugin_l998 = ((! CsrPlugin_pipelineLiberator_active) || decode_arbitration_removeIt);
   always @(*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(when_CsrPlugin_l991) begin
+    if(when_CsrPlugin_l1004) begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException) begin
@@ -4339,7 +4322,7 @@ module VexRiscv (
     end
   end
 
-  assign when_CsrPlugin_l991 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
+  assign when_CsrPlugin_l1004 = ({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000);
   assign CsrPlugin_interruptJump = ((CsrPlugin_interrupt_valid && CsrPlugin_pipelineLiberator_done) && CsrPlugin_allowInterrupts);
   always @(*) begin
     CsrPlugin_targetPrivilege = CsrPlugin_interrupt_targetPrivilege;
@@ -4377,14 +4360,14 @@ module VexRiscv (
     endcase
   end
 
-  assign when_CsrPlugin_l1019 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign when_CsrPlugin_l1064 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign switch_CsrPlugin_l1068 = writeBack_INSTRUCTION[29 : 28];
+  assign when_CsrPlugin_l1032 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign when_CsrPlugin_l1077 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign switch_CsrPlugin_l1081 = writeBack_INSTRUCTION[29 : 28];
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign when_CsrPlugin_l1108 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
-  assign when_CsrPlugin_l1110 = (! execute_CsrPlugin_wfiWake);
-  assign when_CsrPlugin_l1116 = ({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET))}} != 3'b000);
-  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
+  assign when_CsrPlugin_l1121 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_WFI));
+  assign when_CsrPlugin_l1123 = (! execute_CsrPlugin_wfiWake);
+  assign when_CsrPlugin_l1129 = (|{(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == EnvCtrlEnum_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == EnvCtrlEnum_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET))}});
+  assign execute_CsrPlugin_blockedBySideEffects = ((|{writeBack_arbitration_isValid,memory_arbitration_isValid}) || 1'b0);
   always @(*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4482,18 +4465,18 @@ module VexRiscv (
     if(CsrPlugin_csrMapping_allowCsrSignal) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
-    if(when_CsrPlugin_l1302) begin
+    if(when_CsrPlugin_l1315) begin
       execute_CsrPlugin_illegalAccess = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_illegalInstruction = 1'b0;
-    if(when_CsrPlugin_l1136) begin
-      if(when_CsrPlugin_l1137) begin
+    if(when_CsrPlugin_l1149) begin
+      if(when_CsrPlugin_l1150) begin
         execute_CsrPlugin_illegalInstruction = 1'b1;
       end
     end
@@ -4501,20 +4484,20 @@ module VexRiscv (
 
   always @(*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @(*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(when_CsrPlugin_l1129) begin
+    if(when_CsrPlugin_l1142) begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(when_CsrPlugin_l1144) begin
+    if(when_CsrPlugin_l1157) begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4527,20 +4510,20 @@ module VexRiscv (
   end
 
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
-  assign when_CsrPlugin_l1129 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign when_CsrPlugin_l1136 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_XRET));
-  assign when_CsrPlugin_l1137 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
-  assign when_CsrPlugin_l1144 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_binary_sequential_ECALL));
+  assign when_CsrPlugin_l1142 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign when_CsrPlugin_l1149 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_XRET));
+  assign when_CsrPlugin_l1150 = (CsrPlugin_privilege < execute_INSTRUCTION[29 : 28]);
+  assign when_CsrPlugin_l1157 = (execute_arbitration_isValid && (execute_ENV_CTRL == EnvCtrlEnum_ECALL));
   always @(*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @(*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(when_CsrPlugin_l1297) begin
+    if(when_CsrPlugin_l1310) begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4549,9 +4532,9 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign CsrPlugin_csrMapping_hazardFree = (! execute_CsrPlugin_blockedBySideEffects);
   assign execute_CsrPlugin_readToWriteData = CsrPlugin_csrMapping_readDataSignal;
-  assign switch_Misc_l200_2 = execute_INSTRUCTION[13];
+  assign switch_Misc_l210_2 = execute_INSTRUCTION[13];
   always @(*) begin
-    case(switch_Misc_l200_2)
+    case(switch_Misc_l210_2)
       1'b0 : begin
         _zz_CsrPlugin_csrMapping_writeDataSignal = execute_SRC1;
       end
@@ -4562,8 +4545,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_writeDataSignal = _zz_CsrPlugin_csrMapping_writeDataSignal;
-  assign when_CsrPlugin_l1176 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign when_CsrPlugin_l1180 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
+  assign when_CsrPlugin_l1189 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign when_CsrPlugin_l1193 = (execute_arbitration_isValid && (execute_IS_CSR || 1'b0));
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
@@ -4656,12 +4639,15 @@ module VexRiscv (
   end
 
   assign _zz_CsrPlugin_csrMapping_readDataInit_1 = (_zz_CsrPlugin_csrMapping_readDataInit & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_CsrPlugin_csrMapping_readDataInit_1 != 32'h0);
-  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign externalInterrupt = (|_zz_CsrPlugin_csrMapping_readDataInit_1);
+  assign execute_CfuPlugin_hazard = ({(writeBack_arbitration_isValid && writeBack_HAS_SIDE_EFFECT),(memory_arbitration_isValid && memory_HAS_SIDE_EFFECT)} != 2'b00);
+  assign execute_CfuPlugin_scheduleWish = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign execute_CfuPlugin_schedule = (execute_CfuPlugin_scheduleWish && (! execute_CfuPlugin_hazard));
+  assign when_CfuPlugin_l194 = (execute_CfuPlugin_scheduleWish && execute_CfuPlugin_hazard);
   assign CfuPlugin_bus_cmd_fire = (CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready);
-  assign when_CfuPlugin_l171 = (! execute_arbitration_isStuckByOthers);
+  assign when_CfuPlugin_l197 = (! execute_arbitration_isStuck);
   assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
-  assign when_CfuPlugin_l175 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
+  assign when_CfuPlugin_l201 = (CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready));
   assign execute_CfuPlugin_functionsIds_0 = _zz_execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
   assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
@@ -4695,7 +4681,7 @@ module VexRiscv (
 
   always @(*) begin
     case(execute_CfuPlugin_CFU_INPUT_2_KIND)
-      `Input2Kind_binary_sequential_RS : begin
+      Input2Kind_RS : begin
         _zz_CfuPlugin_bus_cmd_payload_inputs_1_2 = execute_RS2;
       end
       default : begin
@@ -4706,16 +4692,16 @@ module VexRiscv (
 
   assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_CfuPlugin_bus_cmd_payload_inputs_1_2;
   assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
-  assign CfuPlugin_bus_rsp_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_rValid);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_rValid ? CfuPlugin_bus_rsp_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
   always @(*) begin
-    CfuPlugin_bus_rsp_rsp_ready = 1'b0;
+    memory_CfuPlugin_rsp_ready = 1'b0;
     if(memory_CfuPlugin_CFU_IN_FLIGHT) begin
-      CfuPlugin_bus_rsp_rsp_ready = (! memory_arbitration_isStuckByOthers);
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  assign when_CfuPlugin_l208 = (! CfuPlugin_bus_rsp_rsp_valid);
+  assign when_CfuPlugin_l237 = (! memory_CfuPlugin_rsp_valid);
   assign when_Pipeline_l124 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_1 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_2 = ((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack));
@@ -4752,64 +4738,67 @@ module VexRiscv (
   assign when_Pipeline_l124_24 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_25 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_26 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_27 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_27 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_28 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_30 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL_1 = decode_ALU_BITWISE_CTRL;
   assign _zz_decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL_1;
-  assign when_Pipeline_l124_28 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
   assign _zz_execute_ALU_BITWISE_CTRL = decode_to_execute_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL_1 = decode_SHIFT_CTRL;
   assign _zz_execute_to_memory_SHIFT_CTRL_1 = execute_SHIFT_CTRL;
   assign _zz_decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL_1;
-  assign when_Pipeline_l124_29 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
   assign _zz_execute_SHIFT_CTRL = decode_to_execute_SHIFT_CTRL;
-  assign when_Pipeline_l124_30 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_33 = (! memory_arbitration_isStuck);
   assign _zz_memory_SHIFT_CTRL = execute_to_memory_SHIFT_CTRL;
   assign _zz_decode_to_execute_BRANCH_CTRL_1 = decode_BRANCH_CTRL;
   assign _zz_decode_BRANCH_CTRL_1 = _zz_decode_BRANCH_CTRL;
-  assign when_Pipeline_l124_31 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_34 = (! execute_arbitration_isStuck);
   assign _zz_execute_BRANCH_CTRL = decode_to_execute_BRANCH_CTRL;
-  assign when_Pipeline_l124_32 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_35 = (! execute_arbitration_isStuck);
   assign _zz_decode_to_execute_ENV_CTRL_1 = decode_ENV_CTRL;
   assign _zz_execute_to_memory_ENV_CTRL_1 = execute_ENV_CTRL;
   assign _zz_memory_to_writeBack_ENV_CTRL_1 = memory_ENV_CTRL;
   assign _zz_decode_ENV_CTRL = _zz_decode_ENV_CTRL_1;
-  assign when_Pipeline_l124_33 = (! execute_arbitration_isStuck);
-  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
-  assign when_Pipeline_l124_34 = (! memory_arbitration_isStuck);
-  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
-  assign when_Pipeline_l124_35 = (! writeBack_arbitration_isStuck);
-  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_36 = (! execute_arbitration_isStuck);
+  assign _zz_execute_ENV_CTRL = decode_to_execute_ENV_CTRL;
   assign when_Pipeline_l124_37 = (! memory_arbitration_isStuck);
+  assign _zz_memory_ENV_CTRL = execute_to_memory_ENV_CTRL;
   assign when_Pipeline_l124_38 = (! writeBack_arbitration_isStuck);
+  assign _zz_writeBack_ENV_CTRL = memory_to_writeBack_ENV_CTRL;
   assign when_Pipeline_l124_39 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_40 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_41 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_41 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_42 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_43 = (! execute_arbitration_isStuck);
-  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
-  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
+  assign when_Pipeline_l124_43 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_44 = (! execute_arbitration_isStuck);
-  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_45 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_46 = (! execute_arbitration_isStuck);
+  assign _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_1 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_decode_CfuPlugin_CFU_INPUT_2_KIND_1;
   assign when_Pipeline_l124_47 = (! execute_arbitration_isStuck);
+  assign _zz_execute_CfuPlugin_CFU_INPUT_2_KIND = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign when_Pipeline_l124_48 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_49 = (! execute_arbitration_isStuck);
   assign when_Pipeline_l124_50 = (! execute_arbitration_isStuck);
-  assign when_Pipeline_l124_51 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_52 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_53 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_54 = (! writeBack_arbitration_isStuck);
-  assign when_Pipeline_l124_55 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_51 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_52 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_53 = (! execute_arbitration_isStuck);
+  assign when_Pipeline_l124_54 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_55 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_56 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_57 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_57 = (! writeBack_arbitration_isStuck);
   assign when_Pipeline_l124_58 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_59 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_60 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_60 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_61 = (! memory_arbitration_isStuck);
-  assign when_Pipeline_l124_62 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_62 = (! memory_arbitration_isStuck);
   assign when_Pipeline_l124_63 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_64 = (! memory_arbitration_isStuck);
+  assign when_Pipeline_l124_65 = (! writeBack_arbitration_isStuck);
+  assign when_Pipeline_l124_66 = (! writeBack_arbitration_isStuck);
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4836,30 +4825,30 @@ module VexRiscv (
   assign when_Pipeline_l154_1 = ((! execute_arbitration_isStuck) && (! execute_arbitration_removeIt));
   assign when_Pipeline_l151_2 = ((! writeBack_arbitration_isStuck) || writeBack_arbitration_removeIt);
   assign when_Pipeline_l154_2 = ((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt));
-  assign when_CsrPlugin_l1264 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_1 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_2 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_3 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_4 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_5 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_6 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_7 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_8 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_9 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_10 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_11 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_12 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_13 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_14 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_15 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_16 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_17 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_18 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_19 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_20 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_21 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_22 = (! execute_arbitration_isStuck);
-  assign when_CsrPlugin_l1264_23 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_1 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_2 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_3 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_4 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_5 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_6 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_7 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_8 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_9 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_10 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_11 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_12 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_13 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_14 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_15 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_16 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_17 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_18 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_19 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_20 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_21 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_22 = (! execute_arbitration_isStuck);
+  assign when_CsrPlugin_l1277_23 = (! execute_arbitration_isStuck);
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
@@ -4897,12 +4886,13 @@ module VexRiscv (
     end
   end
 
+  assign switch_CsrPlugin_l723 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_7[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_CsrPlugin_csrMapping_readDataInit_7[12 : 11] = CsrPlugin_mstatus_MPP;
     end
   end
 
@@ -5032,8 +5022,8 @@ module VexRiscv (
   end
 
   assign CsrPlugin_csrMapping_readDataInit = (((((_zz_CsrPlugin_csrMapping_readDataInit_2 | _zz_CsrPlugin_csrMapping_readDataInit_3) | (_zz_CsrPlugin_csrMapping_readDataInit_4 | _zz_CsrPlugin_csrMapping_readDataInit_5)) | ((_zz_CsrPlugin_csrMapping_readDataInit_25 | _zz_CsrPlugin_csrMapping_readDataInit_6) | (_zz_CsrPlugin_csrMapping_readDataInit_7 | _zz_CsrPlugin_csrMapping_readDataInit_8))) | (((_zz_CsrPlugin_csrMapping_readDataInit_9 | _zz_CsrPlugin_csrMapping_readDataInit_10) | (_zz_CsrPlugin_csrMapping_readDataInit_11 | _zz_CsrPlugin_csrMapping_readDataInit_12)) | ((_zz_CsrPlugin_csrMapping_readDataInit_13 | _zz_CsrPlugin_csrMapping_readDataInit_14) | (_zz_CsrPlugin_csrMapping_readDataInit_15 | _zz_CsrPlugin_csrMapping_readDataInit_16)))) | (((_zz_CsrPlugin_csrMapping_readDataInit_17 | _zz_CsrPlugin_csrMapping_readDataInit_18) | (_zz_CsrPlugin_csrMapping_readDataInit_19 | _zz_CsrPlugin_csrMapping_readDataInit_20)) | ((_zz_CsrPlugin_csrMapping_readDataInit_21 | _zz_CsrPlugin_csrMapping_readDataInit_22) | (_zz_CsrPlugin_csrMapping_readDataInit_23 | _zz_CsrPlugin_csrMapping_readDataInit_24))));
-  assign when_CsrPlugin_l1297 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign when_CsrPlugin_l1302 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
+  assign when_CsrPlugin_l1310 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign when_CsrPlugin_l1315 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
   assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
   assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
@@ -5089,11 +5079,9 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_IBusCachedPlugin_rspCounter;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_DBusCachedPlugin_rspCounter;
       DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_7 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
@@ -5105,6 +5093,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5137,16 +5127,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       end
       IBusCachedPlugin_fetchPc_booted <= 1'b1;
-      if(when_Fetcher_l131) begin
+      if(when_Fetcher_l134) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
       if(IBusCachedPlugin_fetchPc_output_fire_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b1;
       end
-      if(when_Fetcher_l131_1) begin
+      if(when_Fetcher_l134_1) begin
         IBusCachedPlugin_fetchPc_inc <= 1'b0;
       end
-      if(when_Fetcher_l158) begin
+      if(when_Fetcher_l161) begin
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush) begin
@@ -5164,13 +5154,13 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
-      if(when_Fetcher_l329) begin
+      if(when_Fetcher_l332) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
-      if(when_Fetcher_l329_1) begin
+      if(when_Fetcher_l332_1) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5179,7 +5169,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
-      if(when_Fetcher_l329_2) begin
+      if(when_Fetcher_l332_2) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5188,7 +5178,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(when_Fetcher_l329_3) begin
+      if(when_Fetcher_l332_3) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5197,7 +5187,7 @@ module VexRiscv (
       if(IBusCachedPlugin_fetchPc_flushed) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
-      if(when_Fetcher_l329_4) begin
+      if(when_Fetcher_l332_4) begin
         IBusCachedPlugin_injector_nextPcCalc_valids_4 <= IBusCachedPlugin_injector_nextPcCalc_valids_3;
       end
       if(IBusCachedPlugin_fetchPc_flushed) begin
@@ -5220,51 +5210,55 @@ module VexRiscv (
       end
       _zz_7 <= 1'b0;
       HazardSimplePlugin_writeBackBuffer_valid <= HazardSimplePlugin_writeBackWrites_valid;
-      if(when_CsrPlugin_l909) begin
+      CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
+      if(writeBack_arbitration_isFiring) begin
+        CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
+      end
+      if(when_CsrPlugin_l922) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
       end
-      if(when_CsrPlugin_l909_1) begin
+      if(when_CsrPlugin_l922_1) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= (CsrPlugin_exceptionPortCtrl_exceptionValids_decode && (! decode_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
       end
-      if(when_CsrPlugin_l909_2) begin
+      if(when_CsrPlugin_l922_2) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= (CsrPlugin_exceptionPortCtrl_exceptionValids_execute && (! execute_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
       end
-      if(when_CsrPlugin_l909_3) begin
+      if(when_CsrPlugin_l922_3) begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= (CsrPlugin_exceptionPortCtrl_exceptionValids_memory && (! memory_arbitration_isStuck));
       end else begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(when_CsrPlugin_l946) begin
-        if(when_CsrPlugin_l952) begin
+      if(when_CsrPlugin_l959) begin
+        if(when_CsrPlugin_l965) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_1) begin
+        if(when_CsrPlugin_l965_1) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(when_CsrPlugin_l952_2) begin
+        if(when_CsrPlugin_l965_2) begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == `EnvCtrlEnum_binary_sequential_WFI));
+      CsrPlugin_lastStageWasWfi <= (writeBack_arbitration_isFiring && (writeBack_ENV_CTRL == EnvCtrlEnum_WFI));
       if(CsrPlugin_pipelineLiberator_active) begin
-        if(when_CsrPlugin_l980) begin
+        if(when_CsrPlugin_l993) begin
           CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b1;
         end
-        if(when_CsrPlugin_l980_1) begin
+        if(when_CsrPlugin_l993_1) begin
           CsrPlugin_pipelineLiberator_pcValids_1 <= CsrPlugin_pipelineLiberator_pcValids_0;
         end
-        if(when_CsrPlugin_l980_2) begin
+        if(when_CsrPlugin_l993_2) begin
           CsrPlugin_pipelineLiberator_pcValids_2 <= CsrPlugin_pipelineLiberator_pcValids_1;
         end
       end
-      if(when_CsrPlugin_l985) begin
+      if(when_CsrPlugin_l998) begin
         CsrPlugin_pipelineLiberator_pcValids_0 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_1 <= 1'b0;
         CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
@@ -5273,7 +5267,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(when_CsrPlugin_l1019) begin
+      if(when_CsrPlugin_l1032) begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5284,8 +5278,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(when_CsrPlugin_l1064) begin
-        case(switch_CsrPlugin_l1068)
+      if(when_CsrPlugin_l1077) begin
+        case(switch_CsrPlugin_l1081)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -5295,7 +5289,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l952_2,{_zz_when_CsrPlugin_l952_1,_zz_when_CsrPlugin_l952}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_when_CsrPlugin_l965_2,{_zz_when_CsrPlugin_l965_1,_zz_when_CsrPlugin_l965}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if(execute_CfuPlugin_schedule) begin
         execute_CfuPlugin_hold <= 1'b1;
@@ -5306,16 +5300,16 @@ module VexRiscv (
       if(CfuPlugin_bus_cmd_fire) begin
         execute_CfuPlugin_fired <= 1'b1;
       end
-      if(when_CfuPlugin_l171) begin
+      if(when_CfuPlugin_l197) begin
         execute_CfuPlugin_fired <= 1'b0;
       end
       if(CfuPlugin_bus_rsp_valid) begin
         CfuPlugin_bus_rsp_rValid <= 1'b1;
       end
-      if(CfuPlugin_bus_rsp_rsp_ready) begin
+      if(memory_CfuPlugin_rsp_ready) begin
         CfuPlugin_bus_rsp_rValid <= 1'b0;
       end
-      if(when_Pipeline_l124_61) begin
+      if(when_Pipeline_l124_64) begin
         execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
       end
       if(when_Pipeline_l151) begin
@@ -5344,9 +5338,15 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768) begin
         if(execute_CsrPlugin_writeEnable) begin
-          CsrPlugin_mstatus_MPP <= CsrPlugin_csrMapping_writeDataSignal[12 : 11];
           CsrPlugin_mstatus_MPIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mstatus_MIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+          case(switch_CsrPlugin_l723)
+            2'b11 : begin
+              CsrPlugin_mstatus_MPP <= 2'b11;
+            end
+            default : begin
+            end
+          endcase
         end
       end
       if(execute_CsrPlugin_csr_772) begin
@@ -5354,6 +5354,26 @@ module VexRiscv (
           CsrPlugin_mie_MEIE <= CsrPlugin_csrMapping_writeDataSignal[11];
           CsrPlugin_mie_MTIE <= CsrPlugin_csrMapping_writeDataSignal[7];
           CsrPlugin_mie_MSIE <= CsrPlugin_csrMapping_writeDataSignal[3];
+        end
+      end
+      if(execute_CsrPlugin_csr_2816) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2944) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2818) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
+        end
+      end
+      if(execute_CsrPlugin_csr_2946) begin
+        if(execute_CsrPlugin_writeEnable) begin
+          CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_3008) begin
@@ -5410,10 +5430,6 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    CsrPlugin_mcycle <= (CsrPlugin_mcycle + 64'h0000000000000001);
-    if(writeBack_arbitration_isFiring) begin
-      CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
-    end
     if(_zz_when) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
@@ -5426,21 +5442,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(when_CsrPlugin_l946) begin
-      if(when_CsrPlugin_l952) begin
+    if(when_CsrPlugin_l959) begin
+      if(when_CsrPlugin_l965) begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_1) begin
+      if(when_CsrPlugin_l965_1) begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(when_CsrPlugin_l952_2) begin
+      if(when_CsrPlugin_l965_2) begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(when_CsrPlugin_l1019) begin
+    if(when_CsrPlugin_l1032) begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5558,186 +5574,195 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if(when_Pipeline_l124_26) begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_HAS_SIDE_EFFECT <= decode_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_27) begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      execute_to_memory_HAS_SIDE_EFFECT <= execute_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_28) begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
+      memory_to_writeBack_HAS_SIDE_EFFECT <= memory_HAS_SIDE_EFFECT;
     end
     if(when_Pipeline_l124_29) begin
-      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if(when_Pipeline_l124_30) begin
-      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if(when_Pipeline_l124_31) begin
-      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_decode_to_execute_ALU_BITWISE_CTRL;
     end
     if(when_Pipeline_l124_32) begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SHIFT_CTRL <= _zz_decode_to_execute_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_33) begin
-      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
+      execute_to_memory_SHIFT_CTRL <= _zz_execute_to_memory_SHIFT_CTRL;
     end
     if(when_Pipeline_l124_34) begin
-      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
+      decode_to_execute_BRANCH_CTRL <= _zz_decode_to_execute_BRANCH_CTRL;
     end
     if(when_Pipeline_l124_35) begin
-      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if(when_Pipeline_l124_36) begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_ENV_CTRL <= _zz_decode_to_execute_ENV_CTRL;
     end
     if(when_Pipeline_l124_37) begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_ENV_CTRL <= _zz_execute_to_memory_ENV_CTRL;
     end
     if(when_Pipeline_l124_38) begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      memory_to_writeBack_ENV_CTRL <= _zz_memory_to_writeBack_ENV_CTRL;
     end
     if(when_Pipeline_l124_39) begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
     end
     if(when_Pipeline_l124_40) begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if(when_Pipeline_l124_41) begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if(when_Pipeline_l124_42) begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if(when_Pipeline_l124_43) begin
-      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if(when_Pipeline_l124_44) begin
-      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if(when_Pipeline_l124_45) begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if(when_Pipeline_l124_46) begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
     end
     if(when_Pipeline_l124_47) begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
     end
     if(when_Pipeline_l124_48) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if(when_Pipeline_l124_49) begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if(when_Pipeline_l124_50) begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
     end
     if(when_Pipeline_l124_52) begin
-      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if(when_Pipeline_l124_53) begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if(when_Pipeline_l124_54) begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
+      execute_to_memory_MEMORY_STORE_DATA_RF <= execute_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_55) begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_MEMORY_STORE_DATA_RF <= memory_MEMORY_STORE_DATA_RF;
     end
     if(when_Pipeline_l124_56) begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_decode_RS2;
     end
     if(when_Pipeline_l124_57) begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_decode_RS2_1;
     end
     if(when_Pipeline_l124_58) begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
     if(when_Pipeline_l124_59) begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if(when_Pipeline_l124_60) begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if(when_Pipeline_l124_61) begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if(when_Pipeline_l124_62) begin
-      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
     end
     if(when_Pipeline_l124_63) begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if(when_Pipeline_l124_65) begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+    end
+    if(when_Pipeline_l124_66) begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
-    if(when_CsrPlugin_l1264) begin
+    if(when_CsrPlugin_l1277) begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
     end
-    if(when_CsrPlugin_l1264_1) begin
+    if(when_CsrPlugin_l1277_1) begin
       execute_CsrPlugin_csr_3857 <= (decode_INSTRUCTION[31 : 20] == 12'hf11);
     end
-    if(when_CsrPlugin_l1264_2) begin
+    if(when_CsrPlugin_l1277_2) begin
       execute_CsrPlugin_csr_3858 <= (decode_INSTRUCTION[31 : 20] == 12'hf12);
     end
-    if(when_CsrPlugin_l1264_3) begin
+    if(when_CsrPlugin_l1277_3) begin
       execute_CsrPlugin_csr_3859 <= (decode_INSTRUCTION[31 : 20] == 12'hf13);
     end
-    if(when_CsrPlugin_l1264_4) begin
+    if(when_CsrPlugin_l1277_4) begin
       execute_CsrPlugin_csr_3860 <= (decode_INSTRUCTION[31 : 20] == 12'hf14);
     end
-    if(when_CsrPlugin_l1264_5) begin
+    if(when_CsrPlugin_l1277_5) begin
       execute_CsrPlugin_csr_769 <= (decode_INSTRUCTION[31 : 20] == 12'h301);
     end
-    if(when_CsrPlugin_l1264_6) begin
+    if(when_CsrPlugin_l1277_6) begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
     end
-    if(when_CsrPlugin_l1264_7) begin
+    if(when_CsrPlugin_l1277_7) begin
       execute_CsrPlugin_csr_836 <= (decode_INSTRUCTION[31 : 20] == 12'h344);
     end
-    if(when_CsrPlugin_l1264_8) begin
+    if(when_CsrPlugin_l1277_8) begin
       execute_CsrPlugin_csr_772 <= (decode_INSTRUCTION[31 : 20] == 12'h304);
     end
-    if(when_CsrPlugin_l1264_9) begin
+    if(when_CsrPlugin_l1277_9) begin
       execute_CsrPlugin_csr_773 <= (decode_INSTRUCTION[31 : 20] == 12'h305);
     end
-    if(when_CsrPlugin_l1264_10) begin
+    if(when_CsrPlugin_l1277_10) begin
       execute_CsrPlugin_csr_833 <= (decode_INSTRUCTION[31 : 20] == 12'h341);
     end
-    if(when_CsrPlugin_l1264_11) begin
+    if(when_CsrPlugin_l1277_11) begin
       execute_CsrPlugin_csr_832 <= (decode_INSTRUCTION[31 : 20] == 12'h340);
     end
-    if(when_CsrPlugin_l1264_12) begin
+    if(when_CsrPlugin_l1277_12) begin
       execute_CsrPlugin_csr_834 <= (decode_INSTRUCTION[31 : 20] == 12'h342);
     end
-    if(when_CsrPlugin_l1264_13) begin
+    if(when_CsrPlugin_l1277_13) begin
       execute_CsrPlugin_csr_835 <= (decode_INSTRUCTION[31 : 20] == 12'h343);
     end
-    if(when_CsrPlugin_l1264_14) begin
+    if(when_CsrPlugin_l1277_14) begin
       execute_CsrPlugin_csr_2816 <= (decode_INSTRUCTION[31 : 20] == 12'hb00);
     end
-    if(when_CsrPlugin_l1264_15) begin
+    if(when_CsrPlugin_l1277_15) begin
       execute_CsrPlugin_csr_2944 <= (decode_INSTRUCTION[31 : 20] == 12'hb80);
     end
-    if(when_CsrPlugin_l1264_16) begin
+    if(when_CsrPlugin_l1277_16) begin
       execute_CsrPlugin_csr_2818 <= (decode_INSTRUCTION[31 : 20] == 12'hb02);
     end
-    if(when_CsrPlugin_l1264_17) begin
+    if(when_CsrPlugin_l1277_17) begin
       execute_CsrPlugin_csr_2946 <= (decode_INSTRUCTION[31 : 20] == 12'hb82);
     end
-    if(when_CsrPlugin_l1264_18) begin
+    if(when_CsrPlugin_l1277_18) begin
       execute_CsrPlugin_csr_3072 <= (decode_INSTRUCTION[31 : 20] == 12'hc00);
     end
-    if(when_CsrPlugin_l1264_19) begin
+    if(when_CsrPlugin_l1277_19) begin
       execute_CsrPlugin_csr_3200 <= (decode_INSTRUCTION[31 : 20] == 12'hc80);
     end
-    if(when_CsrPlugin_l1264_20) begin
+    if(when_CsrPlugin_l1277_20) begin
       execute_CsrPlugin_csr_3074 <= (decode_INSTRUCTION[31 : 20] == 12'hc02);
     end
-    if(when_CsrPlugin_l1264_21) begin
+    if(when_CsrPlugin_l1277_21) begin
       execute_CsrPlugin_csr_3202 <= (decode_INSTRUCTION[31 : 20] == 12'hc82);
     end
-    if(when_CsrPlugin_l1264_22) begin
+    if(when_CsrPlugin_l1277_22) begin
       execute_CsrPlugin_csr_3008 <= (decode_INSTRUCTION[31 : 20] == 12'hbc0);
     end
-    if(when_CsrPlugin_l1264_23) begin
+    if(when_CsrPlugin_l1277_23) begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
     if(execute_CsrPlugin_csr_836) begin
@@ -5772,26 +5797,6 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    if(execute_CsrPlugin_csr_2816) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2944) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_mcycle[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2818) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[31 : 0] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_2946) begin
-      if(execute_CsrPlugin_writeEnable) begin
-        CsrPlugin_minstret[63 : 32] <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
-      end
-    end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
   end
@@ -5822,6 +5827,7 @@ module DataCache (
   input               io_cpu_memory_mmuRsp_bypassTranslation,
   input               io_cpu_writeBack_isValid,
   input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isFiring,
   input               io_cpu_writeBack_isUser,
   output reg          io_cpu_writeBack_haltIt,
   output              io_cpu_writeBack_isWrite,
@@ -5845,6 +5851,8 @@ module DataCache (
   output reg          io_cpu_redo,
   input               io_cpu_flush_valid,
   output              io_cpu_flush_ready,
+  input               io_cpu_flush_payload_singleLine,
+  input      [8:0]    io_cpu_flush_payload_lineId,
   output reg          io_mem_cmd_valid,
   input               io_mem_cmd_ready,
   output reg          io_mem_cmd_payload_wr,
@@ -5861,6 +5869,7 @@ module DataCache (
   input               clk,
   input               reset
 );
+
   reg        [21:0]   _zz_ways_0_tags_port0;
   reg        [31:0]   _zz_ways_0_data_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
@@ -5900,40 +5909,40 @@ module DataCache (
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
-  wire                when_DataCache_l634;
-  wire                when_DataCache_l637;
-  wire                when_DataCache_l656;
+  wire                when_DataCache_l642;
+  wire                when_DataCache_l645;
+  wire                when_DataCache_l664;
   wire                rspSync;
   wire                rspLast;
   reg                 memCmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_DataCache_l678;
+  wire                when_DataCache_l686;
   reg        [3:0]    _zz_stage0_mask;
   wire       [3:0]    stage0_mask;
   wire       [0:0]    stage0_dataColisions;
   wire       [0:0]    stage0_wayInvalidate;
   wire                stage0_isAmo;
-  wire                when_DataCache_l763;
+  wire                when_DataCache_l771;
   reg                 stageA_request_wr;
   reg        [1:0]    stageA_request_size;
   reg                 stageA_request_totalyConsistent;
-  wire                when_DataCache_l763_1;
+  wire                when_DataCache_l771_1;
   reg        [3:0]    stageA_mask;
   wire                stageA_isAmo;
   wire                stageA_isLrsc;
   wire       [0:0]    stageA_wayHits;
-  wire                when_DataCache_l763_2;
+  wire                when_DataCache_l771_2;
   reg        [0:0]    stageA_wayInvalidate;
-  wire                when_DataCache_l763_3;
+  wire                when_DataCache_l771_3;
   reg        [0:0]    stage0_dataColisions_regNextWhen;
   wire       [0:0]    _zz_stageA_dataColisions;
   wire       [0:0]    stageA_dataColisions;
-  wire                when_DataCache_l814;
+  wire                when_DataCache_l822;
   reg                 stageB_request_wr;
   reg        [1:0]    stageB_request_size;
   reg                 stageB_request_totalyConsistent;
   reg                 stageB_mmuRspFreeze;
-  wire                when_DataCache_l816;
+  wire                when_DataCache_l824;
   reg        [31:0]   stageB_mmuRsp_physicalAddress;
   reg                 stageB_mmuRsp_isIoAccess;
   reg                 stageB_mmuRsp_isPaging;
@@ -5943,33 +5952,33 @@ module DataCache (
   reg                 stageB_mmuRsp_exception;
   reg                 stageB_mmuRsp_refilling;
   reg                 stageB_mmuRsp_bypassTranslation;
-  wire                when_DataCache_l813;
+  wire                when_DataCache_l821;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
   reg        [19:0]   stageB_tagsReadRsp_0_address;
-  wire                when_DataCache_l813_1;
+  wire                when_DataCache_l821_1;
   reg        [31:0]   stageB_dataReadRsp_0;
-  wire                when_DataCache_l812;
+  wire                when_DataCache_l820;
   reg        [0:0]    stageB_wayInvalidate;
   wire                stageB_consistancyHazard;
-  wire                when_DataCache_l812_1;
+  wire                when_DataCache_l820_1;
   reg        [0:0]    stageB_dataColisions;
-  wire                when_DataCache_l812_2;
+  wire                when_DataCache_l820_2;
   reg                 stageB_unaligned;
-  wire                when_DataCache_l812_3;
+  wire                when_DataCache_l820_3;
   reg        [0:0]    stageB_waysHitsBeforeInvalidate;
   wire       [0:0]    stageB_waysHits;
   wire                stageB_waysHit;
   wire       [31:0]   stageB_dataMux;
-  wire                when_DataCache_l812_4;
+  wire                when_DataCache_l820_4;
   reg        [3:0]    stageB_mask;
   reg                 stageB_loaderValid;
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
   reg        [9:0]    stageB_flusher_counter;
-  wire                when_DataCache_l842;
-  wire                when_DataCache_l848;
+  wire                when_DataCache_l850;
+  wire                when_DataCache_l856;
   reg                 stageB_flusher_start;
   wire                stageB_isAmo;
   wire                stageB_isAmoCached;
@@ -5977,18 +5986,18 @@ module DataCache (
   wire                stageB_isExternalAmo;
   wire       [31:0]   stageB_requestDataBypass;
   reg                 stageB_cpuWriteToCache;
-  wire                when_DataCache_l911;
+  wire                when_DataCache_l926;
   wire                stageB_badPermissions;
   wire                stageB_loadStoreFault;
   wire                stageB_bypassCache;
-  wire                when_DataCache_l980;
-  wire                when_DataCache_l989;
-  wire                when_DataCache_l994;
-  wire                when_DataCache_l1005;
-  wire                when_DataCache_l1017;
-  wire                when_DataCache_l976;
-  wire                when_DataCache_l1051;
-  wire                when_DataCache_l1060;
+  wire                when_DataCache_l995;
+  wire                when_DataCache_l1004;
+  wire                when_DataCache_l1009;
+  wire                when_DataCache_l1020;
+  wire                when_DataCache_l1032;
+  wire                when_DataCache_l991;
+  wire                when_DataCache_l1066;
+  wire                when_DataCache_l1075;
   reg                 loader_valid;
   reg                 loader_counter_willIncrement;
   wire                loader_counter_willClear;
@@ -6000,17 +6009,17 @@ module DataCache (
   reg                 loader_error;
   wire                loader_kill;
   reg                 loader_killReg;
-  wire                when_DataCache_l1075;
+  wire                when_DataCache_l1090;
   wire                loader_done;
-  wire                when_DataCache_l1103;
+  wire                when_DataCache_l1118;
   reg                 loader_valid_regNext;
-  wire                when_DataCache_l1107;
-  wire                when_DataCache_l1110;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:511];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  wire                when_DataCache_l1122;
+  wire                when_DataCache_l1125;
+  (* no_rw_check , ram_style = "block" *) reg [21:0] ways_0_tags [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* no_rw_check , ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6062,14 +6071,14 @@ module DataCache (
 
   always @(*) begin
     _zz_1 = 1'b0;
-    if(when_DataCache_l637) begin
+    if(when_DataCache_l645) begin
       _zz_1 = 1'b1;
     end
   end
 
   always @(*) begin
     _zz_2 = 1'b0;
-    if(when_DataCache_l634) begin
+    if(when_DataCache_l642) begin
       _zz_2 = 1'b1;
     end
   end
@@ -6083,42 +6092,42 @@ module DataCache (
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
-  assign when_DataCache_l634 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
-  assign when_DataCache_l637 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
+  assign when_DataCache_l642 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
+  assign when_DataCache_l645 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
   always @(*) begin
     tagsReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     tagsReadCmd_payload = 9'bxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       tagsReadCmd_payload = io_cpu_execute_address[11 : 3];
     end
   end
 
   always @(*) begin
     dataReadCmd_valid = 1'b0;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_valid = 1'b1;
     end
   end
 
   always @(*) begin
     dataReadCmd_payload = 10'bxxxxxxxxxx;
-    if(when_DataCache_l656) begin
+    if(when_DataCache_l664) begin
       dataReadCmd_payload = io_cpu_execute_address[11 : 2];
     end
   end
 
   always @(*) begin
     tagsWriteCmd_valid = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_valid = 1'b1;
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       tagsWriteCmd_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6128,7 +6137,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_way = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_way = 1'b1;
     end
     if(loader_done) begin
@@ -6138,7 +6147,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_address = 9'bxxxxxxxxx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_address = stageB_flusher_counter[8:0];
     end
     if(loader_done) begin
@@ -6148,7 +6157,7 @@ module DataCache (
 
   always @(*) begin
     tagsWriteCmd_payload_data_valid = 1'bx;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       tagsWriteCmd_payload_data_valid = 1'b0;
     end
     if(loader_done) begin
@@ -6173,14 +6182,14 @@ module DataCache (
   always @(*) begin
     dataWriteCmd_valid = 1'b0;
     if(stageB_cpuWriteToCache) begin
-      if(when_DataCache_l911) begin
+      if(when_DataCache_l926) begin
         dataWriteCmd_valid = 1'b1;
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       dataWriteCmd_valid = 1'b0;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_valid = 1'b1;
     end
   end
@@ -6190,7 +6199,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_way = stageB_waysHits;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_way = loader_waysAllocator;
     end
   end
@@ -6200,7 +6209,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 3],loader_counter_value};
     end
   end
@@ -6210,7 +6219,7 @@ module DataCache (
     if(stageB_cpuWriteToCache) begin
       dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_data = io_mem_rsp_payload_data;
     end
   end
@@ -6223,15 +6232,15 @@ module DataCache (
         dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
       end
     end
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       dataWriteCmd_payload_mask = 4'b1111;
     end
   end
 
-  assign when_DataCache_l656 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign when_DataCache_l664 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
   always @(*) begin
     io_cpu_execute_haltIt = 1'b0;
-    if(when_DataCache_l842) begin
+    if(when_DataCache_l850) begin
       io_cpu_execute_haltIt = 1'b1;
     end
   end
@@ -6239,7 +6248,7 @@ module DataCache (
   assign rspSync = 1'b1;
   assign rspLast = 1'b1;
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign when_DataCache_l678 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l686 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     _zz_stage0_mask = 4'bxxxx;
     case(io_cpu_execute_args_size)
@@ -6261,42 +6270,42 @@ module DataCache (
   assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_stage0_dataColisions)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign stage0_isAmo = 1'b0;
-  assign when_DataCache_l763 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_1 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
   assign stageA_isAmo = 1'b0;
   assign stageA_isLrsc = 1'b0;
   assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign when_DataCache_l763_2 = (! io_cpu_memory_isStuck);
-  assign when_DataCache_l763_3 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_2 = (! io_cpu_memory_isStuck);
+  assign when_DataCache_l771_3 = (! io_cpu_memory_isStuck);
   assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz__zz_stageA_dataColisions)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
-  assign when_DataCache_l814 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l822 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_mmuRspFreeze = 1'b0;
-    if(when_DataCache_l1110) begin
+    if(when_DataCache_l1125) begin
       stageB_mmuRspFreeze = 1'b1;
     end
   end
 
-  assign when_DataCache_l816 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
-  assign when_DataCache_l813 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l813_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l824 = ((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze));
+  assign when_DataCache_l821 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l821_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820 = (! io_cpu_writeBack_isStuck);
   assign stageB_consistancyHazard = 1'b0;
-  assign when_DataCache_l812_1 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_2 = (! io_cpu_writeBack_isStuck);
-  assign when_DataCache_l812_3 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_1 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_2 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_3 = (! io_cpu_writeBack_isStuck);
   assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
-  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_waysHit = (|stageB_waysHits);
   assign stageB_dataMux = stageB_dataReadRsp_0;
-  assign when_DataCache_l812_4 = (! io_cpu_writeBack_isStuck);
+  assign when_DataCache_l820_4 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
     stageB_loaderValid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             if(io_mem_cmd_ready) begin
               stageB_loaderValid = 1'b1;
             end
@@ -6304,7 +6313,7 @@ module DataCache (
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       stageB_loaderValid = 1'b0;
     end
   end
@@ -6314,27 +6323,27 @@ module DataCache (
     io_cpu_writeBack_haltIt = 1'b1;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
-          if(when_DataCache_l980) begin
+        if(when_DataCache_l991) begin
+          if(when_DataCache_l995) begin
             io_cpu_writeBack_haltIt = 1'b0;
           end
         end else begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l994) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1009) begin
               io_cpu_writeBack_haltIt = 1'b0;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_cpu_writeBack_haltIt = 1'b0;
     end
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l842 = (! stageB_flusher_counter[9]);
-  assign when_DataCache_l848 = (! stageB_flusher_hold);
+  assign when_DataCache_l850 = (! stageB_flusher_counter[9]);
+  assign when_DataCache_l856 = (! stageB_flusher_hold);
   assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[9]);
   assign stageB_isAmo = 1'b0;
   assign stageB_isAmoCached = 1'b0;
@@ -6345,8 +6354,8 @@ module DataCache (
     stageB_cpuWriteToCache = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
             stageB_cpuWriteToCache = 1'b1;
           end
         end
@@ -6354,26 +6363,26 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l911 = (stageB_request_wr && stageB_waysHit);
+  assign when_DataCache_l926 = (stageB_request_wr && stageB_waysHit);
   assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
   assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
   always @(*) begin
     io_cpu_redo = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(when_DataCache_l989) begin
-            if(when_DataCache_l1005) begin
+        if(!when_DataCache_l991) begin
+          if(when_DataCache_l1004) begin
+            if(when_DataCache_l1020) begin
               io_cpu_redo = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1060) begin
+    if(when_DataCache_l1075) begin
       io_cpu_redo = 1'b1;
     end
-    if(when_DataCache_l1107) begin
+    if(when_DataCache_l1122) begin
       io_cpu_redo = 1'b1;
     end
   end
@@ -6394,22 +6403,22 @@ module DataCache (
     io_mem_cmd_valid = 1'b0;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(when_DataCache_l976) begin
+        if(when_DataCache_l991) begin
           io_mem_cmd_valid = (! memCmdSent);
         end else begin
-          if(when_DataCache_l989) begin
+          if(when_DataCache_l1004) begin
             if(stageB_request_wr) begin
               io_mem_cmd_valid = 1'b1;
             end
           end else begin
-            if(when_DataCache_l1017) begin
+            if(when_DataCache_l1032) begin
               io_mem_cmd_valid = 1'b1;
             end
           end
         end
       end
     end
-    if(when_DataCache_l1051) begin
+    if(when_DataCache_l1066) begin
       io_mem_cmd_valid = 1'b0;
     end
   end
@@ -6418,8 +6427,8 @@ module DataCache (
     io_mem_cmd_payload_address = stageB_mmuRsp_physicalAddress;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_address[2 : 0] = 3'b000;
           end
         end
@@ -6432,8 +6441,8 @@ module DataCache (
     io_mem_cmd_payload_wr = stageB_request_wr;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_wr = 1'b0;
           end
         end
@@ -6448,8 +6457,8 @@ module DataCache (
     io_mem_cmd_payload_size = stageB_request_size;
     if(io_cpu_writeBack_isValid) begin
       if(!stageB_isExternalAmo) begin
-        if(!when_DataCache_l976) begin
-          if(!when_DataCache_l989) begin
+        if(!when_DataCache_l991) begin
+          if(!when_DataCache_l1004) begin
             io_mem_cmd_payload_size = 2'b11;
           end
         end
@@ -6459,12 +6468,12 @@ module DataCache (
 
   assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
   assign io_cpu_writeBack_keepMemRspData = 1'b0;
-  assign when_DataCache_l980 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
-  assign when_DataCache_l989 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
-  assign when_DataCache_l994 = ((! stageB_request_wr) || io_mem_cmd_ready);
-  assign when_DataCache_l1005 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
-  assign when_DataCache_l1017 = (! memCmdSent);
-  assign when_DataCache_l976 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign when_DataCache_l995 = ((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready);
+  assign when_DataCache_l1004 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign when_DataCache_l1009 = ((! stageB_request_wr) || io_mem_cmd_ready);
+  assign when_DataCache_l1020 = (((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign when_DataCache_l1032 = (! memCmdSent);
+  assign when_DataCache_l991 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
   always @(*) begin
     if(stageB_bypassCache) begin
       io_cpu_writeBack_data = stageB_ioMemRspMuxed;
@@ -6473,11 +6482,11 @@ module DataCache (
     end
   end
 
-  assign when_DataCache_l1051 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign when_DataCache_l1060 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
+  assign when_DataCache_l1066 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign when_DataCache_l1075 = (io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard));
   always @(*) begin
     loader_counter_willIncrement = 1'b0;
-    if(when_DataCache_l1075) begin
+    if(when_DataCache_l1090) begin
       loader_counter_willIncrement = 1'b1;
     end
   end
@@ -6493,12 +6502,12 @@ module DataCache (
   end
 
   assign loader_kill = 1'b0;
-  assign when_DataCache_l1075 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign when_DataCache_l1090 = ((loader_valid && io_mem_rsp_valid) && rspLast);
   assign loader_done = loader_counter_willOverflow;
-  assign when_DataCache_l1103 = (! loader_valid);
-  assign when_DataCache_l1107 = (loader_valid && (! loader_valid_regNext));
+  assign when_DataCache_l1118 = (! loader_valid);
+  assign when_DataCache_l1122 = (loader_valid && (! loader_valid_regNext));
   assign io_cpu_execute_refilling = loader_valid;
-  assign when_DataCache_l1110 = (stageB_loaderValid || loader_valid);
+  assign when_DataCache_l1125 = (stageB_loaderValid || loader_valid);
   always @(posedge clk) begin
     tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
     tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
@@ -6506,26 +6515,26 @@ module DataCache (
     tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
     tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
     tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if(when_DataCache_l763) begin
+    if(when_DataCache_l771) begin
       stageA_request_wr <= io_cpu_execute_args_wr;
       stageA_request_size <= io_cpu_execute_args_size;
       stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
     end
-    if(when_DataCache_l763_1) begin
+    if(when_DataCache_l771_1) begin
       stageA_mask <= stage0_mask;
     end
-    if(when_DataCache_l763_2) begin
+    if(when_DataCache_l771_2) begin
       stageA_wayInvalidate <= stage0_wayInvalidate;
     end
-    if(when_DataCache_l763_3) begin
+    if(when_DataCache_l771_3) begin
       stage0_dataColisions_regNextWhen <= stage0_dataColisions;
     end
-    if(when_DataCache_l814) begin
+    if(when_DataCache_l822) begin
       stageB_request_wr <= stageA_request_wr;
       stageB_request_size <= stageA_request_size;
       stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
     end
-    if(when_DataCache_l816) begin
+    if(when_DataCache_l824) begin
       stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
       stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
       stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
@@ -6536,27 +6545,27 @@ module DataCache (
       stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
       stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
     end
-    if(when_DataCache_l813) begin
+    if(when_DataCache_l821) begin
       stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
       stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
       stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
     end
-    if(when_DataCache_l813_1) begin
+    if(when_DataCache_l821_1) begin
       stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
     end
-    if(when_DataCache_l812) begin
+    if(when_DataCache_l820) begin
       stageB_wayInvalidate <= stageA_wayInvalidate;
     end
-    if(when_DataCache_l812_1) begin
+    if(when_DataCache_l820_1) begin
       stageB_dataColisions <= stageA_dataColisions;
     end
-    if(when_DataCache_l812_2) begin
+    if(when_DataCache_l820_2) begin
       stageB_unaligned <= ({((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)),((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0))} != 2'b00);
     end
-    if(when_DataCache_l812_3) begin
+    if(when_DataCache_l820_3) begin
       stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
     end
-    if(when_DataCache_l812_4) begin
+    if(when_DataCache_l820_4) begin
       stageB_mask <= stageA_mask;
     end
     loader_valid_regNext <= loader_valid;
@@ -6577,28 +6586,34 @@ module DataCache (
       if(io_mem_cmd_fire) begin
         memCmdSent <= 1'b1;
       end
-      if(when_DataCache_l678) begin
+      if(when_DataCache_l686) begin
         memCmdSent <= 1'b0;
       end
       if(io_cpu_flush_ready) begin
         stageB_flusher_waitDone <= 1'b0;
       end
-      if(when_DataCache_l842) begin
-        if(when_DataCache_l848) begin
+      if(when_DataCache_l850) begin
+        if(when_DataCache_l856) begin
           stageB_flusher_counter <= (stageB_flusher_counter + 10'h001);
+          if(io_cpu_flush_payload_singleLine) begin
+            stageB_flusher_counter[9] <= 1'b1;
+          end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
         stageB_flusher_counter <= 10'h0;
+        if(io_cpu_flush_payload_singleLine) begin
+          stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
+        end
       end
       `ifndef SYNTHESIS
         `ifdef FORMAL
-          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))); // DataCache.scala:L1077
         `else
           if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-            $display("ERROR writeBack stuck by another plugin is not allowed");
+            $display("ERROR writeBack stuck by another plugin is not allowed"); // DataCache.scala:L1077
           end
         `endif
       `endif
@@ -6609,7 +6624,7 @@ module DataCache (
       if(loader_kill) begin
         loader_killReg <= 1'b1;
       end
-      if(when_DataCache_l1075) begin
+      if(when_DataCache_l1090) begin
         loader_error <= (loader_error || io_mem_rsp_payload_error);
       end
       if(loader_done) begin
@@ -6617,7 +6632,7 @@ module DataCache (
         loader_error <= 1'b0;
         loader_killReg <= 1'b0;
       end
-      if(when_DataCache_l1103) begin
+      if(when_DataCache_l1118) begin
         loader_waysAllocator <= _zz_loader_waysAllocator[0:0];
       end
     end
@@ -6668,6 +6683,7 @@ module InstructionCache (
   input               clk,
   input               reset
 );
+
   reg        [31:0]   _zz_banks_0_port1;
   reg        [22:0]   _zz_ways_0_tags_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
@@ -6685,7 +6701,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l357;
+  wire                when_Utils_l515;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6731,8 +6747,8 @@ module InstructionCache (
   reg                 decodeStage_hit_valid;
   wire                when_InstructionCache_l459_2;
   reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+  (* no_rw_check , ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* no_rw_check , ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
 
   assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @(posedge clk) begin
@@ -6802,10 +6818,10 @@ module InstructionCache (
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
   assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l357 = (! lineLoader_valid);
+  assign when_Utils_l515 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l357) begin
+    if(when_Utils_l515) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -6833,7 +6849,7 @@ module InstructionCache (
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
   assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
   assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
   assign fetchStage_hit_word = fetchStage_hit_data;


### PR DESCRIPTION
VexRiscv build script updated and all verilog files rebuilt.  Makefile fixed (added missing verilog targets).

Now at tip of master of the VexRiscv.  The issue of #596 is avoided by configuring the CfuPlugin with "withEnable = false".     See also https://github.com/SpinalHDL/VexRiscv/issues/258.
    
This also incorporates a change to add the attribute   `(* no_rw_check *)`  on the block memories in VexRiscv --     regfile and caches.   This prevents Yosys from adding circuitry for a check that we don't need, according to Charles P.    Having the check consumes resources, particularly noticeable     when targetting ice40.
    
Signed-off-by: Tim Callahan <tcal@google.com>