### PR TITLE
Re-enable L2 cache size option `--l2-size`.

### DIFF
--- a/soc/board_specific_workflows/digilent_arty.py
+++ b/soc/board_specific_workflows/digilent_arty.py
@@ -61,7 +61,7 @@ class DigilentArtySoCWorkflow(general.GeneralSoCWorkflow):
 
     def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
         """Runs make_soc with jtagbone disabled."""
-        return super().make_soc(l2_size=self.args.variant,
+        return super().make_soc(l2_size=self.args.l2_size,
                                 variant=self.args.variant,
                                 with_jtagbone=False,
                                 **kwargs)

--- a/soc/board_specific_workflows/digilent_arty.py
+++ b/soc/board_specific_workflows/digilent_arty.py
@@ -60,8 +60,8 @@ class DigilentArtySoCWorkflow(general.GeneralSoCWorkflow):
         super().__init__(args, soc_constructor, builder_constructor)
 
     def make_soc(self, **kwargs) -> litex_soc.LiteXSoC:
-        """Runs make_soc with a l2_size parameter and jtagbone disabled."""
-        return super().make_soc(l2_size=8 * 1024,
+        """Runs make_soc with jtagbone disabled."""
+        return super().make_soc(l2_size=self.args.variant,
                                 variant=self.args.variant,
                                 with_jtagbone=False,
                                 **kwargs)

--- a/soc/board_specific_workflows/test_digilent_arty.py
+++ b/soc/board_specific_workflows/test_digilent_arty.py
@@ -50,7 +50,7 @@ class DigilentArtySoCWorkflowTest(unittest.TestCase):
         workflow.make_soc()
         kwargs = self.soc_constructor.call_args.kwargs
 
-        self.assertEqual(kwargs['l2_size'], 8 * 1024)
+        self.assertEqual(kwargs['l2_size'], workflow.args.l2_size)
         self.assertFalse(kwargs['with_jtagbone'], False)
         self.assertEqual(kwargs['variant'], workflow.args.variant)
 


### PR DESCRIPTION
It had been disabled (L2 cache size had been forced to 8kB).

Signed-off-by: Tim Callahan <tcal@google.com>