### PR TITLE
Add 'donut' demo from LiteX.

### DIFF
--- a/common/src/main.c
+++ b/common/src/main.c
@@ -36,6 +36,9 @@
 #include "models/models.h"
 #endif
 
+void donut(void);
+
+
 #ifdef PLATFORM_sim
 static void trace_sim() {
   puts("Beginning trace");
@@ -63,6 +66,9 @@ static struct Menu MENU = {
         MENU_ITEM('6', "Benchmarks", do_benchmarks_menu),
         MENU_ITEM('7', "Util Tests", do_util_tests_menu),
         MENU_ITEM('8', "Embench IoT", embench_menu),
+#ifdef DONUT_DEMO
+        MENU_ITEM('d', "Donut demo", donut),
+#endif
 #ifdef SPIFLASH_BASE
         MENU_ITEM('9', "SPI Flash Debugging", spiflash_menu),
 #endif

--- a/common/src/main.c
+++ b/common/src/main.c
@@ -22,6 +22,7 @@
 
 #include "base.h"
 #include "benchmarks.h"
+#include "donut.h"
 #include "fb_util.h"
 #include "functional_cfu_tests.h"
 #include "instruction_handler.h"
@@ -35,9 +36,6 @@
 #ifndef SKIP_TFLM
 #include "models/models.h"
 #endif
-
-void donut(void);
-
 
 #ifdef PLATFORM_sim
 static void trace_sim() {

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -119,6 +119,7 @@ RVI_DIR            := $(COMMON_DIR)/renode-verilator-integration
 COMMON_FILES       := $(shell find $(COMMON_DIR) -type f)
 MLCOMMONS_SRC_DIR  := $(CFU_ROOT)/third_party/mlcommons
 SAXON_SRC_DIR      := $(CFU_ROOT)/third_party/SaxonSoc
+DONUT_SRC_DIR      := $(CFU_ROOT)/third_party/litex-donut
 RENODE_DIR         := $(CFU_ROOT)/third_party/renode
 VIL_DIR            := $(RENODE_DIR)/verilator-integration-library
 LITEX_RENODE_DIR   := $(CFU_ROOT)/third_party/python/litex-renode
@@ -285,6 +286,7 @@ build-dir: $(BUILD_DIR)/src tflite-micro-src $(BUILD_DIR_EXTRA_DEP)
 	$(COPY) $(COMMON_DIR)/*              $(BUILD_DIR)
 	$(COPY) $(MLCOMMONS_SRC_DIR)/*       $(BUILD_DIR)/src
 	$(COPY) $(SAXON_SRC_DIR)/riscv.h     $(BUILD_DIR)/src
+	$(COPY) $(DONUT_SRC_DIR)/donut.c     $(BUILD_DIR)/src
 	$(COPY) $(SRC_DIR)/*                 $(BUILD_DIR)/src
 	$(RM)			             $(BUILD_DIR)/_*
 ifdef SKIP_TFLM

--- a/proj/proj.mk
+++ b/proj/proj.mk
@@ -286,7 +286,7 @@ build-dir: $(BUILD_DIR)/src tflite-micro-src $(BUILD_DIR_EXTRA_DEP)
 	$(COPY) $(COMMON_DIR)/*              $(BUILD_DIR)
 	$(COPY) $(MLCOMMONS_SRC_DIR)/*       $(BUILD_DIR)/src
 	$(COPY) $(SAXON_SRC_DIR)/riscv.h     $(BUILD_DIR)/src
-	$(COPY) $(DONUT_SRC_DIR)/donut.c     $(BUILD_DIR)/src
+	$(COPY) $(DONUT_SRC_DIR)/donut.*     $(BUILD_DIR)/src
 	$(COPY) $(SRC_DIR)/*                 $(BUILD_DIR)/src
 	$(RM)			             $(BUILD_DIR)/_*
 ifdef SKIP_TFLM

--- a/proj/proj_template/Makefile
+++ b/proj/proj_template/Makefile
@@ -39,4 +39,8 @@ DEFINES += INCLUDE_MODEL_PDTI8
 # Uncomment to include all TFLM examples (pdti8, micro_speech, magic_wand)
 #DEFINES += INCLUDE_ALL_TFLM_EXAMPLES
 
+# Uncomment this line to include the ASCII animated donut demo.
+DEFINES += DONUT_DEMO
+
+
 include ../proj.mk

--- a/proj/proj_template_v/Makefile
+++ b/proj/proj_template_v/Makefile
@@ -39,4 +39,7 @@ DEFINES += INCLUDE_MODEL_PDTI8
 # Uncomment to include all TFLM examples (pdti8, micro_speech, magic_wand)
 #DEFINES += INCLUDE_ALL_TFLM_EXAMPLES
 
+# Uncomment this line to include the ASCII animated donut demo.
+DEFINES += DONUT_DEMO
+
 include ../proj.mk

--- a/proj/skip_tflm/Makefile
+++ b/proj/skip_tflm/Makefile
@@ -28,5 +28,9 @@ export SKIP_TFLM=1
 # Uncomment this line to skip individual profiling output (has minor effect on performance).
 #DEFINES += NPROFILE
 
+# Uncomment this line to include the ASCII animated donut demo.
+DEFINES += DONUT_DEMO
+
+
 
 include ../proj.mk

--- a/third_party/litex-donut/LICENSE
+++ b/third_party/litex-donut/LICENSE
@@ -1,0 +1,34 @@
+LiteX is a Migen/MiSoC based Core/SoC builder that provides the infrastructure to
+easily create Cores/SoCs.
+
+Unless otherwise noted, LiteX is copyright (C) 2012-2022 Enjoy-Digital.
+Unless otherwise noted, MiSoC is copyright (C) 2012-2015 Enjoy-Digital.
+Unless otherwise noted, MiSoC is copyright (C) 2007-2015 M-Labs Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Other authors retain ownership of their contributions. If a submission can
+reasonably be considered independently copyrightable, it's yours and we
+encourage you to claim it with appropriate copyright notices. This submission
+then falls under the "otherwise noted" category. All submissions are strongly
+encouraged to use the two-clause BSD license reproduced above.

--- a/third_party/litex-donut/README
+++ b/third_party/litex-donut/README
@@ -1,0 +1,6 @@
+"donut.c" is copied with small changes from
+https://github.com/enjoy-digital/litex/blob/master/litex/soc/software/demo/donut.c
+The LiteX LICENSE is included in this directory.
+
+There are some comments in donut.c about the *original* source
+of the code.

--- a/third_party/litex-donut/donut.c
+++ b/third_party/litex-donut/donut.c
@@ -1,0 +1,69 @@
+// The donut code with fixed-point arithmetic; no sines, cosines, square roots, or anything.
+// a1k0n 2020
+// Code from: https://gist.github.com/a1k0n/80f48aa8911fffd805316b8ba8f48e83
+// For more info:
+// - https://www.a1k0n.net/2011/07/20/donut-math.html
+// - https://www.youtube.com/watch?v=DEqXNfs_HhY
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <console.h>
+
+#define R(mul,shift,x,y) \
+  _=x; \
+  x -= mul*y>>shift; \
+  y += mul*_>>shift; \
+  _ = 3145728-x*x-y*y>>11; \
+  x = x*_>>10; \
+  y = y*_>>10;
+
+static signed char b[1760], z[1760];
+
+void donut(void);
+void donut(void) {
+  int sA=1024,cA=0,sB=1024,cB=0,_;
+  puts("\nPress any key to exit.\n");
+  for (;;) {
+    memset(b, 32, 1760);  // text buffer
+    memset(z, 127, 1760);   // z buffer
+    int sj=0, cj=1024;
+    for (int j = 0; j < 90; j++) {
+      int si = 0, ci = 1024;  // sine and cosine of angle i
+      for (int i = 0; i < 324; i++) {
+        int R1 = 1, R2 = 2048, K2 = 5120*1024;
+
+        int x0 = R1*cj + R2,
+            x1 = ci*x0 >> 10,
+            x2 = cA*sj >> 10,
+            x3 = si*x0 >> 10,
+            x4 = R1*x2 - (sA*x3 >> 10),
+            x5 = sA*sj >> 10,
+            x6 = K2 + R1*1024*x5 + cA*x3,
+            x7 = cj*si >> 10,
+            x = 40 + 30*(cB*x1 - sB*x4)/x6,
+            y = 12 + 15*(cB*x4 + sB*x1)/x6,
+            N = (-cA*x7 - cB*((-sA*x7>>10) + x2) - ci*(cj*sB >> 10) >> 10) - x5 >> 7;
+
+        int o = x + 80 * y;
+        signed char zz = (x6-K2)>>15;
+        if (22 > y && y > 0 && x > 0 && 80 > x && zz < z[o]) {
+          z[o] = zz;
+          b[o] = ".,-~:;=!*#$@"[N > 0 ? N : 0];
+        }
+        R(5, 8, ci, si)  // rotate i
+      }
+      R(9, 7, cj, sj)  // rotate j
+    }
+    for (int k = 0; 1761 > k; k++)
+      putchar(k % 80 ? b[k] : 10);
+    R(5, 7, cA, sA);
+    R(5, 8, cB, sB);
+    if (readchar_nonblock()) {
+        getchar();
+        break;
+    }
+    puts("\x1b[24A");
+  }
+}

--- a/third_party/litex-donut/donut.h
+++ b/third_party/litex-donut/donut.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The CFU-Playground Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+extern void donut(void);


### PR DESCRIPTION
It is enabled in projects `skip_tflm`, `proj_template`, and `proj_template_v`.
It *can* be enabled in any project.

Signed-off-by: Tim Callahan <tcal@google.com>