### PR TITLE
Pin the Yosys package to a version compatible with the F4PGA plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ install-sf:
 	wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-install-xc7-${F4PGA_HASH}.tar.xz | tar -xJC $(SF_INSTALL)/xc7/install
 	wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-xc7a50t_test-${F4PGA_HASH}.tar.xz | tar -xJC $(SF_INSTALL)/xc7/install
 	wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-xc7a100t_test-${F4PGA_HASH}.tar.xz | tar -xJC $(SF_INSTALL)/xc7/install
-	wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-xc7a200t_test-${F4PGA_HASH}.tar.xz | tar -xJC $(SF_INSTALL)/xc7/install
+# Uncomment the following line to enable xc7a200t
+#	wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/${F4PGA_TIMESTAMP}/symbiflow-arch-defs-xc7a200t_test-${F4PGA_HASH}.tar.xz | tar -xJC $(SF_INSTALL)/xc7/install
 	$(MAKE) USE_SYMBIFLOW=1 env
 	@echo
 	@echo "Done installing SymbiFlow.  To enter the environment, type 'make enter-sf', which creates a new subshell, and 'exit' when done."

--- a/conf/environment-symbiflow.yml
+++ b/conf/environment-symbiflow.yml
@@ -12,7 +12,8 @@ dependencies:
   - litex-hub::nextpnr-nexus
   - litex-hub::nextpnr-ecp5
   - litex-hub::nextpnr-ice40
-  - litex-hub::yosys
+# Temporarily pin Yosys until symbiflow-yosys-plugins catches up
+  - litex-hub::yosys=0.33_11_g31ee566ec=20230724_080446_py37
   - litex-hub::iceprog
   - litex-hub::prjxray-tools
   - litex-hub::prjxray-db

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -12,7 +12,8 @@ dependencies:
   - litex-hub::nextpnr-ecp5
   - litex-hub::nextpnr-ice40
   - litex-hub::iceprog
-  - litex-hub::yosys
+# Temporarily pin Yosys until symbiflow-yosys-plugins catches up
+  - litex-hub::yosys=0.33_11_g31ee566ec=20230724_080446_py37
   - litex-hub::symbiflow-yosys-plugins
   - libevent
   - json-c


### PR DESCRIPTION
Pin the Yosys package to a version compatible with the F4PGA Yosys plugins.

This fixes #808.

Tested: manually built the bitstream and tested it on an Arty 35T board with the CFU Playground firmware.

When the plugins package updates, we can unpin Yosys.

Also, comment out the download of the xc7a200t database to make the installation of F4PGA faster.

**NOTE**: After you sync to this update, you don't need to reinstall the entire Symbiflow/F4PGA environment.   Just do this (while not *inside* the environment, at the root directory of the CFU-Playground repo):
```
# Update the existing Symbiflow F4PGA environment
make USE_SYMBIFLOW=1 env
```
Then enter the Symbiflow/F4PGA environment and use:
```
make enter-sf
cd proj/proj_template_v
make USE_SYMBIFLOW=1 bitstream
```
