### PR TITLE
Pin Yosys back to 0.29 as workaround for Nexus flow (Yosys #4081).

### DIFF
--- a/conf/environment-symbiflow.yml
+++ b/conf/environment-symbiflow.yml
@@ -13,7 +13,8 @@ dependencies:
   - litex-hub::nextpnr-ecp5
   - litex-hub::nextpnr-ice40
 # Temporarily pin Yosys until symbiflow-yosys-plugins catches up
-  - litex-hub::yosys=0.33_11_g31ee566ec=20230724_080446_py37
+#   AND https://github.com/YosysHQ/yosys/issues/4081 is resolved
+  - litex-hub::yosys=0.29_35_g57c9eb70f=20230524_010725_py37
   - litex-hub::iceprog
   - litex-hub::prjxray-tools
   - litex-hub::prjxray-db

--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -13,7 +13,8 @@ dependencies:
   - litex-hub::nextpnr-ice40
   - litex-hub::iceprog
 # Temporarily pin Yosys until symbiflow-yosys-plugins catches up
-  - litex-hub::yosys=0.33_11_g31ee566ec=20230724_080446_py37
+#   AND https://github.com/YosysHQ/yosys/issues/4081 is resolved
+  - litex-hub::yosys=0.29_35_g57c9eb70f=20230524_010725_py37
   - litex-hub::symbiflow-yosys-plugins
   - libevent
   - json-c


### PR DESCRIPTION
Workaround for https://github.com/YosysHQ/yosys/issues/4081.

This issue is specific to the Lattice Nexus flow.

With current Yosys, the synthesized netlist from `synth_nexus` contains an explicit 1'b0 driving the low order CIN of a chain of CCU2 (carry chain) primitives.  This causes a `nextpnr-nexus` error.    `nextpnr-nexus` expects this input to be undriven which I assume implies an implicit 1'b0 input.
