### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/sync-renode.yml
+++ b/.github/workflows/sync-renode.yml
@@ -51,10 +51,10 @@ jobs:
 
             RENODE_SHA=${RENODE_VERSION#*git}
             git commit -sm "Update Renode to $RENODE_SHA."
-            echo "::set-output name=committed::true"
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice title=Early exit::Renode is up to date."
-            echo "::set-output name=committed::false"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
 
           rm renode-latest.linux-portable.tar.gz

--- a/.github/workflows/sync-tflm.yml
+++ b/.github/workflows/sync-tflm.yml
@@ -48,10 +48,10 @@ jobs:
 
           if [ -n "$(git status --porcelain)" ]; then
             git commit -sm "Sync from tflite-micro at $TFLM_SHA."
-            echo "::set-output name=committed::true"
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice title=Early exit::TFLM is up to date."
-            echo "::set-output name=committed::false"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Pull Request

--- a/.github/workflows/test-projects.yml
+++ b/.github/workflows/test-projects.yml
@@ -50,7 +50,7 @@ jobs:
       id: setup-matrix-combinations
       run: |
         export MATRIX_PARAMS=$(./.github/scripts/generate_ci_matrix.py)
-        echo "::set-output name=matrix-combinations::{\"include\":$MATRIX_PARAMS}"
+        echo "matrix-combinations={\"include\":$MATRIX_PARAMS}" >> "$GITHUB_OUTPUT"
 
     - name: Setup environment
       run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter