### PR TITLE
Fix usage of read command.

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -81,7 +81,7 @@ if [ ${#missing[@]} -gt 0 ]; then
             $_sudo apt install -y "${missing[@]}"
         else
             echo -n "Install [y]/n? " >&2
-            answer=$(read)
+            read answer
             if [ "$answer" == "y" -o -z "$answer" ]; then
                 $_sudo apt update
                 $_sudo apt install "${missing[@]}"


### PR DESCRIPTION
Hello.
The `read` command returns nothing, so the expression in the following `apt` commands are executed whatever you write to the prompt.
I fixed it, and the `apt` commands are executed when you type `y` or nothing.
If the conventional behavior is expected, please close this PR.
Thank you.