### PR TITLE
Increase IMGC tensor arena to 54 KiB

### DIFF
--- a/common/src/tflite.cc
+++ b/common/src/tflite.cc
@@ -99,7 +99,7 @@ constexpr int kTensorArenaSize = const_max<int>(
     3 * 1024,
 #endif
 #ifdef INCLUDE_MODEL_MLCOMMONS_TINY_V01_IMGC
-    53 * 1024,
+    54 * 1024,
 #endif
 #ifdef INCLUDE_MODEL_MLCOMMONS_TINY_V01_KWS
     23 * 1024,


### PR DESCRIPTION
A kTensorArenaSize of 53 * 1024 is a bit too small, causing following error:

"Running MLCommons Tiny V0.1 Image Classification
Error_reporter OK!
Failed to allocate tail memory. Requested: 40, available 0, missing: 40 Failed to allocate tail memory. Requested: 12, available 0, missing: 12 Unable to allocate TfLiteAffineQuantization.

Failed to populate a persistent TfLiteTensor struct from flatbuffer data! Failed to initialize output tensor 0
AllocateTensors() failed"

Using 54 * 1024 solves this problem.

Plattform: digilent_arty (A7 35T) using Vivado

Only the IMGC model and standard project configuration were used for testing.